### PR TITLE
Patient search: first feature port (TDD/BDD)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   test:
@@ -39,8 +38,12 @@ jobs:
           bundler-cache: true
       - name: Prepare database
         run: bundle exec rails app:db:create app:db:migrate
-      - name: Run tests
+      - name: Zeitwerk eager-load check
+        run: bundle exec rails app:zeitwerk:check
+      - name: Run unit tests
         run: bundle exec rake test
+      - name: Run Cucumber features
+        run: bundle exec cucumber --publish-quiet
 
   lint:
     name: Lint

--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,5 @@ gem "propshaft"
 
 group :development, :test do
   gem "rubocop-rails-omakase", require: false
+  gem "cucumber-rails", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,17 +90,66 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.1)
     builder (3.3.0)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
+    cucumber (10.2.0)
+      base64 (~> 0.2)
+      builder (~> 3.2)
+      cucumber-ci-environment (> 9, < 12)
+      cucumber-core (> 15, < 17)
+      cucumber-cucumber-expressions (> 17, < 20)
+      cucumber-html-formatter (> 21, < 23)
+      diff-lcs (~> 1.5)
+      logger (~> 1.6)
+      mini_mime (~> 1.1)
+      multi_test (~> 1.1)
+      sys-uname (~> 1.3)
+    cucumber-ci-environment (11.0.0)
+    cucumber-core (16.2.0)
+      cucumber-gherkin (> 36, < 40)
+      cucumber-messages (> 31, < 33)
+      cucumber-tag-expressions (> 6, < 9)
+    cucumber-cucumber-expressions (19.0.0)
+      bigdecimal
+    cucumber-gherkin (39.0.0)
+      cucumber-messages (>= 31, < 33)
+    cucumber-html-formatter (22.3.0)
+      cucumber-messages (> 23, < 33)
+    cucumber-messages (32.2.0)
+    cucumber-rails (4.0.1)
+      capybara (>= 3.25, < 4)
+      cucumber (>= 7, < 11)
+      railties (>= 6.1, < 9)
+    cucumber-tag-expressions (8.1.0)
     date (3.5.1)
+    diff-lcs (1.6.2)
     drb (2.2.3)
     erb (6.0.2)
     erubi (1.13.1)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.8)
@@ -125,10 +174,13 @@ GEM
       net-pop
       net-smtp
     marcel (1.1.0)
+    matrix (0.4.3)
+    memoist3 (1.0.0)
     mini_mime (1.1.5)
     minitest (6.0.3)
       drb (~> 2.0)
       prism (~> 1.5)
+    multi_test (1.1.0)
     net-imap (0.6.3)
       date
       net-protocol
@@ -177,6 +229,7 @@ GEM
     psych (5.3.1)
       date
       stringio
+    public_suffix (7.0.5)
     puma (7.2.0)
       nio4r (~> 2.0)
     racc (1.8.1)
@@ -259,6 +312,9 @@ GEM
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     stringio (3.2.0)
+    sys-uname (1.5.1)
+      ffi (~> 1.1)
+      memoist3 (~> 1.0.0)
     thor (1.5.0)
     timeout (0.6.1)
     tsort (0.2.0)
@@ -273,6 +329,8 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.7.5)
 
 PLATFORMS
@@ -288,6 +346,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  cucumber-rails
   lakeraven-ehr!
   pg
   propshaft

--- a/app/controllers/lakeraven/ehr/application_controller.rb
+++ b/app/controllers/lakeraven/ehr/application_controller.rb
@@ -1,5 +1,5 @@
 module Lakeraven
-  module Ehr
+  module EHR
     class ApplicationController < ActionController::Base
     end
   end

--- a/app/helpers/lakeraven/ehr/application_helper.rb
+++ b/app/helpers/lakeraven/ehr/application_helper.rb
@@ -1,5 +1,5 @@
 module Lakeraven
-  module Ehr
+  module EHR
     module ApplicationHelper
     end
   end

--- a/app/jobs/lakeraven/ehr/application_job.rb
+++ b/app/jobs/lakeraven/ehr/application_job.rb
@@ -1,5 +1,5 @@
 module Lakeraven
-  module Ehr
+  module EHR
     class ApplicationJob < ActiveJob::Base
     end
   end

--- a/app/models/lakeraven/ehr/application_record.rb
+++ b/app/models/lakeraven/ehr/application_record.rb
@@ -1,5 +1,5 @@
 module Lakeraven
-  module Ehr
+  module EHR
     class ApplicationRecord < ActiveRecord::Base
       self.abstract_class = true
     end

--- a/app/services/lakeraven/ehr/patient_search.rb
+++ b/app/services/lakeraven/ehr/patient_search.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # Patient search service.
+    #
+    # The single entry point for finding patients in the EHR. Reads
+    # tenant and facility scope from Lakeraven::EHR::Current per
+    # ADR 0003 (fail-loud if tenant is unset), delegates the actual
+    # search to the configured adapter, and returns plain hashes
+    # whose shape is documented on Adapters::Base#search_patients.
+    #
+    #   Lakeraven::EHR::PatientSearch.call(name: "DOE")
+    #   Lakeraven::EHR::PatientSearch.call(identifier_system: "...", identifier_value: "...")
+    #
+    # The result hashes use the *_identifier convention from ADR 0004
+    # and never expose backend-native ids — that's enforced at the
+    # adapter level and asserted in the cucumber feature.
+    class PatientSearch
+      def self.call(name: nil, identifier_system: nil, identifier_value: nil, date_of_birth: nil)
+        new.call(
+          name: name,
+          identifier_system: identifier_system,
+          identifier_value: identifier_value,
+          date_of_birth: date_of_birth
+        )
+      end
+
+      def call(name: nil, identifier_system: nil, identifier_value: nil, date_of_birth: nil)
+        tenant = Current.tenant_identifier
+        if tenant.nil? || tenant.to_s.empty?
+          raise MissingTenantContextError,
+            "PatientSearch requires Lakeraven::EHR::Current.tenant_identifier to be set " \
+            "(see ADR 0003 — fail-loud tenancy)"
+        end
+
+        EHR.adapter.search_patients(
+          tenant_identifier: tenant,
+          facility_identifier: Current.facility_identifier,
+          name: name,
+          identifier_system: identifier_system,
+          identifier_value: identifier_value,
+          date_of_birth: date_of_birth
+        )
+      end
+    end
+  end
+end

--- a/features/patient_search.feature
+++ b/features/patient_search.feature
@@ -1,0 +1,52 @@
+Feature: Patient search
+  As a SMART-on-FHIR client
+  I need to search for patients in the EHR
+  So that I can resolve a patient context for a clinical workflow
+
+  Background:
+    Given the EHR adapter is the in-memory mock
+    And the current tenant is "tnt_test"
+    And the current facility is "fac_main"
+    And the following patients are registered at facility "fac_main":
+      | display_name | date_of_birth | gender |
+      | DOE,JOHN     | 1980-01-15    | male   |
+      | SMITH,JANE   | 1975-06-20    | female |
+      | JOHNSON,BOB  | 1990-03-10    | male   |
+    And the following patients are registered at facility "fac_other":
+      | display_name | date_of_birth | gender |
+      | OTHER,PERSON | 1985-12-05    | male   |
+
+  Scenario: Search by full name
+    When I search for patients by name "DOE,JOHN"
+    Then the search returns 1 patient
+    And the result includes a patient with display name "DOE,JOHN"
+
+  Scenario: Search by partial last name
+    When I search for patients by name "JOH"
+    Then the search returns 2 patients
+    And the result includes a patient with display name "DOE,JOHN"
+    And the result includes a patient with display name "JOHNSON,BOB"
+
+  Scenario: Search returns opaque patient identifiers
+    When I search for patients by name "DOE,JOHN"
+    Then every result has an opaque patient_identifier prefixed with "pt_"
+    And no result exposes a backend-native DFN
+
+  Scenario: Empty result is a valid empty array, not an error
+    When I search for patients by name "NONEXISTENT"
+    Then the search returns 0 patients
+    And the search succeeds without raising
+
+  Scenario: Search is scoped to the current facility
+    When I search for patients by name "PERSON"
+    Then the search returns 0 patients
+
+  Scenario: Search across all facilities in the tenant when no facility is set
+    Given the current facility is unset
+    When I search for patients by name "PERSON"
+    Then the search returns 1 patient
+
+  Scenario: Search fails loud when no tenant context is set
+    Given the current tenant is unset
+    When I search for patients by name "DOE,JOHN"
+    Then the search raises a missing-tenant-context error

--- a/features/step_definitions/patient_search_steps.rb
+++ b/features/step_definitions/patient_search_steps.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+Given("the EHR adapter is the in-memory mock") do
+  Lakeraven::EHR.configure do |config|
+    config.adapter = Lakeraven::EHR::Adapters::MockAdapter.new
+  end
+end
+
+Given("the current tenant is {string}") do |tenant_identifier|
+  Lakeraven::EHR::Current.tenant_identifier = tenant_identifier
+end
+
+Given("the current tenant is unset") do
+  Lakeraven::EHR::Current.tenant_identifier = nil
+end
+
+Given("the current facility is {string}") do |facility_identifier|
+  Lakeraven::EHR::Current.facility_identifier = facility_identifier
+end
+
+Given("the current facility is unset") do
+  Lakeraven::EHR::Current.facility_identifier = nil
+end
+
+Given("the following patients are registered at facility {string}:") do |facility_identifier, table|
+  table.hashes.each do |row|
+    Lakeraven::EHR.adapter.seed_patient(
+      tenant_identifier: Lakeraven::EHR::Current.tenant_identifier || "tnt_test",
+      facility_identifier: facility_identifier,
+      display_name: row["display_name"],
+      date_of_birth: Date.parse(row["date_of_birth"]),
+      gender: row["gender"]
+    )
+  end
+end
+
+When("I search for patients by name {string}") do |name|
+  @search_error = nil
+  @search_results = Lakeraven::EHR::PatientSearch.call(name: name)
+rescue Lakeraven::EHR::MissingTenantContextError => e
+  @search_error = e
+end
+
+Then("the search returns {int} patient(s)") do |count|
+  assert_nil @search_error, "expected no error but got #{@search_error&.class}: #{@search_error&.message}"
+  assert_equal count, @search_results.length
+end
+
+Then("the result includes a patient with display name {string}") do |display_name|
+  display_names = @search_results.map { |r| r[:display_name] }
+  assert_includes display_names, display_name
+end
+
+Then('every result has an opaque patient_identifier prefixed with {string}') do |prefix|
+  @search_results.each do |result|
+    assert result[:patient_identifier].start_with?(prefix),
+      "expected patient_identifier to start with #{prefix}, got #{result[:patient_identifier]}"
+  end
+end
+
+Then("no result exposes a backend-native DFN") do
+  @search_results.each do |result|
+    refute_includes result.keys, :dfn
+    refute_includes result.keys, "dfn"
+    refute_includes result.keys, :DFN
+  end
+end
+
+Then("the search succeeds without raising") do
+  assert_nil @search_error
+end
+
+Then("the search raises a missing-tenant-context error") do
+  assert_kind_of Lakeraven::EHR::MissingTenantContextError, @search_error
+end

--- a/features/step_definitions/patient_search_steps.rb
+++ b/features/step_definitions/patient_search_steps.rb
@@ -59,10 +59,12 @@ Then('every result has an opaque patient_identifier prefixed with {string}') do 
 end
 
 Then("no result exposes a backend-native DFN") do
+  # Normalize keys to lowercase strings so we catch any casing/symbol
+  # variant: :dfn, "dfn", :DFN, "DFN", and anything else that means the
+  # same thing.
   @search_results.each do |result|
-    refute_includes result.keys, :dfn
-    refute_includes result.keys, "dfn"
-    refute_includes result.keys, :DFN
+    normalized_keys = result.keys.map { |k| k.to_s.downcase }
+    refute_includes normalized_keys, "dfn"
   end
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Cucumber bootstraps from the dummy app so the engine and its
+# dependencies are loaded the same way they would be in a host
+# application. We don't need a browser, so no Capybara.
+
+ENV["RAILS_ENV"] ||= "test"
+
+require_relative "../../test/dummy/config/environment"
+require "lakeraven/ehr"
+require "minitest"
+require "minitest/assertions"
+
+# Bring Minitest assertions into the Cucumber World so step
+# definitions can use assert / assert_equal / refute directly.
+World(Minitest::Assertions)
+
+# Reset engine state between scenarios so one scenario can't
+# leak adapter or tenant context into the next.
+Before do
+  Lakeraven::EHR.reset_configuration!
+  Lakeraven::EHR::Current.reset!
+end

--- a/lib/lakeraven/ehr.rb
+++ b/lib/lakeraven/ehr.rb
@@ -5,6 +5,7 @@ require "lakeraven/ehr/engine"
 require "lakeraven/ehr/configuration"
 require "lakeraven/ehr/current"
 require "lakeraven/ehr/adapters/base"
+require "lakeraven/ehr/adapters/mock_adapter"
 
 module Lakeraven
   # Lakeraven EHR — public Rails engine for SMART-on-FHIR-compliant

--- a/lib/lakeraven/ehr.rb
+++ b/lib/lakeraven/ehr.rb
@@ -2,6 +2,7 @@
 
 require "lakeraven/ehr/version"
 require "lakeraven/ehr/engine"
+require "lakeraven/ehr/configuration"
 
 module Lakeraven
   # Lakeraven EHR — public Rails engine for SMART-on-FHIR-compliant

--- a/lib/lakeraven/ehr.rb
+++ b/lib/lakeraven/ehr.rb
@@ -4,6 +4,7 @@ require "lakeraven/ehr/version"
 require "lakeraven/ehr/engine"
 require "lakeraven/ehr/configuration"
 require "lakeraven/ehr/current"
+require "lakeraven/ehr/adapters/base"
 
 module Lakeraven
   # Lakeraven EHR — public Rails engine for SMART-on-FHIR-compliant

--- a/lib/lakeraven/ehr.rb
+++ b/lib/lakeraven/ehr.rb
@@ -3,6 +3,7 @@
 require "lakeraven/ehr/version"
 require "lakeraven/ehr/engine"
 require "lakeraven/ehr/configuration"
+require "lakeraven/ehr/current"
 
 module Lakeraven
   # Lakeraven EHR — public Rails engine for SMART-on-FHIR-compliant

--- a/lib/lakeraven/ehr/adapters/base.rb
+++ b/lib/lakeraven/ehr/adapters/base.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    module Adapters
+      # Abstract adapter for the EHR backend.
+      #
+      # The host application provides a concrete subclass that implements
+      # the methods declared here. The reference implementation calls
+      # rpms-rpc; alternative implementations can point at a FHIR server,
+      # a fixture, or any other source of truth.
+      #
+      # Per ADR 0002 (PHI tokenization), every method on this contract
+      # accepts opaque identifiers and returns plain hashes whose keys
+      # use the *_identifier convention from ADR 0004. The engine never
+      # persists the returned data — it serializes to FHIR at request
+      # time and discards it.
+      #
+      # Per ADR 0003 (tenancy), every method takes a tenant_identifier
+      # and (where applicable) a facility_identifier. The adapter
+      # implementation is responsible for honoring those scopes when
+      # talking to the backend.
+      class Base
+        # Search patients by name and/or FHIR Identifier.
+        #
+        # @param tenant_identifier [String] opaque tenant token
+        # @param facility_identifier [String, nil] opaque facility token; nil = all facilities in tenant
+        # @param name [String, nil] partial or full name (e.g. "DOE,JOHN", "DOE")
+        # @param identifier_system [String, nil] FHIR Identifier system URI
+        # @param identifier_value [String, nil] FHIR Identifier value
+        # @param date_of_birth [Date, String, nil] DOB filter
+        # @return [Array<Hash>] each result hash with keys :patient_identifier,
+        #   :display_name, :date_of_birth, :gender, :facility_identifier
+        def search_patients(tenant_identifier:, facility_identifier: nil, name: nil, identifier_system: nil, identifier_value: nil, date_of_birth: nil)
+          raise NotImplementedError, "#{self.class} must implement #search_patients"
+        end
+
+        # Resolve a single patient by opaque identifier.
+        #
+        # @param tenant_identifier [String]
+        # @param patient_identifier [String]
+        # @return [Hash, nil] same shape as a search_patients result, or nil if not found
+        def find_patient(tenant_identifier:, patient_identifier:)
+          raise NotImplementedError, "#{self.class} must implement #find_patient"
+        end
+      end
+    end
+  end
+end

--- a/lib/lakeraven/ehr/adapters/mock_adapter.rb
+++ b/lib/lakeraven/ehr/adapters/mock_adapter.rb
@@ -25,8 +25,10 @@ module Lakeraven
         end
 
         # Test helper — adds a patient to the in-memory store. Mints
-        # an opaque patient_identifier and returns it.
-        def seed_patient(tenant_identifier:, facility_identifier:, display_name:, date_of_birth:, gender:)
+        # an opaque patient_identifier and returns it. `identifiers`
+        # is an optional array of FHIR-shaped { system:, value: } hashes
+        # so seeded patients can carry MRNs, NPIs, SSNs, tribal IDs, etc.
+        def seed_patient(tenant_identifier:, facility_identifier:, display_name:, date_of_birth:, gender:, identifiers: [])
           identifier = mint_patient_identifier
           record = {
             patient_identifier: identifier,
@@ -34,7 +36,8 @@ module Lakeraven
             facility_identifier: facility_identifier,
             display_name: display_name,
             date_of_birth: date_of_birth,
-            gender: gender
+            gender: gender,
+            identifiers: identifiers
           }
           @patients[tenant_identifier] << record
           identifier
@@ -45,6 +48,9 @@ module Lakeraven
           rows = rows.select { |r| r[:facility_identifier] == facility_identifier } if facility_identifier
           rows = rows.select { |r| r[:display_name].downcase.include?(name.downcase) } if name && !name.empty?
           rows = rows.select { |r| r[:date_of_birth] == coerce_date(date_of_birth) } if date_of_birth
+          if identifier_system || identifier_value
+            rows = rows.select { |r| match_identifier?(r, identifier_system, identifier_value) }
+          end
           rows.map { |r| public_view(r) }
         end
 
@@ -71,8 +77,20 @@ module Lakeraven
             facility_identifier: row[:facility_identifier],
             display_name: row[:display_name],
             date_of_birth: row[:date_of_birth],
-            gender: row[:gender]
+            gender: row[:gender],
+            identifiers: row[:identifiers] || []
           }
+        end
+
+        # Match a row against a (system, value) pair. Either side may be
+        # nil — a nil system matches any system; a nil value matches any
+        # value (so callers can search by system alone if they want all
+        # patients with an MRN, etc.).
+        def match_identifier?(row, system, value)
+          (row[:identifiers] || []).any? do |id|
+            (system.nil? || id[:system] == system) &&
+              (value.nil? || id[:value] == value)
+          end
         end
 
         def coerce_date(value)

--- a/lib/lakeraven/ehr/adapters/mock_adapter.rb
+++ b/lib/lakeraven/ehr/adapters/mock_adapter.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "lakeraven/ehr/adapters/base"
+
+module Lakeraven
+  module EHR
+    module Adapters
+      # In-memory adapter used by tests and Cucumber scenarios.
+      #
+      # Holds patients in a Ruby hash keyed by tenant_identifier so each
+      # test can seed its own data without coordinating with anyone
+      # else. Not thread-safe — there's no need; tests run serially
+      # against a fresh instance.
+      #
+      # Per ADR 0002, this still doesn't store backend-native identifiers
+      # in the result hashes returned to engine code. The patient_identifier
+      # it returns is an opaque token (per ADR 0004), and the internal DFN
+      # equivalent is held only inside the adapter.
+      class MockAdapter < Base
+        def initialize
+          super
+          # patients[tenant_identifier] => Array<Hash>
+          @patients = Hash.new { |h, k| h[k] = [] }
+        end
+
+        # Test helper — adds a patient to the in-memory store. Mints
+        # an opaque patient_identifier and returns it.
+        def seed_patient(tenant_identifier:, facility_identifier:, display_name:, date_of_birth:, gender:)
+          identifier = mint_patient_identifier
+          record = {
+            patient_identifier: identifier,
+            tenant_identifier: tenant_identifier,
+            facility_identifier: facility_identifier,
+            display_name: display_name,
+            date_of_birth: date_of_birth,
+            gender: gender
+          }
+          @patients[tenant_identifier] << record
+          identifier
+        end
+
+        def search_patients(tenant_identifier:, facility_identifier: nil, name: nil, identifier_system: nil, identifier_value: nil, date_of_birth: nil)
+          rows = @patients[tenant_identifier]
+          rows = rows.select { |r| r[:facility_identifier] == facility_identifier } if facility_identifier
+          rows = rows.select { |r| r[:display_name].downcase.include?(name.downcase) } if name && !name.empty?
+          rows = rows.select { |r| r[:date_of_birth] == coerce_date(date_of_birth) } if date_of_birth
+          rows.map { |r| public_view(r) }
+        end
+
+        def find_patient(tenant_identifier:, patient_identifier:)
+          row = @patients[tenant_identifier].find { |r| r[:patient_identifier] == patient_identifier }
+          row ? public_view(row) : nil
+        end
+
+        private
+
+        # Mints a prefixed token. Uses a UUIDv4 internally rather than a
+        # full ULID; the test fixture doesn't need lex-sortability and
+        # SecureRandom is in stdlib. Real adapters mint per ADR 0004.
+        def mint_patient_identifier
+          "pt_#{SecureRandom.uuid.delete('-')}"
+        end
+
+        # Strip internal-only keys before returning to caller. tenant_identifier
+        # stays in because the caller already has it; the row needs to round-trip
+        # cleanly through find_patient. No backend-native fields are exposed.
+        def public_view(row)
+          {
+            patient_identifier: row[:patient_identifier],
+            facility_identifier: row[:facility_identifier],
+            display_name: row[:display_name],
+            date_of_birth: row[:date_of_birth],
+            gender: row[:gender]
+          }
+        end
+
+        def coerce_date(value)
+          return value if value.is_a?(Date)
+          Date.parse(value.to_s)
+        end
+      end
+    end
+  end
+end

--- a/lib/lakeraven/ehr/configuration.rb
+++ b/lib/lakeraven/ehr/configuration.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # Application-level configuration for the engine.
+    #
+    # Host applications configure the engine via:
+    #
+    #   Lakeraven::EHR.configure do |config|
+    #     config.adapter = MyAdapter.new
+    #   end
+    #
+    # The adapter is the only required setting at boot.
+    class Configuration
+      attr_accessor :adapter
+
+      def initialize
+        @adapter = nil
+      end
+    end
+
+    # Raised when engine code touches the adapter before the host has
+    # configured one. Surfaces immediately, before any feature runs.
+    class NotConfiguredError < StandardError; end
+
+    class << self
+      def configuration
+        @configuration ||= Configuration.new
+      end
+
+      def configure
+        yield(configuration)
+      end
+
+      def reset_configuration!
+        @configuration = Configuration.new
+      end
+
+      # Convenience accessor — engine code reads through here rather
+      # than touching configuration directly.
+      def adapter
+        configuration.adapter || raise(
+          NotConfiguredError,
+          "Lakeraven::EHR.adapter is not configured. " \
+          "Set one via Lakeraven::EHR.configure { |c| c.adapter = ... } " \
+          "before using the engine."
+        )
+      end
+    end
+  end
+end

--- a/lib/lakeraven/ehr/current.rb
+++ b/lib/lakeraven/ehr/current.rb
@@ -24,11 +24,17 @@ module Lakeraven
     class Current < ActiveSupport::CurrentAttributes
       attribute :tenant_identifier, :facility_identifier
 
-      # Alias for ActiveSupport::CurrentAttributes.clear_all so engine
-      # code can use the more conventional reset! verb. Cucumber Before
-      # hooks and test setups call this between scenarios.
+      # Reset only this engine's Current class, not every
+      # ActiveSupport::CurrentAttributes subclass in the process.
+      # `clear_all` would wipe the host application's own Current
+      # state too, which would be a hostile thing for an embedded
+      # engine to do between scenarios. `instance.reset` only
+      # resets the per-thread instance for this class.
+      #
+      # Cucumber Before hooks and test setups call this between
+      # scenarios; the host app's Current is left untouched.
       def self.reset!
-        clear_all
+        instance.reset
       end
 
       # Run the block with tenant_identifier set to the supplied value,

--- a/lib/lakeraven/ehr/current.rb
+++ b/lib/lakeraven/ehr/current.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "active_support/current_attributes"
+
+module Lakeraven
+  module EHR
+    # Per-request store for tenant and facility context.
+    #
+    # The host application sets these at the request boundary
+    # (typically from the SMART launch context or an authenticated
+    # session) and engine code reads them via the fail-loud default
+    # scopes described in ADR 0003.
+    #
+    #   Lakeraven::EHR::Current.tenant_identifier   = "tnt_..."
+    #   Lakeraven::EHR::Current.facility_identifier = "fac_..."
+    #
+    # Background jobs that touch engine models must wrap their work
+    # in `with_tenant` so the context is set even outside the request
+    # cycle:
+    #
+    #   Lakeraven::EHR::Current.with_tenant("tnt_...") do
+    #     do_some_work
+    #   end
+    class Current < ActiveSupport::CurrentAttributes
+      attribute :tenant_identifier, :facility_identifier
+
+      # Alias for ActiveSupport::CurrentAttributes.clear_all so engine
+      # code can use the more conventional reset! verb. Cucumber Before
+      # hooks and test setups call this between scenarios.
+      def self.reset!
+        clear_all
+      end
+
+      # Run the block with tenant_identifier set to the supplied value,
+      # restoring whatever was previously set when the block exits
+      # (even on exception). Useful for jobs and console sessions.
+      def self.with_tenant(tenant_identifier)
+        previous = self.tenant_identifier
+        self.tenant_identifier = tenant_identifier
+        yield
+      ensure
+        self.tenant_identifier = previous
+      end
+    end
+
+    # Raised by default scopes (and any other engine code that requires
+    # tenant scoping) when Current.tenant_identifier is unset. Per
+    # ADR 0003, the engine fails loudly rather than silently returning
+    # an empty result set.
+    class MissingTenantContextError < StandardError; end
+  end
+end

--- a/lib/lakeraven/ehr/engine.rb
+++ b/lib/lakeraven/ehr/engine.rb
@@ -4,6 +4,16 @@ module Lakeraven
   module EHR
     class Engine < ::Rails::Engine
       isolate_namespace Lakeraven::EHR
+
+      # Tell Zeitwerk that "ehr" should resolve to the EHR constant
+      # (capitalized acronym) rather than the default "Ehr". Without
+      # this, autoloading from app/services/lakeraven/ehr/foo.rb would
+      # try to find Lakeraven::Ehr::Foo and not find Lakeraven::EHR::Foo.
+      config.before_initialize do
+        Rails.autoloaders.each do |loader|
+          loader.inflector.inflect("ehr" => "EHR")
+        end
+      end
     end
   end
 end

--- a/test/lakeraven/ehr/adapters/base_test.rb
+++ b/test/lakeraven/ehr/adapters/base_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::Adapters::BaseTest < ActiveSupport::TestCase
+  Base = Lakeraven::EHR::Adapters::Base
+
+  test "search_patients raises NotImplementedError on the base class" do
+    error = assert_raises(NotImplementedError) do
+      Base.new.search_patients(tenant_identifier: "tnt_test")
+    end
+    assert_match(/search_patients/, error.message)
+  end
+
+  test "find_patient raises NotImplementedError on the base class" do
+    error = assert_raises(NotImplementedError) do
+      Base.new.find_patient(tenant_identifier: "tnt_test", patient_identifier: "pt_x")
+    end
+    assert_match(/find_patient/, error.message)
+  end
+
+  test "subclass that implements search_patients does not raise" do
+    subclass = Class.new(Base) do
+      def search_patients(**)
+        []
+      end
+    end
+    assert_equal [], subclass.new.search_patients(tenant_identifier: "tnt_test")
+  end
+end

--- a/test/lakeraven/ehr/adapters/mock_adapter_test.rb
+++ b/test/lakeraven/ehr/adapters/mock_adapter_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::Adapters::MockAdapterTest < ActiveSupport::TestCase
+  Adapter = Lakeraven::EHR::Adapters::MockAdapter
+
+  setup do
+    @adapter = Adapter.new
+  end
+
+  test "inherits from Adapters::Base" do
+    assert Adapter < Lakeraven::EHR::Adapters::Base
+  end
+
+  test "starts with no patients" do
+    assert_empty @adapter.search_patients(tenant_identifier: "tnt_test")
+  end
+
+  test "seed_patient adds a patient and search returns it" do
+    @adapter.seed_patient(
+      tenant_identifier: "tnt_test",
+      facility_identifier: "fac_main",
+      display_name: "DOE,JOHN",
+      date_of_birth: Date.new(1980, 1, 15),
+      gender: "male"
+    )
+    results = @adapter.search_patients(tenant_identifier: "tnt_test", name: "DOE")
+    assert_equal 1, results.length
+    assert_equal "DOE,JOHN", results.first[:display_name]
+  end
+
+  test "seeded patient gets an opaque patient_identifier prefixed with pt_" do
+    @adapter.seed_patient(
+      tenant_identifier: "tnt_test",
+      facility_identifier: "fac_main",
+      display_name: "DOE,JOHN",
+      date_of_birth: Date.new(1980, 1, 15),
+      gender: "male"
+    )
+    result = @adapter.search_patients(tenant_identifier: "tnt_test", name: "DOE").first
+    assert result[:patient_identifier].start_with?("pt_"), result[:patient_identifier]
+  end
+
+  test "search by name is case-insensitive partial match" do
+    @adapter.seed_patient(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                          display_name: "DOE,JOHN", date_of_birth: Date.new(1980, 1, 15), gender: "male")
+    @adapter.seed_patient(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                          display_name: "JOHNSON,BOB", date_of_birth: Date.new(1990, 3, 10), gender: "male")
+    results = @adapter.search_patients(tenant_identifier: "tnt_test", name: "joh")
+    assert_equal 2, results.length
+  end
+
+  test "search is scoped to tenant" do
+    @adapter.seed_patient(tenant_identifier: "tnt_a", facility_identifier: "fac_main",
+                          display_name: "DOE,JOHN", date_of_birth: Date.new(1980, 1, 15), gender: "male")
+    @adapter.seed_patient(tenant_identifier: "tnt_b", facility_identifier: "fac_main",
+                          display_name: "DOE,JANE", date_of_birth: Date.new(1981, 2, 16), gender: "female")
+    results = @adapter.search_patients(tenant_identifier: "tnt_a", name: "DOE")
+    assert_equal 1, results.length
+    assert_equal "DOE,JOHN", results.first[:display_name]
+  end
+
+  test "search is scoped to facility when facility_identifier is given" do
+    @adapter.seed_patient(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                          display_name: "DOE,JOHN", date_of_birth: Date.new(1980, 1, 15), gender: "male")
+    @adapter.seed_patient(tenant_identifier: "tnt_test", facility_identifier: "fac_other",
+                          display_name: "OTHER,PERSON", date_of_birth: Date.new(1985, 12, 5), gender: "male")
+    results = @adapter.search_patients(tenant_identifier: "tnt_test", facility_identifier: "fac_main")
+    assert_equal 1, results.length
+    assert_equal "DOE,JOHN", results.first[:display_name]
+  end
+
+  test "search returns all facilities in tenant when facility_identifier is nil" do
+    @adapter.seed_patient(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                          display_name: "DOE,JOHN", date_of_birth: Date.new(1980, 1, 15), gender: "male")
+    @adapter.seed_patient(tenant_identifier: "tnt_test", facility_identifier: "fac_other",
+                          display_name: "OTHER,PERSON", date_of_birth: Date.new(1985, 12, 5), gender: "male")
+    results = @adapter.search_patients(tenant_identifier: "tnt_test")
+    assert_equal 2, results.length
+  end
+
+  test "search results never expose backend-native dfn key" do
+    @adapter.seed_patient(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                          display_name: "DOE,JOHN", date_of_birth: Date.new(1980, 1, 15), gender: "male")
+    result = @adapter.search_patients(tenant_identifier: "tnt_test", name: "DOE").first
+    refute_includes result.keys, :dfn
+    refute_includes result.keys, "dfn"
+  end
+
+  test "find_patient resolves a previously-seeded patient by identifier" do
+    @adapter.seed_patient(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                          display_name: "DOE,JOHN", date_of_birth: Date.new(1980, 1, 15), gender: "male")
+    identifier = @adapter.search_patients(tenant_identifier: "tnt_test", name: "DOE").first[:patient_identifier]
+    found = @adapter.find_patient(tenant_identifier: "tnt_test", patient_identifier: identifier)
+    assert_equal "DOE,JOHN", found[:display_name]
+  end
+
+  test "find_patient returns nil for unknown identifier" do
+    assert_nil @adapter.find_patient(tenant_identifier: "tnt_test", patient_identifier: "pt_unknown")
+  end
+
+  test "find_patient returns nil if identifier exists in a different tenant" do
+    @adapter.seed_patient(tenant_identifier: "tnt_a", facility_identifier: "fac_main",
+                          display_name: "DOE,JOHN", date_of_birth: Date.new(1980, 1, 15), gender: "male")
+    identifier = @adapter.search_patients(tenant_identifier: "tnt_a", name: "DOE").first[:patient_identifier]
+    assert_nil @adapter.find_patient(tenant_identifier: "tnt_b", patient_identifier: identifier)
+  end
+end

--- a/test/lakeraven/ehr/adapters/mock_adapter_test.rb
+++ b/test/lakeraven/ehr/adapters/mock_adapter_test.rb
@@ -106,4 +106,60 @@ class Lakeraven::EHR::Adapters::MockAdapterTest < ActiveSupport::TestCase
     identifier = @adapter.search_patients(tenant_identifier: "tnt_a", name: "DOE").first[:patient_identifier]
     assert_nil @adapter.find_patient(tenant_identifier: "tnt_b", patient_identifier: identifier)
   end
+
+  # -- identifier filtering ---------------------------------------------------
+
+  test "search by identifier_system + identifier_value matches FHIR Identifier" do
+    @adapter.seed_patient(
+      tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+      display_name: "DOE,JOHN", date_of_birth: Date.new(1980, 1, 15), gender: "male",
+      identifiers: [ { system: "http://hl7.org/fhir/sid/us-ssn", value: "123-45-6789" } ]
+    )
+    @adapter.seed_patient(
+      tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+      display_name: "SMITH,JANE", date_of_birth: Date.new(1975, 6, 20), gender: "female",
+      identifiers: [ { system: "http://hl7.org/fhir/sid/us-ssn", value: "987-65-4321" } ]
+    )
+    results = @adapter.search_patients(
+      tenant_identifier: "tnt_test",
+      identifier_system: "http://hl7.org/fhir/sid/us-ssn",
+      identifier_value: "123-45-6789"
+    )
+    assert_equal 1, results.length
+    assert_equal "DOE,JOHN", results.first[:display_name]
+  end
+
+  test "search by identifier_system alone matches any value with that system" do
+    @adapter.seed_patient(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                          display_name: "WITH,SSN", date_of_birth: Date.new(1980, 1, 1), gender: "male",
+                          identifiers: [ { system: "http://hl7.org/fhir/sid/us-ssn", value: "111-11-1111" } ])
+    @adapter.seed_patient(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                          display_name: "WITHOUT,SSN", date_of_birth: Date.new(1981, 2, 2), gender: "female",
+                          identifiers: [])
+    results = @adapter.search_patients(
+      tenant_identifier: "tnt_test",
+      identifier_system: "http://hl7.org/fhir/sid/us-ssn"
+    )
+    assert_equal 1, results.length
+    assert_equal "WITH,SSN", results.first[:display_name]
+  end
+
+  test "search by identifier returns nothing when value doesn't match" do
+    @adapter.seed_patient(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                          display_name: "DOE,JOHN", date_of_birth: Date.new(1980, 1, 15), gender: "male",
+                          identifiers: [ { system: "http://hl7.org/fhir/sid/us-ssn", value: "123-45-6789" } ])
+    results = @adapter.search_patients(
+      tenant_identifier: "tnt_test",
+      identifier_system: "http://hl7.org/fhir/sid/us-ssn",
+      identifier_value: "000-00-0000"
+    )
+    assert_empty results
+  end
+
+  test "patient with no identifiers seeded gets an empty identifiers array in results" do
+    @adapter.seed_patient(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                          display_name: "DOE,JOHN", date_of_birth: Date.new(1980, 1, 15), gender: "male")
+    result = @adapter.search_patients(tenant_identifier: "tnt_test", name: "DOE").first
+    assert_equal [], result[:identifiers]
+  end
 end

--- a/test/lakeraven/ehr/configuration_test.rb
+++ b/test/lakeraven/ehr/configuration_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::ConfigurationTest < ActiveSupport::TestCase
+  setup do
+    Lakeraven::EHR.reset_configuration!
+  end
+
+  teardown do
+    Lakeraven::EHR.reset_configuration!
+  end
+
+  test "configuration starts with no adapter" do
+    assert_nil Lakeraven::EHR.configuration.adapter
+  end
+
+  test "configure block sets the adapter" do
+    custom_adapter = Object.new
+    Lakeraven::EHR.configure do |config|
+      config.adapter = custom_adapter
+    end
+    assert_equal custom_adapter, Lakeraven::EHR.configuration.adapter
+  end
+
+  test "Lakeraven::EHR.adapter returns the configured adapter" do
+    custom_adapter = Object.new
+    Lakeraven::EHR.configure { |c| c.adapter = custom_adapter }
+    assert_equal custom_adapter, Lakeraven::EHR.adapter
+  end
+
+  test "Lakeraven::EHR.adapter raises NotConfiguredError when no adapter is set" do
+    Lakeraven::EHR.reset_configuration!
+    error = assert_raises(Lakeraven::EHR::NotConfiguredError) do
+      Lakeraven::EHR.adapter
+    end
+    assert_match(/not configured/i, error.message)
+  end
+
+  test "reset_configuration! clears the adapter" do
+    Lakeraven::EHR.configure { |c| c.adapter = Object.new }
+    Lakeraven::EHR.reset_configuration!
+    assert_nil Lakeraven::EHR.configuration.adapter
+  end
+end

--- a/test/lakeraven/ehr/current_test.rb
+++ b/test/lakeraven/ehr/current_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::CurrentTest < ActiveSupport::TestCase
+  setup do
+    Lakeraven::EHR::Current.reset!
+  end
+
+  teardown do
+    Lakeraven::EHR::Current.reset!
+  end
+
+  test "tenant_identifier defaults to nil" do
+    assert_nil Lakeraven::EHR::Current.tenant_identifier
+  end
+
+  test "facility_identifier defaults to nil" do
+    assert_nil Lakeraven::EHR::Current.facility_identifier
+  end
+
+  test "tenant_identifier can be set and read" do
+    Lakeraven::EHR::Current.tenant_identifier = "tnt_test"
+    assert_equal "tnt_test", Lakeraven::EHR::Current.tenant_identifier
+  end
+
+  test "facility_identifier can be set and read" do
+    Lakeraven::EHR::Current.facility_identifier = "fac_main"
+    assert_equal "fac_main", Lakeraven::EHR::Current.facility_identifier
+  end
+
+  test "reset! clears both tenant and facility" do
+    Lakeraven::EHR::Current.tenant_identifier = "tnt_test"
+    Lakeraven::EHR::Current.facility_identifier = "fac_main"
+    Lakeraven::EHR::Current.reset!
+    assert_nil Lakeraven::EHR::Current.tenant_identifier
+    assert_nil Lakeraven::EHR::Current.facility_identifier
+  end
+
+  test "with_tenant block sets and restores tenant_identifier" do
+    Lakeraven::EHR::Current.tenant_identifier = "tnt_outer"
+    Lakeraven::EHR::Current.with_tenant("tnt_inner") do
+      assert_equal "tnt_inner", Lakeraven::EHR::Current.tenant_identifier
+    end
+    assert_equal "tnt_outer", Lakeraven::EHR::Current.tenant_identifier
+  end
+
+  test "with_tenant restores tenant even if block raises" do
+    Lakeraven::EHR::Current.tenant_identifier = "tnt_outer"
+    assert_raises(RuntimeError) do
+      Lakeraven::EHR::Current.with_tenant("tnt_inner") do
+        raise "boom"
+      end
+    end
+    assert_equal "tnt_outer", Lakeraven::EHR::Current.tenant_identifier
+  end
+
+  test "MissingTenantContextError exists and inherits from StandardError" do
+    assert Lakeraven::EHR::MissingTenantContextError < StandardError
+  end
+end

--- a/test/lakeraven/ehr/current_test.rb
+++ b/test/lakeraven/ehr/current_test.rb
@@ -58,4 +58,33 @@ class Lakeraven::EHR::CurrentTest < ActiveSupport::TestCase
   test "MissingTenantContextError exists and inherits from StandardError" do
     assert Lakeraven::EHR::MissingTenantContextError < StandardError
   end
+
+  # Regression for Copilot review #1 on PR #1: Current.reset! must not
+  # clear sibling ActiveSupport::CurrentAttributes subclasses, because
+  # this engine is meant to be embedded in host apps that have their
+  # own Current state. Using clear_all (the previous implementation)
+  # would wipe the host's state every time the engine reset between
+  # scenarios — a hostile thing for an engine to do.
+  #
+  # CurrentAttributes uses .name in its internal lookup key, so the
+  # stand-in host class must be a named constant rather than an
+  # anonymous Class.new — anonymous subclasses raise NoMethodError on
+  # name.to_sym before they can be exercised.
+  class FakeHostCurrent < ActiveSupport::CurrentAttributes
+    attribute :host_value
+  end
+
+  test "reset! does not clear sibling CurrentAttributes subclasses" do
+    FakeHostCurrent.host_value = "host-state-survives"
+
+    Lakeraven::EHR::Current.tenant_identifier = "tnt_test"
+    Lakeraven::EHR::Current.reset!
+
+    assert_nil Lakeraven::EHR::Current.tenant_identifier,
+      "engine Current should be cleared by reset!"
+    assert_equal "host-state-survives", FakeHostCurrent.host_value,
+      "host app's Current state should survive engine reset"
+  ensure
+    FakeHostCurrent.host_value = nil
+  end
 end

--- a/test/lakeraven/ehr/eager_load_test.rb
+++ b/test/lakeraven/ehr/eager_load_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Regression test for the Zeitwerk EHR-vs-Ehr inflection trap.
+#
+# When the engine module was renamed from Lakeraven::Ehr (the
+# generator default) to Lakeraven::EHR, several scaffold files
+# under app/{controllers,models,jobs,helpers}/lakeraven/ehr/ kept
+# the old casing. They worked fine in development because Zeitwerk
+# resolves files lazily — nothing tried to load them. They worked
+# fine in `rake test` because the test runner doesn't eager-load
+# unless you ask it to. They blew up the moment anything triggered
+# eager loading (production boot, `rails app:zeitwerk:check`,
+# Cucumber via the dummy app in some configurations) with a
+# Zeitwerk::NameError pointing at the wrong constant.
+#
+# This test forces eager loading from the unit suite so the trap
+# never reopens silently. If a future scaffold file lands with
+# `module Ehr` instead of `module EHR`, this test fails before
+# the next CI run.
+class Lakeraven::EHR::EagerLoadTest < ActiveSupport::TestCase
+  test "the engine eager-loads cleanly" do
+    assert_nothing_raised do
+      Rails.application.eager_load!
+    end
+  end
+
+  test "scaffold constants resolve to Lakeraven::EHR namespace" do
+    assert defined?(Lakeraven::EHR::ApplicationController)
+    assert defined?(Lakeraven::EHR::ApplicationRecord)
+    assert defined?(Lakeraven::EHR::ApplicationJob)
+    assert defined?(Lakeraven::EHR::ApplicationHelper)
+  end
+
+  test "no constant is defined under the Lakeraven::Ehr namespace" do
+    refute defined?(Lakeraven::Ehr),
+      "Lakeraven::Ehr should not exist — the engine namespace is Lakeraven::EHR"
+  end
+end

--- a/test/lakeraven/ehr/patient_search_test.rb
+++ b/test/lakeraven/ehr/patient_search_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::PatientSearchTest < ActiveSupport::TestCase
+  setup do
+    Lakeraven::EHR.reset_configuration!
+    Lakeraven::EHR::Current.reset!
+    Lakeraven::EHR.configure do |config|
+      config.adapter = Lakeraven::EHR::Adapters::MockAdapter.new
+    end
+    Lakeraven::EHR::Current.tenant_identifier = "tnt_test"
+    Lakeraven::EHR::Current.facility_identifier = "fac_main"
+
+    @adapter = Lakeraven::EHR.adapter
+    @adapter.seed_patient(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                          display_name: "DOE,JOHN", date_of_birth: Date.new(1980, 1, 15), gender: "male")
+    @adapter.seed_patient(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                          display_name: "JOHNSON,BOB", date_of_birth: Date.new(1990, 3, 10), gender: "male")
+  end
+
+  teardown do
+    Lakeraven::EHR.reset_configuration!
+    Lakeraven::EHR::Current.reset!
+  end
+
+  test "PatientSearch.call delegates to the configured adapter" do
+    results = Lakeraven::EHR::PatientSearch.call(name: "DOE")
+    assert_equal 1, results.length
+    assert_equal "DOE,JOHN", results.first[:display_name]
+  end
+
+  test "PatientSearch passes the current tenant_identifier to the adapter" do
+    results = Lakeraven::EHR::PatientSearch.call(name: "DOE")
+    assert_equal 1, results.length
+  end
+
+  test "PatientSearch passes the current facility_identifier when set" do
+    @adapter.seed_patient(tenant_identifier: "tnt_test", facility_identifier: "fac_other",
+                          display_name: "OTHER,PERSON", date_of_birth: Date.new(1985, 12, 5), gender: "male")
+    Lakeraven::EHR::Current.facility_identifier = "fac_main"
+    results = Lakeraven::EHR::PatientSearch.call(name: "PERSON")
+    assert_equal 0, results.length
+  end
+
+  test "PatientSearch returns all facilities when current facility is unset" do
+    @adapter.seed_patient(tenant_identifier: "tnt_test", facility_identifier: "fac_other",
+                          display_name: "OTHER,PERSON", date_of_birth: Date.new(1985, 12, 5), gender: "male")
+    Lakeraven::EHR::Current.facility_identifier = nil
+    results = Lakeraven::EHR::PatientSearch.call(name: "PERSON")
+    assert_equal 1, results.length
+  end
+
+  test "PatientSearch raises MissingTenantContextError when tenant is unset" do
+    Lakeraven::EHR::Current.tenant_identifier = nil
+    assert_raises(Lakeraven::EHR::MissingTenantContextError) do
+      Lakeraven::EHR::PatientSearch.call(name: "DOE")
+    end
+  end
+
+  test "PatientSearch returns an empty array (not nil) for no matches" do
+    result = Lakeraven::EHR::PatientSearch.call(name: "NONEXISTENT")
+    assert_equal [], result
+  end
+
+  test "PatientSearch raises NotConfiguredError when adapter is missing" do
+    Lakeraven::EHR.reset_configuration!
+    Lakeraven::EHR::Current.tenant_identifier = "tnt_test"
+    assert_raises(Lakeraven::EHR::NotConfiguredError) do
+      Lakeraven::EHR::PatientSearch.call(name: "DOE")
+    end
+  end
+end

--- a/test/lakeraven/ehr/patient_search_test.rb
+++ b/test/lakeraven/ehr/patient_search_test.rb
@@ -31,8 +31,13 @@ class Lakeraven::EHR::PatientSearchTest < ActiveSupport::TestCase
   end
 
   test "PatientSearch passes the current tenant_identifier to the adapter" do
+    # Seed an identically-named patient in a different tenant. If
+    # PatientSearch ignored Current.tenant_identifier and passed nothing
+    # (or the wrong value) through to the adapter, this would return 2.
+    @adapter.seed_patient(tenant_identifier: "tnt_other", facility_identifier: "fac_main",
+                          display_name: "DOE,JOHN", date_of_birth: Date.new(1980, 1, 15), gender: "male")
     results = Lakeraven::EHR::PatientSearch.call(name: "DOE")
-    assert_equal 1, results.length
+    assert_equal 1, results.length, "expected tnt_other patient to be filtered out by tenant scope"
   end
 
   test "PatientSearch passes the current facility_identifier when set" do


### PR DESCRIPTION
## Summary

First feature port for the engine. Lands the foundational adapter/configuration/tenancy layer along with the patient_search service and its Cucumber spec.

Closes #49.

## What's in this PR

Six TDD/BDD commits, each with red→green tests landing alongside the implementation:

1. **`Lakeraven::EHR.configure` / `.adapter` accessor** — host-application configuration hook with `NotConfiguredError` fail-loud
2. **`Current` request store + `MissingTenantContextError`** — `ActiveSupport::CurrentAttributes` for tenant/facility context, with a `with_tenant` block helper for jobs and consoles
3. **`Adapters::Base` contract** — abstract adapter declaring `search_patients` and `find_patient`
4. **`Adapters::MockAdapter`** — in-memory adapter for tests; mints opaque `pt_*` identifiers; honors tenant + facility scoping
5. **`PatientSearch` service + Zeitwerk `EHR` inflection** — single entry point that reads `Current`, fails loud on missing tenant, delegates to the configured adapter
6. **`patient_search` Cucumber feature** — 7 scenarios, 56 steps, all green

## Architecture references

- **ADR 0001** — engine scope: this is the data-layer slice, not case management
- **ADR 0002** — PHI tokenization: results carry opaque `patient_identifier`, never DFN
- **ADR 0003** — fail-loud tenancy: search raises `MissingTenantContextError` when no tenant is set
- **ADR 0004** — `id` vs `identifier` convention: every external token uses `*_identifier`

## Test plan

- [x] `bundle exec rake test` — 37 runs, 54 assertions, 0 failures
- [x] `bundle exec cucumber` — 7 scenarios, 56 steps, all passed
- [x] `bundle exec rubocop` — 27 files, no offenses
- [ ] CI green on GitHub Actions

## Cucumber scenarios

Search by full name; search by partial last name; search returns opaque identifiers (with explicit assertion that no `:dfn` key leaks); empty result is a valid empty array (not an error); search is scoped to current facility; search across all facilities when facility is unset; search fails loud when no tenant context is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)