### PR TITLE
Provider search: second feature port (TDD/BDD)

### DIFF
--- a/app/services/lakeraven/ehr/provider_search.rb
+++ b/app/services/lakeraven/ehr/provider_search.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # Practitioner search service.
+    #
+    # Mirrors PatientSearch — single entry point that reads tenant
+    # and facility scope from Lakeraven::EHR::Current per ADR 0003,
+    # raises MissingTenantContextError if tenant is unset, and
+    # delegates to the configured adapter's #search_practitioners.
+    #
+    #   Lakeraven::EHR::ProviderSearch.call(name: "MARTINEZ")
+    #   Lakeraven::EHR::ProviderSearch.call(specialty: "Cardiology")
+    #   Lakeraven::EHR::ProviderSearch.call(
+    #     identifier_system: "http://hl7.org/fhir/sid/us-npi",
+    #     identifier_value: "1234567890"
+    #   )
+    #
+    # The result hashes use the *_identifier convention from ADR 0004
+    # and never expose backend-native ids — that's enforced at the
+    # adapter level and asserted in the cucumber feature.
+    class ProviderSearch
+      def self.call(name: nil, specialty: nil, identifier_system: nil, identifier_value: nil)
+        new.call(
+          name: name,
+          specialty: specialty,
+          identifier_system: identifier_system,
+          identifier_value: identifier_value
+        )
+      end
+
+      def call(name: nil, specialty: nil, identifier_system: nil, identifier_value: nil)
+        tenant = Current.tenant_identifier
+        if tenant.nil? || tenant.to_s.empty?
+          raise MissingTenantContextError,
+            "ProviderSearch requires Lakeraven::EHR::Current.tenant_identifier to be set " \
+            "(see ADR 0003 — fail-loud tenancy)"
+        end
+
+        EHR.adapter.search_practitioners(
+          tenant_identifier: tenant,
+          facility_identifier: Current.facility_identifier,
+          name: name,
+          specialty: specialty,
+          identifier_system: identifier_system,
+          identifier_value: identifier_value
+        )
+      end
+    end
+  end
+end

--- a/features/provider_search.feature
+++ b/features/provider_search.feature
@@ -1,0 +1,65 @@
+Feature: Provider search
+  As a SMART-on-FHIR client
+  I need to search for practitioners in the EHR
+  So that I can resolve a provider context for referrals, signing, and orders
+
+  Background:
+    Given the EHR adapter is the in-memory mock
+    And the current tenant is "tnt_test"
+    And the current facility is "fac_main"
+    And the following practitioners are registered at facility "fac_main":
+      | display_name      | specialty            | npi        |
+      | MARTINEZ,SARAH    | Cardiology           | 1234567890 |
+      | CHEN,JAMES        | Orthopedic Surgery   | 2345678901 |
+      | RODRIGUEZ,LISA    | Family Medicine      | 3456789012 |
+    And the following practitioners are registered at facility "fac_other":
+      | display_name      | specialty            | npi        |
+      | OTHER,PROVIDER    | Dermatology          | 4567890123 |
+
+  Scenario: Search by full name
+    When I search for practitioners by name "MARTINEZ,SARAH"
+    Then the practitioner search returns 1 practitioner
+    And the result includes a practitioner with display name "MARTINEZ,SARAH"
+
+  Scenario: Search by partial last name
+    When I search for practitioners by name "MARTINEZ"
+    Then the practitioner search returns 1 practitioner
+    And the result includes a practitioner with display name "MARTINEZ,SARAH"
+
+  Scenario: Search by specialty
+    When I search for practitioners by specialty "Cardiology"
+    Then the practitioner search returns 1 practitioner
+    And the result includes a practitioner with display name "MARTINEZ,SARAH"
+
+  Scenario: Search by NPI as FHIR Identifier
+    When I search for practitioners with identifier system "http://hl7.org/fhir/sid/us-npi" and value "2345678901"
+    Then the practitioner search returns 1 practitioner
+    And the result includes a practitioner with display name "CHEN,JAMES"
+
+  Scenario: List all practitioners in the current facility
+    When I search for practitioners with no filter
+    Then the practitioner search returns 3 practitioners
+
+  Scenario: Search returns opaque practitioner identifiers
+    When I search for practitioners by name "MARTINEZ"
+    Then every practitioner result has an opaque practitioner_identifier prefixed with "pr_"
+    And no practitioner result exposes a backend-native IEN
+
+  Scenario: Empty result is a valid empty array, not an error
+    When I search for practitioners by name "NONEXISTENT"
+    Then the practitioner search returns 0 practitioners
+    And the practitioner search succeeds without raising
+
+  Scenario: Search is scoped to the current facility
+    When I search for practitioners by name "PROVIDER"
+    Then the practitioner search returns 0 practitioners
+
+  Scenario: Search across all facilities in the tenant when no facility is set
+    Given the current facility is unset
+    When I search for practitioners by name "PROVIDER"
+    Then the practitioner search returns 1 practitioner
+
+  Scenario: Search fails loud when no tenant context is set
+    Given the current tenant is unset
+    When I search for practitioners by name "MARTINEZ"
+    Then the practitioner search raises a missing-tenant-context error

--- a/features/step_definitions/provider_search_steps.rb
+++ b/features/step_definitions/provider_search_steps.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+Given("the following practitioners are registered at facility {string}:") do |facility_identifier, table|
+  table.hashes.each do |row|
+    Lakeraven::EHR.adapter.seed_practitioner(
+      tenant_identifier: Lakeraven::EHR::Current.tenant_identifier || "tnt_test",
+      facility_identifier: facility_identifier,
+      display_name: row["display_name"],
+      specialty: row["specialty"],
+      identifiers: row["npi"] ? [ { system: "http://hl7.org/fhir/sid/us-npi", value: row["npi"] } ] : []
+    )
+  end
+end
+
+When("I search for practitioners by name {string}") do |name|
+  @provider_search_error = nil
+  @provider_search_results = Lakeraven::EHR::ProviderSearch.call(name: name)
+rescue Lakeraven::EHR::MissingTenantContextError => e
+  @provider_search_error = e
+end
+
+When("I search for practitioners by specialty {string}") do |specialty|
+  @provider_search_error = nil
+  @provider_search_results = Lakeraven::EHR::ProviderSearch.call(specialty: specialty)
+rescue Lakeraven::EHR::MissingTenantContextError => e
+  @provider_search_error = e
+end
+
+When("I search for practitioners with identifier system {string} and value {string}") do |system, value|
+  @provider_search_error = nil
+  @provider_search_results = Lakeraven::EHR::ProviderSearch.call(identifier_system: system, identifier_value: value)
+rescue Lakeraven::EHR::MissingTenantContextError => e
+  @provider_search_error = e
+end
+
+When("I search for practitioners with no filter") do
+  @provider_search_error = nil
+  @provider_search_results = Lakeraven::EHR::ProviderSearch.call
+rescue Lakeraven::EHR::MissingTenantContextError => e
+  @provider_search_error = e
+end
+
+Then("the practitioner search returns {int} practitioner(s)") do |count|
+  assert_nil @provider_search_error, "expected no error but got #{@provider_search_error&.class}: #{@provider_search_error&.message}"
+  assert_equal count, @provider_search_results.length
+end
+
+Then("the result includes a practitioner with display name {string}") do |display_name|
+  display_names = @provider_search_results.map { |r| r[:display_name] }
+  assert_includes display_names, display_name
+end
+
+Then('every practitioner result has an opaque practitioner_identifier prefixed with {string}') do |prefix|
+  @provider_search_results.each do |result|
+    assert result[:practitioner_identifier].start_with?(prefix),
+      "expected practitioner_identifier to start with #{prefix}, got #{result[:practitioner_identifier]}"
+  end
+end
+
+Then("no practitioner result exposes a backend-native IEN") do
+  @provider_search_results.each do |result|
+    normalized_keys = result.keys.map { |k| k.to_s.downcase }
+    refute_includes normalized_keys, "ien"
+  end
+end
+
+Then("the practitioner search succeeds without raising") do
+  assert_nil @provider_search_error
+end
+
+Then("the practitioner search raises a missing-tenant-context error") do
+  assert_kind_of Lakeraven::EHR::MissingTenantContextError, @provider_search_error
+end

--- a/lib/lakeraven/ehr/adapters/base.rb
+++ b/lib/lakeraven/ehr/adapters/base.rb
@@ -43,6 +43,29 @@ module Lakeraven
         def find_patient(tenant_identifier:, patient_identifier:)
           raise NotImplementedError, "#{self.class} must implement #find_patient"
         end
+
+        # Search practitioners by name, specialty, and/or FHIR Identifier.
+        #
+        # @param tenant_identifier [String] opaque tenant token
+        # @param facility_identifier [String, nil] opaque facility token; nil = all facilities
+        # @param name [String, nil] partial or full name (case-insensitive substring)
+        # @param specialty [String, nil] specialty / qualification text
+        # @param identifier_system [String, nil] FHIR Identifier system URI (e.g. NPI)
+        # @param identifier_value [String, nil] FHIR Identifier value
+        # @return [Array<Hash>] each result with keys :practitioner_identifier,
+        #   :display_name, :specialty, :facility_identifier, :identifiers
+        def search_practitioners(tenant_identifier:, facility_identifier: nil, name: nil, specialty: nil, identifier_system: nil, identifier_value: nil)
+          raise NotImplementedError, "#{self.class} must implement #search_practitioners"
+        end
+
+        # Resolve a single practitioner by opaque identifier.
+        #
+        # @param tenant_identifier [String]
+        # @param practitioner_identifier [String]
+        # @return [Hash, nil] same shape as a search_practitioners result, or nil if not found
+        def find_practitioner(tenant_identifier:, practitioner_identifier:)
+          raise NotImplementedError, "#{self.class} must implement #find_practitioner"
+        end
       end
     end
   end

--- a/lib/lakeraven/ehr/adapters/mock_adapter.rb
+++ b/lib/lakeraven/ehr/adapters/mock_adapter.rb
@@ -22,6 +22,8 @@ module Lakeraven
           super
           # patients[tenant_identifier] => Array<Hash>
           @patients = Hash.new { |h, k| h[k] = [] }
+          # practitioners[tenant_identifier] => Array<Hash>
+          @practitioners = Hash.new { |h, k| h[k] = [] }
         end
 
         # Test helper — adds a patient to the in-memory store. Mints
@@ -59,6 +61,43 @@ module Lakeraven
           row ? public_view(row) : nil
         end
 
+        # -- practitioners ----------------------------------------------------
+
+        # Test helper — adds a practitioner to the in-memory store. Mints
+        # an opaque practitioner_identifier and returns it. `identifiers`
+        # is an optional array of FHIR-shaped { system:, value: } hashes
+        # so seeded practitioners can carry NPIs, DEA numbers, state
+        # license numbers, etc.
+        def seed_practitioner(tenant_identifier:, facility_identifier:, display_name:, specialty:, identifiers: [])
+          identifier = mint_practitioner_identifier
+          record = {
+            practitioner_identifier: identifier,
+            tenant_identifier: tenant_identifier,
+            facility_identifier: facility_identifier,
+            display_name: display_name,
+            specialty: specialty,
+            identifiers: identifiers
+          }
+          @practitioners[tenant_identifier] << record
+          identifier
+        end
+
+        def search_practitioners(tenant_identifier:, facility_identifier: nil, name: nil, specialty: nil, identifier_system: nil, identifier_value: nil)
+          rows = @practitioners[tenant_identifier]
+          rows = rows.select { |r| r[:facility_identifier] == facility_identifier } if facility_identifier
+          rows = rows.select { |r| r[:display_name].downcase.include?(name.downcase) } if name && !name.empty?
+          rows = rows.select { |r| r[:specialty].to_s.downcase.include?(specialty.downcase) } if specialty && !specialty.empty?
+          if identifier_system || identifier_value
+            rows = rows.select { |r| match_identifier?(r, identifier_system, identifier_value) }
+          end
+          rows.map { |r| public_practitioner_view(r) }
+        end
+
+        def find_practitioner(tenant_identifier:, practitioner_identifier:)
+          row = @practitioners[tenant_identifier].find { |r| r[:practitioner_identifier] == practitioner_identifier }
+          row ? public_practitioner_view(row) : nil
+        end
+
         private
 
         # Mints a prefixed token. Uses a UUIDv4 internally rather than a
@@ -66,6 +105,10 @@ module Lakeraven
         # SecureRandom is in stdlib. Real adapters mint per ADR 0004.
         def mint_patient_identifier
           "pt_#{SecureRandom.uuid.delete('-')}"
+        end
+
+        def mint_practitioner_identifier
+          "pr_#{SecureRandom.uuid.delete('-')}"
         end
 
         # Strip internal-only keys before returning to caller. tenant_identifier
@@ -78,6 +121,16 @@ module Lakeraven
             display_name: row[:display_name],
             date_of_birth: row[:date_of_birth],
             gender: row[:gender],
+            identifiers: row[:identifiers] || []
+          }
+        end
+
+        def public_practitioner_view(row)
+          {
+            practitioner_identifier: row[:practitioner_identifier],
+            facility_identifier: row[:facility_identifier],
+            display_name: row[:display_name],
+            specialty: row[:specialty],
             identifiers: row[:identifiers] || []
           }
         end

--- a/lib/lakeraven/ehr/adapters/mock_adapter.rb
+++ b/lib/lakeraven/ehr/adapters/mock_adapter.rb
@@ -8,15 +8,16 @@ module Lakeraven
     module Adapters
       # In-memory adapter used by tests and Cucumber scenarios.
       #
-      # Holds patients in a Ruby hash keyed by tenant_identifier so each
-      # test can seed its own data without coordinating with anyone
-      # else. Not thread-safe — there's no need; tests run serially
-      # against a fresh instance.
+      # Holds patients and practitioners in Ruby hashes keyed by
+      # tenant_identifier so each test can seed its own data without
+      # coordinating with anyone else. Not thread-safe — there's no need;
+      # tests run serially against a fresh instance.
       #
       # Per ADR 0002, this still doesn't store backend-native identifiers
       # in the result hashes returned to engine code. The patient_identifier
-      # it returns is an opaque token (per ADR 0004), and the internal DFN
-      # equivalent is held only inside the adapter.
+      # and practitioner_identifier it returns are opaque tokens (per
+      # ADR 0004); the internal DFN/IEN equivalents are held only inside
+      # the adapter and stripped from the public_view shapes.
       class MockAdapter < Base
         def initialize
           super

--- a/test/lakeraven/ehr/adapters/base_test.rb
+++ b/test/lakeraven/ehr/adapters/base_test.rb
@@ -27,4 +27,18 @@ class Lakeraven::EHR::Adapters::BaseTest < ActiveSupport::TestCase
     end
     assert_equal [], subclass.new.search_patients(tenant_identifier: "tnt_test")
   end
+
+  test "search_practitioners raises NotImplementedError on the base class" do
+    error = assert_raises(NotImplementedError) do
+      Base.new.search_practitioners(tenant_identifier: "tnt_test")
+    end
+    assert_match(/search_practitioners/, error.message)
+  end
+
+  test "find_practitioner raises NotImplementedError on the base class" do
+    error = assert_raises(NotImplementedError) do
+      Base.new.find_practitioner(tenant_identifier: "tnt_test", practitioner_identifier: "pr_x")
+    end
+    assert_match(/find_practitioner/, error.message)
+  end
 end

--- a/test/lakeraven/ehr/adapters/mock_adapter_test.rb
+++ b/test/lakeraven/ehr/adapters/mock_adapter_test.rb
@@ -162,4 +162,115 @@ class Lakeraven::EHR::Adapters::MockAdapterTest < ActiveSupport::TestCase
     result = @adapter.search_patients(tenant_identifier: "tnt_test", name: "DOE").first
     assert_equal [], result[:identifiers]
   end
+
+  # -- practitioners ----------------------------------------------------------
+
+  test "starts with no practitioners" do
+    assert_empty @adapter.search_practitioners(tenant_identifier: "tnt_test")
+  end
+
+  test "seed_practitioner adds a practitioner and search returns it" do
+    @adapter.seed_practitioner(
+      tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+      display_name: "MARTINEZ,SARAH", specialty: "Cardiology"
+    )
+    results = @adapter.search_practitioners(tenant_identifier: "tnt_test", name: "MARTINEZ")
+    assert_equal 1, results.length
+    assert_equal "MARTINEZ,SARAH", results.first[:display_name]
+    assert_equal "Cardiology", results.first[:specialty]
+  end
+
+  test "seeded practitioner gets an opaque practitioner_identifier prefixed with pr_" do
+    @adapter.seed_practitioner(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                               display_name: "MARTINEZ,SARAH", specialty: "Cardiology")
+    result = @adapter.search_practitioners(tenant_identifier: "tnt_test", name: "MARTINEZ").first
+    assert result[:practitioner_identifier].start_with?("pr_"), result[:practitioner_identifier]
+  end
+
+  test "search_practitioners by name is case-insensitive partial match" do
+    @adapter.seed_practitioner(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                               display_name: "MARTINEZ,SARAH", specialty: "Cardiology")
+    @adapter.seed_practitioner(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                               display_name: "MARTIN,JANE", specialty: "Family Medicine")
+    results = @adapter.search_practitioners(tenant_identifier: "tnt_test", name: "martin")
+    assert_equal 2, results.length
+  end
+
+  test "search_practitioners by specialty matches case-insensitively" do
+    @adapter.seed_practitioner(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                               display_name: "MARTINEZ,SARAH", specialty: "Cardiology")
+    @adapter.seed_practitioner(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                               display_name: "CHEN,JAMES", specialty: "Orthopedic Surgery")
+    results = @adapter.search_practitioners(tenant_identifier: "tnt_test", specialty: "cardiology")
+    assert_equal 1, results.length
+    assert_equal "MARTINEZ,SARAH", results.first[:display_name]
+  end
+
+  test "search_practitioners by NPI identifier matches" do
+    @adapter.seed_practitioner(
+      tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+      display_name: "MARTINEZ,SARAH", specialty: "Cardiology",
+      identifiers: [ { system: "http://hl7.org/fhir/sid/us-npi", value: "1234567890" } ]
+    )
+    @adapter.seed_practitioner(
+      tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+      display_name: "CHEN,JAMES", specialty: "Orthopedic Surgery",
+      identifiers: [ { system: "http://hl7.org/fhir/sid/us-npi", value: "2345678901" } ]
+    )
+    results = @adapter.search_practitioners(
+      tenant_identifier: "tnt_test",
+      identifier_system: "http://hl7.org/fhir/sid/us-npi",
+      identifier_value: "2345678901"
+    )
+    assert_equal 1, results.length
+    assert_equal "CHEN,JAMES", results.first[:display_name]
+  end
+
+  test "search_practitioners is scoped to tenant" do
+    @adapter.seed_practitioner(tenant_identifier: "tnt_a", facility_identifier: "fac_main",
+                               display_name: "MARTINEZ,SARAH", specialty: "Cardiology")
+    @adapter.seed_practitioner(tenant_identifier: "tnt_b", facility_identifier: "fac_main",
+                               display_name: "MARTINEZ,JANE", specialty: "Cardiology")
+    results = @adapter.search_practitioners(tenant_identifier: "tnt_a", name: "MARTINEZ")
+    assert_equal 1, results.length
+    assert_equal "MARTINEZ,SARAH", results.first[:display_name]
+  end
+
+  test "search_practitioners is scoped to facility when facility_identifier is given" do
+    @adapter.seed_practitioner(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                               display_name: "MARTINEZ,SARAH", specialty: "Cardiology")
+    @adapter.seed_practitioner(tenant_identifier: "tnt_test", facility_identifier: "fac_other",
+                               display_name: "OTHER,PROVIDER", specialty: "Dermatology")
+    results = @adapter.search_practitioners(tenant_identifier: "tnt_test", facility_identifier: "fac_main")
+    assert_equal 1, results.length
+  end
+
+  test "search_practitioners results never expose backend-native ien key" do
+    @adapter.seed_practitioner(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                               display_name: "MARTINEZ,SARAH", specialty: "Cardiology")
+    result = @adapter.search_practitioners(tenant_identifier: "tnt_test", name: "MARTINEZ").first
+    refute_includes result.keys, :ien
+    refute_includes result.keys, "ien"
+    refute_includes result.keys, :IEN
+    refute_includes result.keys, "IEN"
+  end
+
+  test "find_practitioner resolves a previously-seeded practitioner by identifier" do
+    @adapter.seed_practitioner(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                               display_name: "MARTINEZ,SARAH", specialty: "Cardiology")
+    identifier = @adapter.search_practitioners(tenant_identifier: "tnt_test", name: "MARTINEZ").first[:practitioner_identifier]
+    found = @adapter.find_practitioner(tenant_identifier: "tnt_test", practitioner_identifier: identifier)
+    assert_equal "MARTINEZ,SARAH", found[:display_name]
+  end
+
+  test "find_practitioner returns nil for unknown identifier" do
+    assert_nil @adapter.find_practitioner(tenant_identifier: "tnt_test", practitioner_identifier: "pr_unknown")
+  end
+
+  test "find_practitioner returns nil if identifier exists in a different tenant" do
+    @adapter.seed_practitioner(tenant_identifier: "tnt_a", facility_identifier: "fac_main",
+                               display_name: "MARTINEZ,SARAH", specialty: "Cardiology")
+    identifier = @adapter.search_practitioners(tenant_identifier: "tnt_a", name: "MARTINEZ").first[:practitioner_identifier]
+    assert_nil @adapter.find_practitioner(tenant_identifier: "tnt_b", practitioner_identifier: identifier)
+  end
 end

--- a/test/lakeraven/ehr/provider_search_test.rb
+++ b/test/lakeraven/ehr/provider_search_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::ProviderSearchTest < ActiveSupport::TestCase
+  setup do
+    Lakeraven::EHR.reset_configuration!
+    Lakeraven::EHR::Current.reset!
+    Lakeraven::EHR.configure do |config|
+      config.adapter = Lakeraven::EHR::Adapters::MockAdapter.new
+    end
+    Lakeraven::EHR::Current.tenant_identifier = "tnt_test"
+    Lakeraven::EHR::Current.facility_identifier = "fac_main"
+
+    @adapter = Lakeraven::EHR.adapter
+    @adapter.seed_practitioner(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                               display_name: "MARTINEZ,SARAH", specialty: "Cardiology",
+                               identifiers: [ { system: "http://hl7.org/fhir/sid/us-npi", value: "1234567890" } ])
+    @adapter.seed_practitioner(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+                               display_name: "CHEN,JAMES", specialty: "Orthopedic Surgery",
+                               identifiers: [ { system: "http://hl7.org/fhir/sid/us-npi", value: "2345678901" } ])
+  end
+
+  teardown do
+    Lakeraven::EHR.reset_configuration!
+    Lakeraven::EHR::Current.reset!
+  end
+
+  test "ProviderSearch.call delegates to the configured adapter" do
+    results = Lakeraven::EHR::ProviderSearch.call(name: "MARTINEZ")
+    assert_equal 1, results.length
+    assert_equal "MARTINEZ,SARAH", results.first[:display_name]
+  end
+
+  test "ProviderSearch passes the current tenant_identifier to the adapter" do
+    @adapter.seed_practitioner(tenant_identifier: "tnt_other", facility_identifier: "fac_main",
+                               display_name: "MARTINEZ,SARAH", specialty: "Cardiology")
+    results = Lakeraven::EHR::ProviderSearch.call(name: "MARTINEZ")
+    assert_equal 1, results.length, "expected tnt_other practitioner to be filtered out by tenant scope"
+  end
+
+  test "ProviderSearch passes the current facility_identifier when set" do
+    @adapter.seed_practitioner(tenant_identifier: "tnt_test", facility_identifier: "fac_other",
+                               display_name: "OTHER,PROVIDER", specialty: "Dermatology")
+    Lakeraven::EHR::Current.facility_identifier = "fac_main"
+    results = Lakeraven::EHR::ProviderSearch.call(name: "PROVIDER")
+    assert_equal 0, results.length
+  end
+
+  test "ProviderSearch returns all facilities when current facility is unset" do
+    @adapter.seed_practitioner(tenant_identifier: "tnt_test", facility_identifier: "fac_other",
+                               display_name: "OTHER,PROVIDER", specialty: "Dermatology")
+    Lakeraven::EHR::Current.facility_identifier = nil
+    results = Lakeraven::EHR::ProviderSearch.call(name: "PROVIDER")
+    assert_equal 1, results.length
+  end
+
+  test "ProviderSearch by specialty filters correctly" do
+    results = Lakeraven::EHR::ProviderSearch.call(specialty: "Cardiology")
+    assert_equal 1, results.length
+    assert_equal "MARTINEZ,SARAH", results.first[:display_name]
+  end
+
+  test "ProviderSearch by NPI identifier filters correctly" do
+    results = Lakeraven::EHR::ProviderSearch.call(
+      identifier_system: "http://hl7.org/fhir/sid/us-npi",
+      identifier_value: "2345678901"
+    )
+    assert_equal 1, results.length
+    assert_equal "CHEN,JAMES", results.first[:display_name]
+  end
+
+  test "ProviderSearch with no filter returns all practitioners in scope" do
+    results = Lakeraven::EHR::ProviderSearch.call
+    assert_equal 2, results.length
+  end
+
+  test "ProviderSearch raises MissingTenantContextError when tenant is unset" do
+    Lakeraven::EHR::Current.tenant_identifier = nil
+    assert_raises(Lakeraven::EHR::MissingTenantContextError) do
+      Lakeraven::EHR::ProviderSearch.call(name: "MARTINEZ")
+    end
+  end
+
+  test "ProviderSearch returns an empty array (not nil) for no matches" do
+    result = Lakeraven::EHR::ProviderSearch.call(name: "NONEXISTENT")
+    assert_equal [], result
+  end
+
+  test "ProviderSearch raises NotConfiguredError when adapter is missing" do
+    Lakeraven::EHR.reset_configuration!
+    Lakeraven::EHR::Current.tenant_identifier = "tnt_test"
+    assert_raises(Lakeraven::EHR::NotConfiguredError) do
+      Lakeraven::EHR::ProviderSearch.call(name: "MARTINEZ")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Second feature port for the engine. Mirrors patient_search structurally — same TDD/BDD discipline, same adapter pattern, same fail-loud tenancy. Closes #50.

## What's in this PR

Four TDD/BDD commits, each red→green:

1. **Extend `Adapters::Base` contract** — `search_practitioners` and `find_practitioner` declared on the abstract base, both raise `NotImplementedError` on the base class
2. **Extend `MockAdapter`** — `seed_practitioner` test helper, in-memory store keyed by tenant, search with name/specialty/identifier filters, find with cross-tenant nil-return
3. **`ProviderSearch` service** — single entry point that reads `Current`, fails loud on missing tenant, delegates to the adapter
4. **`provider_search` Cucumber feature** — 10 scenarios covering name/specialty/NPI search, no-filter all, opaque `pr_` identifier guarantee, no IEN leak, facility scoping, cross-facility, and missing-tenant fail-loud

## Architecture references

- **ADR 0001** — engine scope: data layer only, no clinical workflow
- **ADR 0002** — PHI tokenization: results carry opaque `practitioner_identifier`, never IEN
- **ADR 0003** — fail-loud tenancy: search raises `MissingTenantContextError` when no tenant is set
- **ADR 0004** — `id` vs `identifier` convention; FHIR Identifier round-trips through `:identifiers` in result hashes

## Test plan

- [x] `bundle exec rake test` — 69 runs, 113 assertions, 0 failures
- [x] `bundle exec cucumber` — 17 scenarios, 134 steps, all passed (7 patient + 10 provider)
- [x] `bundle exec rubocop` — 31 files, no offenses
- [ ] CI green on GitHub Actions

## Notes

The legacy provider_search feature in `rpms_redux` had scenarios for "view provider's referrals" and "providers who can prescribe controlled substances". Both were dropped here:

- Referrals belong to corvid (case management), not this engine — out of scope per ADR 0001
- DEA controlled-substance filtering is a clinical workflow that involves prescription state, not in v0.1 scope per docs/features.md

The `*` wildcard syntax was also dropped in favor of plain case-insensitive substring matching, consistent with patient_search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)