### PR TITLE
US Core Patient API: third feature port (TDD/BDD)

### DIFF
--- a/app/controllers/lakeraven/ehr/application_controller.rb
+++ b/app/controllers/lakeraven/ehr/application_controller.rb
@@ -24,8 +24,11 @@ module Lakeraven
       private
 
       def require_tenant_context!
-        tenant = request.headers["X-Tenant-Identifier"]
-        if tenant.nil? || tenant.empty?
+        # Strip whitespace before the blank check so a header of " " or
+        # "\t" produces the same 400 OperationOutcome as a missing header
+        # rather than slipping through and producing a 404 downstream.
+        tenant = request.headers["X-Tenant-Identifier"].to_s.strip
+        if tenant.empty?
           render_operation_outcome(
             status: :bad_request,
             severity: "error",
@@ -35,7 +38,7 @@ module Lakeraven
           return
         end
         Current.tenant_identifier   = tenant
-        Current.facility_identifier = request.headers["X-Facility-Identifier"].presence
+        Current.facility_identifier = request.headers["X-Facility-Identifier"].to_s.strip.presence
       end
 
       def render_operation_outcome(status:, severity:, code:, diagnostics: nil)

--- a/app/controllers/lakeraven/ehr/application_controller.rb
+++ b/app/controllers/lakeraven/ehr/application_controller.rb
@@ -1,6 +1,51 @@
+# frozen_string_literal: true
+
 module Lakeraven
   module EHR
-    class ApplicationController < ActionController::Base
+    # Engine-wide controller base.
+    #
+    # Handles two cross-cutting concerns:
+    #
+    # 1. **Tenant context.** Reads X-Tenant-Identifier and
+    #    X-Facility-Identifier from request headers and stuffs them
+    #    into Lakeraven::EHR::Current. SMART auth (#52) will replace
+    #    the header source with the SMART launch context once it
+    #    lands; the rest of the engine doesn't need to care which
+    #    flavor populated Current.
+    #
+    # 2. **FHIR error rendering.** Standardizes 404, 400, and other
+    #    error responses as application/fhir+json OperationOutcome
+    #    resources rather than the Rails default HTML / JSON.
+    class ApplicationController < ActionController::API
+      FHIR_CONTENT_TYPE = "application/fhir+json"
+
+      before_action :require_tenant_context!
+
+      private
+
+      def require_tenant_context!
+        tenant = request.headers["X-Tenant-Identifier"]
+        if tenant.nil? || tenant.empty?
+          render_operation_outcome(
+            status: :bad_request,
+            severity: "error",
+            code: "required",
+            diagnostics: "X-Tenant-Identifier header is required"
+          )
+          return
+        end
+        Current.tenant_identifier   = tenant
+        Current.facility_identifier = request.headers["X-Facility-Identifier"].presence
+      end
+
+      def render_operation_outcome(status:, severity:, code:, diagnostics: nil)
+        outcome = FHIR::OperationOutcome.call(severity: severity, code: code, diagnostics: diagnostics)
+        render json: outcome, status: status, content_type: FHIR_CONTENT_TYPE
+      end
+
+      def render_fhir(resource, status: :ok)
+        render json: resource, status: status, content_type: FHIR_CONTENT_TYPE
+      end
     end
   end
 end

--- a/app/controllers/lakeraven/ehr/patients_controller.rb
+++ b/app/controllers/lakeraven/ehr/patients_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # FHIR R4 Patient resource controller.
+    #
+    # Handles GET /Patient/:identifier (read by opaque token).
+    # Search via GET /Patient?... will land in a follow-up.
+    class PatientsController < ApplicationController
+      def show
+        record = EHR.adapter.find_patient(
+          tenant_identifier: Current.tenant_identifier,
+          patient_identifier: params[:identifier]
+        )
+
+        if record.nil?
+          render_operation_outcome(
+            status: :not_found,
+            severity: "error",
+            code: "not-found",
+            diagnostics: "Patient not found"
+          )
+          return
+        end
+
+        render_fhir(FHIR::PatientSerializer.call(record))
+      end
+    end
+  end
+end

--- a/app/services/lakeraven/ehr/fhir/operation_outcome.rb
+++ b/app/services/lakeraven/ehr/fhir/operation_outcome.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    module FHIR
+      # Builds a FHIR R4 OperationOutcome resource as a Ruby Hash.
+      #
+      # Used by controllers to render error responses (404 not-found,
+      # 400 required, 403 forbidden) in the FHIR-conventional way
+      # rather than as plain Rails JSON errors. The shape is small
+      # enough that this could live in the controller, but extracting
+      # it makes the controllers easier to read and the failure modes
+      # easier to test in isolation.
+      class OperationOutcome
+        # https://hl7.org/fhir/R4/valueset-issue-severity.html
+        VALID_SEVERITIES = %w[fatal error warning information].freeze
+
+        def self.call(severity:, code:, diagnostics: nil)
+          unless VALID_SEVERITIES.include?(severity)
+            raise ArgumentError, "invalid OperationOutcome severity: #{severity.inspect} (expected one of #{VALID_SEVERITIES})"
+          end
+
+          issue = { severity: severity, code: code }
+          issue[:diagnostics] = diagnostics if diagnostics
+
+          {
+            resourceType: "OperationOutcome",
+            issue: [ issue ]
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/lakeraven/ehr/fhir/patient_serializer.rb
+++ b/app/services/lakeraven/ehr/fhir/patient_serializer.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    module FHIR
+      # Serializes an adapter patient hash to a US Core conformant
+      # FHIR R4 Patient resource.
+      #
+      # The input is the public_view shape returned by Adapters::Base
+      # implementations: opaque patient_identifier, display_name in
+      # "FAMILY,GIVEN" form, date_of_birth, gender, identifiers array.
+      #
+      # The output is a Hash whose keys are symbols matching the FHIR
+      # JSON shape; the controller renders it as application/fhir+json.
+      #
+      # No PHI persistence happens here per ADR 0002 — this serializer
+      # is pure: hash in, hash out.
+      class PatientSerializer
+        US_CORE_PROFILE = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+
+        def self.call(record)
+          new(record).to_h
+        end
+
+        def initialize(record)
+          @record = record
+        end
+
+        def to_h
+          resource = {
+            resourceType: "Patient",
+            id: @record[:patient_identifier],
+            meta: { profile: [ US_CORE_PROFILE ] },
+            name: [ build_name ],
+            gender: gender_value
+          }
+          resource[:birthDate] = format_date(@record[:date_of_birth]) if @record[:date_of_birth]
+          identifiers = build_identifiers
+          resource[:identifier] = identifiers if identifiers.any?
+          resource
+        end
+
+        private
+
+        # Parses VistA-style "FAMILY,GIVEN MIDDLE" into a FHIR HumanName.
+        # Falls back to a single text element when the value doesn't
+        # contain a comma — handles mononyms and adapter-supplied names
+        # we don't recognize the format of.
+        def build_name
+          display = @record[:display_name].to_s
+          return { text: display } unless display.include?(",")
+
+          family, rest = display.split(",", 2)
+          given = rest.to_s.strip.split(/\s+/).reject(&:empty?)
+          { family: family, given: given }
+        end
+
+        # FHIR R4 administrative-gender code set: male | female | other |
+        # unknown. The adapter is expected to supply one of these; if
+        # something else (or nil) comes through, render as "unknown" so
+        # the resource is still valid.
+        def gender_value
+          value = @record[:gender].to_s
+          %w[male female other unknown].include?(value) ? value : "unknown"
+        end
+
+        def format_date(date)
+          date.is_a?(Date) ? date.iso8601 : Date.parse(date.to_s).iso8601
+        end
+
+        def build_identifiers
+          (@record[:identifiers] || []).map do |id|
+            { system: id[:system], value: id[:value] }
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,7 @@
 Lakeraven::EHR::Engine.routes.draw do
+  # FHIR R4 Patient resource. The path uses the resource name (Patient,
+  # not patients) per FHIR convention. The :identifier param is the
+  # opaque pt_-prefixed token from ADR 0004 — never the backend DFN.
+  get "Patient/:identifier", to: "patients#show", as: :patient,
+      constraints: { identifier: %r{[^/]+} }
 end

--- a/features/step_definitions/us_core_patient_api_steps.rb
+++ b/features/step_definitions/us_core_patient_api_steps.rb
@@ -17,10 +17,13 @@ end
 World(FhirRackHelpers)
 
 # Tenancy is established by request headers (X-Tenant-Identifier and
-# X-Facility-Identifier) until SMART auth lands in #52. Cucumber
-# scenarios that already set "the current tenant" via the patient_search
-# steps stash the value in @cucumber_tenant_header so the request can
-# replay it.
+# X-Facility-Identifier) until SMART auth lands in #52. These step
+# definitions read the current tenant/facility back out of
+# Lakeraven::EHR::Current (set by the shared "the current tenant is
+# ..." step from patient_search_steps.rb) and replay them as headers
+# on the rack-test request, so scenarios stay declarative and don't
+# have to know whether the tenant came from a header, a SMART launch,
+# or anywhere else.
 
 Given('patient {string} has identifier system {string} and value {string}') do |display_name, system, value|
   tenant = Lakeraven::EHR::Current.tenant_identifier

--- a/features/step_definitions/us_core_patient_api_steps.rb
+++ b/features/step_definitions/us_core_patient_api_steps.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "rack/test"
+require "json"
+
+# Cucumber Rack::Test wiring — minimal test client against the dummy
+# app so feature scenarios can issue real HTTP requests through the
+# engine routes without spinning up a Capybara browser.
+module FhirRackHelpers
+  include Rack::Test::Methods
+
+  def app
+    Rails.application
+  end
+end
+
+World(FhirRackHelpers)
+
+# Tenancy is established by request headers (X-Tenant-Identifier and
+# X-Facility-Identifier) until SMART auth lands in #52. Cucumber
+# scenarios that already set "the current tenant" via the patient_search
+# steps stash the value in @cucumber_tenant_header so the request can
+# replay it.
+
+Given('patient {string} has identifier system {string} and value {string}') do |display_name, system, value|
+  tenant = Lakeraven::EHR::Current.tenant_identifier
+  patients = Lakeraven::EHR.adapter.search_patients(tenant_identifier: tenant, name: display_name)
+  raise "no patient with display_name #{display_name}" if patients.empty?
+
+  identifier = patients.first[:patient_identifier]
+  Lakeraven::EHR.adapter.attach_patient_identifier(
+    tenant_identifier: tenant,
+    patient_identifier: identifier,
+    system: system,
+    value: value
+  )
+end
+
+Given("a patient {string} exists in tenant {string}") do |display_name, other_tenant|
+  Lakeraven::EHR.adapter.seed_patient(
+    tenant_identifier: other_tenant,
+    facility_identifier: "fac_main",
+    display_name: display_name,
+    date_of_birth: Date.new(1990, 1, 1),
+    gender: "male"
+  )
+  @other_tenant_identifier = Lakeraven::EHR.adapter.search_patients(
+    tenant_identifier: other_tenant, name: display_name
+  ).first[:patient_identifier]
+end
+
+Given("the request omits the tenant header") do
+  @omit_tenant_header = true
+end
+
+When("I GET the FHIR Patient with identifier of {string}") do |display_name|
+  tenant = Lakeraven::EHR::Current.tenant_identifier
+  patient = Lakeraven::EHR.adapter.search_patients(tenant_identifier: tenant, name: display_name).first
+  raise "no patient with display_name #{display_name}" unless patient
+
+  do_get_patient(patient[:patient_identifier])
+end
+
+When("I GET the FHIR Patient with identifier {string}") do |raw_identifier|
+  do_get_patient(raw_identifier)
+end
+
+When("I GET the FHIR Patient with the tnt_other identifier of {string}") do |_display_name|
+  # Send request scoped to tnt_test (background) but ask for tnt_other's patient
+  do_get_patient(@other_tenant_identifier)
+end
+
+Then("the response status is {int}") do |status|
+  assert_equal status, last_response.status, "body: #{last_response.body[0..500]}"
+end
+
+Then("the response Content-Type is {string}") do |content_type|
+  assert_equal content_type, last_response.content_type.split(";").first
+end
+
+Then("the response body is a FHIR Patient resource") do
+  assert_equal "Patient", parsed_body["resourceType"]
+end
+
+Then("the resource id matches the requested identifier") do
+  assert_equal @last_requested_identifier, parsed_body["id"]
+end
+
+Then("the resource meta.profile includes {string}") do |profile|
+  assert_includes parsed_body.dig("meta", "profile") || [], profile
+end
+
+Then("the resource name has family {string}") do |family|
+  assert_equal family, parsed_body["name"]&.first&.[]("family")
+end
+
+Then("the resource name has given {string}") do |given|
+  assert_includes parsed_body["name"]&.first&.[]("given") || [], given
+end
+
+Then("the resource gender is {string}") do |gender|
+  assert_equal gender, parsed_body["gender"]
+end
+
+Then("the resource birthDate is {string}") do |birth_date|
+  assert_equal birth_date, parsed_body["birthDate"]
+end
+
+Then("the resource identifier includes a value of {string} with system {string}") do |value, system|
+  identifiers = parsed_body["identifier"] || []
+  match = identifiers.find { |id| id["system"] == system && id["value"] == value }
+  assert match, "expected identifier { system: #{system}, value: #{value} } not found in #{identifiers.inspect}"
+end
+
+Then('the response body is a FHIR OperationOutcome with severity {string} and code {string}') do |severity, code|
+  assert_equal "OperationOutcome", parsed_body["resourceType"]
+  issue = parsed_body["issue"]&.first
+  refute_nil issue
+  assert_equal severity, issue["severity"]
+  assert_equal code, issue["code"]
+end
+
+# -- helpers ----------------------------------------------------------------
+
+def do_get_patient(identifier)
+  @last_requested_identifier = identifier
+  headers = {}
+  headers["X-Tenant-Identifier"]   = Lakeraven::EHR::Current.tenant_identifier unless @omit_tenant_header
+  headers["X-Facility-Identifier"] = Lakeraven::EHR::Current.facility_identifier if Lakeraven::EHR::Current.facility_identifier
+  rack_env = headers.transform_keys { |k| "HTTP_#{k.upcase.tr('-', '_')}" }
+  get "/lakeraven-ehr/Patient/#{identifier}", {}, rack_env
+end
+
+def parsed_body
+  @parsed_body ||= JSON.parse(last_response.body)
+end
+
+Before do
+  @parsed_body = nil
+  @omit_tenant_header = false
+  @last_requested_identifier = nil
+  @other_tenant_identifier = nil
+end

--- a/features/us_core_patient_api.feature
+++ b/features/us_core_patient_api.feature
@@ -1,0 +1,60 @@
+Feature: US Core Patient API
+  As a SMART-on-FHIR client
+  I need a FHIR R4 Patient read endpoint conforming to US Core
+  So that I can interoperate with EHRs per ONC § 170.315(g)(10)(i)
+
+  This feature lays down the FHIR HTTP layer pattern that every
+  subsequent resource type will reuse: routes mounted under the
+  engine, controllers that read tenant context from request headers,
+  serializers that emit US Core conformant JSON, and OperationOutcome
+  responses for error cases.
+
+  Background:
+    Given the EHR adapter is the in-memory mock
+    And the current tenant is "tnt_test"
+    And the current facility is "fac_main"
+    And the following patients are registered at facility "fac_main":
+      | display_name | date_of_birth | gender |
+      | DOE,JOHN     | 1980-01-15    | male   |
+      | SMITH,JANE   | 1975-06-20    | female |
+    And patient "DOE,JOHN" has identifier system "http://hl7.org/fhir/sid/us-ssn" and value "111-11-1111"
+
+  Scenario: GET Patient by opaque identifier returns a US Core Patient resource
+    When I GET the FHIR Patient with identifier of "DOE,JOHN"
+    Then the response status is 200
+    And the response Content-Type is "application/fhir+json"
+    And the response body is a FHIR Patient resource
+    And the resource id matches the requested identifier
+    And the resource meta.profile includes "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+
+  Scenario: Patient resource exposes name as FHIR HumanName
+    When I GET the FHIR Patient with identifier of "DOE,JOHN"
+    Then the response status is 200
+    And the resource name has family "DOE"
+    And the resource name has given "JOHN"
+
+  Scenario: Patient resource exposes gender and birthDate
+    When I GET the FHIR Patient with identifier of "DOE,JOHN"
+    Then the resource gender is "male"
+    And the resource birthDate is "1980-01-15"
+
+  Scenario: Patient resource includes seeded FHIR Identifiers
+    When I GET the FHIR Patient with identifier of "DOE,JOHN"
+    Then the resource identifier includes a value of "111-11-1111" with system "http://hl7.org/fhir/sid/us-ssn"
+
+  Scenario: Unknown patient identifier returns 404 OperationOutcome
+    When I GET the FHIR Patient with identifier "pt_does_not_exist"
+    Then the response status is 404
+    And the response Content-Type is "application/fhir+json"
+    And the response body is a FHIR OperationOutcome with severity "error" and code "not-found"
+
+  Scenario: Cross-tenant lookup returns 404 OperationOutcome
+    Given a patient "OTHER,PERSON" exists in tenant "tnt_other"
+    When I GET the FHIR Patient with the tnt_other identifier of "OTHER,PERSON"
+    Then the response status is 404
+
+  Scenario: Missing tenant context returns 400 OperationOutcome
+    Given the request omits the tenant header
+    When I GET the FHIR Patient with identifier of "DOE,JOHN"
+    Then the response status is 400
+    And the response body is a FHIR OperationOutcome with severity "error" and code "required"

--- a/lib/lakeraven/ehr/adapters/mock_adapter.rb
+++ b/lib/lakeraven/ehr/adapters/mock_adapter.rb
@@ -62,6 +62,16 @@ module Lakeraven
           row ? public_view(row) : nil
         end
 
+        # Test helper — appends a FHIR-shaped identifier to an existing
+        # patient. Lets test setups attach SSN, MRN, tribal ID, etc. after
+        # the patient has been seeded, so the seed call doesn't have to
+        # know about every identifier shape upfront.
+        def attach_patient_identifier(tenant_identifier:, patient_identifier:, system:, value:)
+          row = @patients[tenant_identifier].find { |r| r[:patient_identifier] == patient_identifier }
+          raise ArgumentError, "no patient with identifier #{patient_identifier} in tenant #{tenant_identifier}" unless row
+          row[:identifiers] = (row[:identifiers] || []) + [ { system: system, value: value } ]
+        end
+
         # -- practitioners ----------------------------------------------------
 
         # Test helper — adds a practitioner to the in-memory store. Mints

--- a/lib/lakeraven/ehr/engine.rb
+++ b/lib/lakeraven/ehr/engine.rb
@@ -14,6 +14,18 @@ module Lakeraven
           loader.inflector.inflect("ehr" => "EHR", "fhir" => "FHIR")
         end
       end
+
+      # Register EHR and FHIR as ActiveSupport acronyms too. Rails
+      # routing uses its own inflector (not Zeitwerk's) to constantize
+      # controller paths — without this, routes pointing at
+      # "lakeraven/ehr/patients#show" would try to resolve
+      # Lakeraven::Ehr::PatientsController and fail.
+      initializer "lakeraven_ehr.acronyms", before: :set_autoload_paths do
+        ActiveSupport::Inflector.inflections(:en) do |inflect|
+          inflect.acronym "EHR"
+          inflect.acronym "FHIR"
+        end
+      end
     end
   end
 end

--- a/lib/lakeraven/ehr/engine.rb
+++ b/lib/lakeraven/ehr/engine.rb
@@ -6,12 +6,12 @@ module Lakeraven
       isolate_namespace Lakeraven::EHR
 
       # Tell Zeitwerk that "ehr" should resolve to the EHR constant
-      # (capitalized acronym) rather than the default "Ehr". Without
-      # this, autoloading from app/services/lakeraven/ehr/foo.rb would
-      # try to find Lakeraven::Ehr::Foo and not find Lakeraven::EHR::Foo.
+      # (capitalized acronym) rather than the default "Ehr". "fhir"
+      # gets the same treatment so app/.../fhir/patient_serializer.rb
+      # resolves to Lakeraven::EHR::FHIR::PatientSerializer.
       config.before_initialize do
         Rails.autoloaders.each do |loader|
-          loader.inflector.inflect("ehr" => "EHR")
+          loader.inflector.inflect("ehr" => "EHR", "fhir" => "FHIR")
         end
       end
     end

--- a/test/lakeraven/ehr/adapters/mock_adapter_test.rb
+++ b/test/lakeraven/ehr/adapters/mock_adapter_test.rb
@@ -163,6 +163,21 @@ class Lakeraven::EHR::Adapters::MockAdapterTest < ActiveSupport::TestCase
     assert_equal [], result[:identifiers]
   end
 
+  test "attach_patient_identifier appends an identifier to an existing patient" do
+    identifier = @adapter.seed_patient(
+      tenant_identifier: "tnt_test", facility_identifier: "fac_main",
+      display_name: "DOE,JOHN", date_of_birth: Date.new(1980, 1, 15), gender: "male"
+    )
+    @adapter.attach_patient_identifier(
+      tenant_identifier: "tnt_test",
+      patient_identifier: identifier,
+      system: "http://hl7.org/fhir/sid/us-ssn",
+      value: "111-11-1111"
+    )
+    result = @adapter.find_patient(tenant_identifier: "tnt_test", patient_identifier: identifier)
+    assert_equal [ { system: "http://hl7.org/fhir/sid/us-ssn", value: "111-11-1111" } ], result[:identifiers]
+  end
+
   # -- practitioners ----------------------------------------------------------
 
   test "starts with no practitioners" do

--- a/test/lakeraven/ehr/fhir/operation_outcome_test.rb
+++ b/test/lakeraven/ehr/fhir/operation_outcome_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::FHIR::OperationOutcomeTest < ActiveSupport::TestCase
+  Outcome = Lakeraven::EHR::FHIR::OperationOutcome
+
+  test "renders resourceType OperationOutcome" do
+    result = Outcome.call(severity: "error", code: "not-found", diagnostics: "x")
+    assert_equal "OperationOutcome", result[:resourceType]
+  end
+
+  test "issue carries severity, code, and diagnostics" do
+    result = Outcome.call(severity: "error", code: "not-found", diagnostics: "Patient not found")
+    issue = result[:issue].first
+    assert_equal "error", issue[:severity]
+    assert_equal "not-found", issue[:code]
+    assert_equal "Patient not found", issue[:diagnostics]
+  end
+
+  test "diagnostics is omitted when nil" do
+    result = Outcome.call(severity: "error", code: "required")
+    refute result[:issue].first.key?(:diagnostics)
+  end
+
+  test "raises ArgumentError for an unknown severity" do
+    assert_raises(ArgumentError) { Outcome.call(severity: "panic", code: "not-found") }
+  end
+
+  test "accepts the four valid severities: fatal, error, warning, information" do
+    %w[fatal error warning information].each do |severity|
+      result = Outcome.call(severity: severity, code: "informational")
+      assert_equal severity, result[:issue].first[:severity]
+    end
+  end
+end

--- a/test/lakeraven/ehr/fhir/patient_serializer_test.rb
+++ b/test/lakeraven/ehr/fhir/patient_serializer_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::FHIR::PatientSerializerTest < ActiveSupport::TestCase
+  Serializer = Lakeraven::EHR::FHIR::PatientSerializer
+  US_CORE_PROFILE = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+
+  def base_record
+    {
+      patient_identifier: "pt_01H8X",
+      facility_identifier: "fac_main",
+      display_name: "DOE,JOHN",
+      date_of_birth: Date.new(1980, 1, 15),
+      gender: "male",
+      identifiers: []
+    }
+  end
+
+  test "renders resourceType Patient" do
+    assert_equal "Patient", Serializer.call(base_record)[:resourceType]
+  end
+
+  test "id is the opaque patient_identifier" do
+    assert_equal "pt_01H8X", Serializer.call(base_record)[:id]
+  end
+
+  test "meta.profile includes the US Core Patient profile" do
+    assert_includes Serializer.call(base_record).dig(:meta, :profile), US_CORE_PROFILE
+  end
+
+  test "name parses display_name into family + given" do
+    name = Serializer.call(base_record)[:name].first
+    assert_equal "DOE", name[:family]
+    assert_equal [ "JOHN" ], name[:given]
+  end
+
+  test "name handles a display_name with multiple given names" do
+    record = base_record.merge(display_name: "DOE,JOHN MIDDLE")
+    name = Serializer.call(record)[:name].first
+    assert_equal "DOE", name[:family]
+    assert_equal [ "JOHN", "MIDDLE" ], name[:given]
+  end
+
+  test "name falls back to a single text element when display_name has no comma" do
+    record = base_record.merge(display_name: "MONONYM")
+    name = Serializer.call(record)[:name].first
+    assert_equal "MONONYM", name[:text]
+    assert_nil name[:family]
+  end
+
+  test "gender passes through unchanged" do
+    assert_equal "male", Serializer.call(base_record)[:gender]
+  end
+
+  test "gender returns 'unknown' for nil" do
+    assert_equal "unknown", Serializer.call(base_record.merge(gender: nil))[:gender]
+  end
+
+  test "birthDate is ISO8601 yyyy-mm-dd" do
+    assert_equal "1980-01-15", Serializer.call(base_record)[:birthDate]
+  end
+
+  test "birthDate is omitted when date_of_birth is nil" do
+    refute Serializer.call(base_record.merge(date_of_birth: nil)).key?(:birthDate)
+  end
+
+  test "identifiers round-trip with system and value" do
+    record = base_record.merge(identifiers: [
+      { system: "http://hl7.org/fhir/sid/us-ssn", value: "111-11-1111" }
+    ])
+    identifiers = Serializer.call(record)[:identifier]
+    assert_equal "http://hl7.org/fhir/sid/us-ssn", identifiers.first[:system]
+    assert_equal "111-11-1111", identifiers.first[:value]
+  end
+
+  test "identifier key is omitted when no identifiers seeded" do
+    refute Serializer.call(base_record).key?(:identifier)
+  end
+end

--- a/test/lakeraven/ehr/fhir/patient_serializer_test.rb
+++ b/test/lakeraven/ehr/fhir/patient_serializer_test.rb
@@ -57,6 +57,15 @@ class Lakeraven::EHR::FHIR::PatientSerializerTest < ActiveSupport::TestCase
     assert_equal "unknown", Serializer.call(base_record.merge(gender: nil))[:gender]
   end
 
+  test "gender returns 'unknown' for an invalid value outside the FHIR code set" do
+    # Locks in the normalization behavior — anything that isn't one of
+    # male/female/other/unknown becomes "unknown" so the rendered
+    # resource always validates against the administrative-gender
+    # value set, regardless of what casing or junk the adapter passes.
+    assert_equal "unknown", Serializer.call(base_record.merge(gender: "MALE"))[:gender]
+    assert_equal "unknown", Serializer.call(base_record.merge(gender: "bogus"))[:gender]
+  end
+
   test "birthDate is ISO8601 yyyy-mm-dd" do
     assert_equal "1980-01-15", Serializer.call(base_record)[:birthDate]
   end

--- a/test/lakeraven/ehr/patients_controller_test.rb
+++ b/test/lakeraven/ehr/patients_controller_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::PatientsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    Lakeraven::EHR.reset_configuration!
+    Lakeraven::EHR::Current.reset!
+    @adapter = Lakeraven::EHR::Adapters::MockAdapter.new
+    Lakeraven::EHR.configure { |c| c.adapter = @adapter }
+
+    @patient_identifier = @adapter.seed_patient(
+      tenant_identifier: "tnt_test",
+      facility_identifier: "fac_main",
+      display_name: "DOE,JOHN",
+      date_of_birth: Date.new(1980, 1, 15),
+      gender: "male"
+    )
+    @adapter.attach_patient_identifier(
+      tenant_identifier: "tnt_test",
+      patient_identifier: @patient_identifier,
+      system: "http://hl7.org/fhir/sid/us-ssn",
+      value: "111-11-1111"
+    )
+  end
+
+  teardown do
+    Lakeraven::EHR.reset_configuration!
+    Lakeraven::EHR::Current.reset!
+  end
+
+  def tenant_headers(facility: "fac_main")
+    headers = { "X-Tenant-Identifier" => "tnt_test" }
+    headers["X-Facility-Identifier"] = facility if facility
+    headers
+  end
+
+  test "GET /Patient/:identifier returns 200 with the FHIR Patient resource" do
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: tenant_headers
+    assert_response :ok
+    assert_equal "application/fhir+json", response.media_type
+    body = JSON.parse(response.body)
+    assert_equal "Patient", body["resourceType"]
+    assert_equal @patient_identifier, body["id"]
+  end
+
+  test "response includes US Core profile in meta.profile" do
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: tenant_headers
+    body = JSON.parse(response.body)
+    assert_includes body.dig("meta", "profile"), "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+  end
+
+  test "response includes name family + given parsed from display_name" do
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: tenant_headers
+    body = JSON.parse(response.body)
+    assert_equal "DOE", body["name"].first["family"]
+    assert_includes body["name"].first["given"], "JOHN"
+  end
+
+  test "response includes the SSN identifier round-tripped" do
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: tenant_headers
+    body = JSON.parse(response.body)
+    assert_includes body["identifier"], { "system" => "http://hl7.org/fhir/sid/us-ssn", "value" => "111-11-1111" }
+  end
+
+  test "unknown patient identifier returns 404 OperationOutcome" do
+    get "/lakeraven-ehr/Patient/pt_does_not_exist", headers: tenant_headers
+    assert_response :not_found
+    assert_equal "application/fhir+json", response.media_type
+    body = JSON.parse(response.body)
+    assert_equal "OperationOutcome", body["resourceType"]
+    issue = body["issue"].first
+    assert_equal "error", issue["severity"]
+    assert_equal "not-found", issue["code"]
+  end
+
+  test "cross-tenant identifier returns 404 (not 403) so the tenant boundary doesn't leak existence" do
+    other_identifier = @adapter.seed_patient(
+      tenant_identifier: "tnt_other", facility_identifier: "fac_main",
+      display_name: "OTHER,PERSON", date_of_birth: Date.new(1990, 1, 1), gender: "male"
+    )
+    get "/lakeraven-ehr/Patient/#{other_identifier}", headers: tenant_headers
+    assert_response :not_found
+  end
+
+  test "missing tenant header returns 400 OperationOutcome with code required" do
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}"
+    assert_response :bad_request
+    assert_equal "application/fhir+json", response.media_type
+    body = JSON.parse(response.body)
+    assert_equal "OperationOutcome", body["resourceType"]
+    issue = body["issue"].first
+    assert_equal "error", issue["severity"]
+    assert_equal "required", issue["code"]
+  end
+
+  test "Current is reset after the request so state doesn't leak across actions" do
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: tenant_headers
+    assert_response :ok
+    # ActiveSupport::CurrentAttributes auto-resets after the request
+    # via the railtie integration. We just verify it didn't carry over.
+    assert_nil Lakeraven::EHR::Current.tenant_identifier
+  end
+end

--- a/test/lakeraven/ehr/patients_controller_test.rb
+++ b/test/lakeraven/ehr/patients_controller_test.rb
@@ -94,6 +94,17 @@ class Lakeraven::EHR::PatientsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "required", issue["code"]
   end
 
+  test "whitespace-only tenant header is treated the same as missing" do
+    # Regression for Copilot review on PR #3: a header of " " was
+    # slipping past the blank check and producing a 404 downstream
+    # instead of the intended 400 required OperationOutcome.
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: { "X-Tenant-Identifier" => "   " }
+    assert_response :bad_request
+    body = JSON.parse(response.body)
+    assert_equal "OperationOutcome", body["resourceType"]
+    assert_equal "required", body["issue"].first["code"]
+  end
+
   test "Current is reset after the request so state doesn't leak across actions" do
     get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: tenant_headers
     assert_response :ok


### PR DESCRIPTION
## Summary

Third feature port. First slice with a real HTTP layer — `GET /lakeraven-ehr/Patient/:identifier` returns a US Core conformant FHIR R4 Patient resource as `application/fhir+json`. Lays down the controller / serializer / OperationOutcome pattern that every subsequent FHIR resource will reuse.

Closes #51.

## What's in this PR

Five TDD/BDD commits, each red→green:

1. **`MockAdapter#attach_patient_identifier`** test helper — lets test setups attach FHIR Identifier shapes (SSN, MRN, etc.) to existing patients after seeding
2. **`FHIR::PatientSerializer`** — pure PORO that turns the adapter `public_view` hash into a US Core conformant FHIR R4 Patient. Parses `"FAMILY,GIVEN MIDDLE"` into `HumanName`, validates gender against the FHIR code set, omits empty optional elements, never leaks DFN
3. **`FHIR::OperationOutcome`** — small builder for error response bodies with severity validation against the FHIR R4 issue-severity value set
4. **`PatientsController` + `ApplicationController` + routes** — engine-mounted `GET Patient/:identifier`, tenant header → `Current` reading, `application/fhir+json` rendering, 404 OperationOutcome on miss, 400 OperationOutcome on missing tenant header. Also registers `EHR` and `FHIR` as `ActiveSupport::Inflector` acronyms (Rails routing uses its own inflector, separate from Zeitwerk's, and was constantizing `Lakeraven::Ehr::PatientsController` before this was added)
5. **`us_core_patient_api` Cucumber feature** — 7 scenarios covering happy path, name parsing, gender + birthDate, identifier round-trip, 404 on unknown, 404 on cross-tenant (not 403), 400 on missing tenant header

## Architecture references

- **ADR 0001** — engine scope: HTTP layer is in scope, case management still isn't
- **ADR 0002** — PHI tokenization: serializer is pure (hash in, hash out), no PHI persisted
- **ADR 0003** — fail-loud tenancy: missing `X-Tenant-Identifier` header returns FHIR 400, not Rails 500
- **ADR 0004** — `id` vs `identifier`: the `Patient.id` field in the response is the opaque `pt_*` token, never the DFN

## Cross-tenant 404 vs 403

Cross-tenant lookups return **404, not 403**. The reason: a 403 would tell a curious caller "this token exists somewhere, just not for you" — the tenant boundary would leak existence by virtue of the status code differing. 404 makes "doesn't exist for me" indistinguishable from "doesn't exist at all". Tested explicitly.

## Test plan

- [x] `bundle exec rake test` — 95 runs, 165 assertions, 0 failures
- [x] `bundle exec cucumber` — 24 scenarios, 195 steps, all passed (7 patient + 10 provider + 7 us_core)
- [x] `bundle exec rubocop` — 38 files, no offenses
- [ ] CI green on GitHub Actions

## Notes

- The legacy `us_core_patient_api` feature in `rpms_redux` exercised SMART Bearer tokens. SMART auth is feature #52 (`fhir_smart_authentication`); for #51 the engine reads tenant from headers as a stand-in. The header path stays usable for non-SMART hosts and unit tests after #52 lands.
- US Core extensions for race, ethnicity, and birthsex are not in this PR. They land when the adapter contract grows the corresponding fields — see `docs/features.md` "after v0.1" section.
- No `GET /Patient` index/Bundle endpoint yet. The opaque-id read covers the read use case; search-by-FHIR-params is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)