### PR TITLE
SMART on FHIR authentication: discovery + Doorkeeper + Bearer concern

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,12 @@ gem "puma"
 gem "pg"
 gem "propshaft"
 
+# SMART on FHIR / OAuth 2.0 provider — handles the authorization
+# code flow, PKCE, refresh tokens, and token introspection. The
+# engine wraps Doorkeeper with a SMART configuration endpoint and
+# its own scope vocabulary; Doorkeeper handles the OAuth 2.0 mechanics.
+gem "doorkeeper", "~> 5.9"
+
 group :development, :test do
   gem "rubocop-rails-omakase", require: false
   gem "cucumber-rails", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
     cucumber-tag-expressions (8.1.0)
     date (3.5.1)
     diff-lcs (1.6.2)
+    doorkeeper (5.9.0)
+      railties (>= 5)
     drb (2.2.3)
     erb (6.0.2)
     erubi (1.13.1)
@@ -347,6 +349,7 @@ PLATFORMS
 
 DEPENDENCIES
   cucumber-rails
+  doorkeeper (~> 5.9)
   lakeraven-ehr!
   pg
   propshaft

--- a/app/controllers/concerns/lakeraven/ehr/smart_authentication.rb
+++ b/app/controllers/concerns/lakeraven/ehr/smart_authentication.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # Bearer-token authentication and SMART scope authorization for
+    # FHIR controllers.
+    #
+    # Usage:
+    #
+    #   class Lakeraven::EHR::PatientsController < ApplicationController
+    #     include Lakeraven::EHR::SmartAuthentication
+    #     before_action :authenticate_smart_token!
+    #     before_action -> { authorize_scope!("patient/Patient.read") }, only: :show
+    #   end
+    #
+    # All error responses are FHIR OperationOutcome resources rendered
+    # as application/fhir+json. Reuses Lakeraven::EHR::FHIR::OperationOutcome
+    # so the wire format is consistent with the rest of the engine.
+    #
+    # Reference: http://hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html
+    module SmartAuthentication
+      extend ActiveSupport::Concern
+
+      FHIR_CONTENT_TYPE = "application/fhir+json"
+
+      included do
+        attr_reader :current_token
+      end
+
+      # Validate the Authorization: Bearer <token> header. Renders a
+      # 401 OperationOutcome with code "login" if the token is missing,
+      # malformed, expired, or revoked.
+      def authenticate_smart_token!
+        token_value = extract_bearer_token
+        if token_value.nil? || token_value.empty?
+          return render_login_error("No Bearer token provided")
+        end
+
+        @current_token = Doorkeeper::AccessToken.by_token(token_value)
+        if @current_token.nil? || @current_token.revoked?
+          return render_login_error("Invalid or revoked token")
+        end
+        if @current_token.expired?
+          return render_login_error("Token has expired")
+        end
+        true
+      end
+
+      # Authorize the current token against a SMART scope string. Returns
+      # true on success; renders a 403 OperationOutcome with code
+      # "forbidden" and returns false on failure.
+      def authorize_scope!(required_scope)
+        return true if current_token&.scopes&.include?(required_scope)
+        return true if wildcard_scope_matches?(required_scope)
+
+        render_forbidden("Insufficient scope: #{required_scope}")
+        false
+      end
+
+      private
+
+      def extract_bearer_token
+        header = request.headers["Authorization"].to_s
+        match = header.match(/\ABearer\s+(.+)\z/i)
+        match && match[1]
+      end
+
+      # Match a required scope like "patient/Patient.read" against the
+      # token's scope list, allowing wildcards in either the resource
+      # or the permission slot, plus system/* fallthrough.
+      def wildcard_scope_matches?(required_scope)
+        return false unless current_token
+
+        match = required_scope.match(%r{\A(patient|user|system)/([^.]+)\.(.+)\z})
+        return false unless match
+
+        context, _resource, perm = match.captures
+        wildcards = [
+          "#{context}/*.#{perm}",
+          "#{context}/*.read",
+          "#{context}/*.*",
+          "system/*.read",
+          "system/*.*"
+        ]
+        wildcards.any? { |w| current_token.scopes.include?(w) }
+      end
+
+      def render_login_error(message)
+        outcome = FHIR::OperationOutcome.call(
+          severity: "error",
+          code: "login",
+          diagnostics: message
+        )
+        render json: outcome, status: :unauthorized, content_type: FHIR_CONTENT_TYPE
+      end
+
+      def render_forbidden(message)
+        outcome = FHIR::OperationOutcome.call(
+          severity: "error",
+          code: "forbidden",
+          diagnostics: message
+        )
+        render json: outcome, status: :forbidden, content_type: FHIR_CONTENT_TYPE
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/lakeraven/ehr/smart_authentication.rb
+++ b/app/controllers/concerns/lakeraven/ehr/smart_authentication.rb
@@ -66,8 +66,14 @@ module Lakeraven
       end
 
       # Match a required scope like "patient/Patient.read" against the
-      # token's scope list, allowing wildcards in either the resource
-      # or the permission slot, plus system/* fallthrough.
+      # token's scope list, allowing wildcards in the resource slot
+      # plus a same-or-broader system/* fallthrough.
+      #
+      # Only candidates whose permission is the SAME as the requested
+      # permission (or `*`, meaning all permissions) are considered.
+      # A required `patient/Patient.write` is NOT satisfied by a
+      # `patient/*.read` token — that would let read scopes silently
+      # grant write access.
       def wildcard_scope_matches?(required_scope)
         return false unless current_token
 
@@ -77,9 +83,8 @@ module Lakeraven
         context, _resource, perm = match.captures
         wildcards = [
           "#{context}/*.#{perm}",
-          "#{context}/*.read",
           "#{context}/*.*",
-          "system/*.read",
+          "system/*.#{perm}",
           "system/*.*"
         ]
         wildcards.any? { |w| current_token.scopes.include?(w) }

--- a/app/controllers/lakeraven/ehr/smart/configuration_controller.rb
+++ b/app/controllers/lakeraven/ehr/smart/configuration_controller.rb
@@ -24,7 +24,6 @@ module Lakeraven
             authorization_endpoint: oauth_authorization_url,
             token_endpoint: oauth_token_url,
             revocation_endpoint: oauth_revoke_url,
-            introspection_endpoint: oauth_introspect_url,
 
             capabilities: capabilities,
             scopes_supported: scopes_supported,
@@ -43,10 +42,15 @@ module Lakeraven
         # SMART App Launch capabilities advertised by this server.
         # See http://hl7.org/fhir/smart-app-launch/conformance.html#capabilities
         def capabilities
+          # client-public is intentionally NOT advertised: the
+          # Doorkeeper schema requires oauth_applications.secret to
+          # be non-null, so public clients (which have no secret)
+          # can't actually be registered. Adding public-client
+          # support is a follow-up that needs a schema change and
+          # PKCE-only client validation.
           %w[
             launch-ehr
             launch-standalone
-            client-public
             client-confidential-symmetric
             context-passthrough-banner
             context-passthrough-style
@@ -105,10 +109,6 @@ module Lakeraven
 
         def oauth_revoke_url
           Lakeraven::EHR::Engine.routes.url_helpers.oauth_revoke_url(host: request.host_with_port, protocol: request.protocol)
-        end
-
-        def oauth_introspect_url
-          Lakeraven::EHR::Engine.routes.url_helpers.oauth_introspect_url(host: request.host_with_port, protocol: request.protocol)
         end
       end
     end

--- a/app/controllers/lakeraven/ehr/smart/configuration_controller.rb
+++ b/app/controllers/lakeraven/ehr/smart/configuration_controller.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    module SMART
+      # SMART App Launch discovery document, served at:
+      #
+      #   GET /.well-known/smart-configuration
+      #
+      # Reference: http://hl7.org/fhir/smart-app-launch/conformance.html
+      #
+      # The discovery doc is unauthenticated by design — clients hit it
+      # before they have a token to find out where the OAuth endpoints
+      # live.
+      class ConfigurationController < ::ActionController::API
+        def show
+          render json: smart_configuration, content_type: "application/json"
+        end
+
+        private
+
+        def smart_configuration
+          {
+            authorization_endpoint: oauth_authorization_url,
+            token_endpoint: oauth_token_url,
+            revocation_endpoint: oauth_revoke_url,
+            introspection_endpoint: oauth_introspect_url,
+
+            capabilities: capabilities,
+            scopes_supported: scopes_supported,
+
+            grant_types_supported: %w[authorization_code client_credentials refresh_token],
+            response_types_supported: %w[code],
+            code_challenge_methods_supported: %w[S256],
+
+            token_endpoint_auth_methods_supported: %w[
+              client_secret_basic
+              client_secret_post
+            ]
+          }
+        end
+
+        # SMART App Launch capabilities advertised by this server.
+        # See http://hl7.org/fhir/smart-app-launch/conformance.html#capabilities
+        def capabilities
+          %w[
+            launch-ehr
+            launch-standalone
+            client-public
+            client-confidential-symmetric
+            context-passthrough-banner
+            context-passthrough-style
+            context-ehr-patient
+            context-ehr-encounter
+            context-standalone-patient
+            context-standalone-encounter
+            permission-offline
+            permission-patient
+            permission-user
+            permission-v2
+          ]
+        end
+
+        # Mirrors the optional_scopes registered with Doorkeeper in
+        # config/initializers/doorkeeper.rb. Both lists must move
+        # together — clients use this list to know what they can
+        # request, Doorkeeper uses its list to validate.
+        def scopes_supported
+          [
+            "openid",
+            "profile",
+            "fhirUser",
+            "launch",
+            "launch/patient",
+            "launch/practitioner",
+            "offline_access",
+            "patient/Patient.read",
+            "patient/Practitioner.read",
+            "patient/Observation.read",
+            "patient/Condition.read",
+            "patient/Encounter.read",
+            "patient/AllergyIntolerance.read",
+            "patient/Immunization.read",
+            "patient/Medication.read",
+            "patient/MedicationRequest.read",
+            "user/Patient.read",
+            "user/Practitioner.read",
+            "user/Patient.write",
+            "system/Patient.read",
+            "system/Practitioner.read",
+            "system/*.read"
+          ]
+        end
+
+        # OAuth endpoint URL helpers — these are mounted by Doorkeeper
+        # under the engine, so use the engine's URL helpers to
+        # construct absolute URLs.
+        def oauth_authorization_url
+          Lakeraven::EHR::Engine.routes.url_helpers.oauth_authorization_url(host: request.host_with_port, protocol: request.protocol)
+        end
+
+        def oauth_token_url
+          Lakeraven::EHR::Engine.routes.url_helpers.oauth_token_url(host: request.host_with_port, protocol: request.protocol)
+        end
+
+        def oauth_revoke_url
+          Lakeraven::EHR::Engine.routes.url_helpers.oauth_revoke_url(host: request.host_with_port, protocol: request.protocol)
+        end
+
+        def oauth_introspect_url
+          Lakeraven::EHR::Engine.routes.url_helpers.oauth_introspect_url(host: request.host_with_port, protocol: request.protocol)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/lakeraven/ehr/smart/configuration_controller.rb
+++ b/app/controllers/lakeraven/ehr/smart/configuration_controller.rb
@@ -2,7 +2,7 @@
 
 module Lakeraven
   module EHR
-    module SMART
+    module Smart
       # SMART App Launch discovery document, served at:
       #
       #   GET /.well-known/smart-configuration

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -15,10 +15,13 @@ Doorkeeper.configure do
   # other ActionController::Base helpers.
   api_only
 
-  # The base controller every Doorkeeper route inherits from. Use the
-  # engine's ApplicationController so the FHIR error helpers and tenant
-  # context are available to OAuth flows that go through the engine.
-  base_controller "Lakeraven::EHR::ApplicationController"
+  # Doorkeeper's controllers must NOT inherit from
+  # Lakeraven::EHR::ApplicationController. That class enforces
+  # require_tenant_context! and returns a 400 OperationOutcome when
+  # X-Tenant-Identifier is missing — but SMART OAuth endpoints
+  # (authorize, token, revoke) are explicitly callable before a
+  # client has tenant context. Doorkeeper falls back to its own
+  # ActionController::API base when base_controller isn't set.
 
   # Resource owner / admin authentication: delegate to host-app hooks.
   # The host-supplied lambda receives `self` (the controller instance)

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Doorkeeper configuration for SMART on FHIR.
+#
+# Most behavior is host-app territory (which user model to authenticate
+# against, what an admin looks like, where unauthenticated users are
+# redirected). Those hooks are exposed via Lakeraven::EHR.configure so
+# the engine can ship a working default that the host can override.
+
+Doorkeeper.configure do
+  orm :active_record
+
+  # The engine's ApplicationController is ActionController::API. Tell
+  # Doorkeeper not to expect protect_from_forgery / view rendering /
+  # other ActionController::Base helpers.
+  api_only
+
+  # The base controller every Doorkeeper route inherits from. Use the
+  # engine's ApplicationController so the FHIR error helpers and tenant
+  # context are available to OAuth flows that go through the engine.
+  base_controller "Lakeraven::EHR::ApplicationController"
+
+  # Resource owner / admin authentication: delegate to host-app hooks.
+  # The host-supplied lambda receives `self` (the controller instance)
+  # so it can read session, headers, and call redirect_to.
+  resource_owner_authenticator do
+    Lakeraven::EHR.configuration.resource_owner_authenticator.call(self)
+  end
+
+  admin_authenticator do
+    Lakeraven::EHR.configuration.admin_authenticator.call(self)
+  end
+
+  # Token lifetimes per the SMART App Launch spec.
+  authorization_code_expires_in 10.minutes
+  access_token_expires_in 1.hour
+
+  # Refresh tokens are required for any client that wants offline_access.
+  use_refresh_token
+
+  # Hash tokens and client secrets at rest. Doorkeeper still validates
+  # the plaintext value against the hash on every request; the database
+  # never sees the secret.
+  hash_token_secrets
+  hash_application_secrets
+
+  # PKCE is enforced as soon as a client passes code_challenge. The
+  # SMART discovery doc advertises S256 as the only method we support
+  # so callers know to send PKCE.
+
+  # SSL is required in production for redirect URIs (per SMART spec).
+  # Allow non-SSL in dev/test so the test suite doesn't need a TLS
+  # endpoint.
+  force_ssl_in_redirect_uri false if Rails.env.development? || Rails.env.test?
+
+  grant_flows %w[authorization_code client_credentials refresh_token]
+
+  # SMART on FHIR scopes — see http://hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html
+  default_scopes :openid
+  optional_scopes(
+    :profile,
+    :fhirUser,
+    :launch,
+    :"launch/patient",
+    :"launch/practitioner",
+    :offline_access,
+    :"patient/Patient.read",
+    :"patient/Practitioner.read",
+    :"patient/Observation.read",
+    :"patient/Condition.read",
+    :"patient/Encounter.read",
+    :"patient/AllergyIntolerance.read",
+    :"patient/Immunization.read",
+    :"patient/Medication.read",
+    :"patient/MedicationRequest.read",
+    :"user/Patient.read",
+    :"user/Practitioner.read",
+    :"user/Patient.write",
+    :"system/Patient.read",
+    :"system/Practitioner.read",
+    :"system/*.read"
+  )
+
+  # First-party clients (those registered without scopes or marked
+  # confidential) skip the consent screen.
+  skip_authorization do |_resource_owner, client|
+    client.application.scopes.blank? || client.application.confidential?
+  end
+end

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -1,0 +1,155 @@
+en:
+  activerecord:
+    attributes:
+      doorkeeper/application:
+        name: 'Name'
+        redirect_uri: 'Redirect URI'
+    errors:
+      models:
+        doorkeeper/application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              invalid_uri: 'must be a valid URI.'
+              unspecified_scheme: 'must specify a scheme.'
+              relative_uri: 'must be an absolute URI.'
+              secured_uri: 'must be an HTTPS/SSL URI.'
+              forbidden_uri: 'is forbidden by the server.'
+            scopes:
+              not_match_configured: "doesn't match configured on the server."
+
+  doorkeeper:
+    applications:
+      confirmations:
+        destroy: 'Are you sure?'
+      buttons:
+        edit: 'Edit'
+        destroy: 'Destroy'
+        submit: 'Submit'
+        cancel: 'Cancel'
+        authorize: 'Authorize'
+      form:
+        error: 'Whoops! Check your form for possible errors'
+      help:
+        confidential: 'Application will be used where the client secret can be kept confidential. Native mobile apps and Single Page Apps are considered non-confidential.'
+        redirect_uri: 'Use one line per URI'
+        blank_redirect_uri: "Leave it blank if you configured your provider to use Client Credentials, Resource Owner Password Credentials or any other grant type that doesn't require redirect URI."
+        scopes: 'Separate scopes with spaces. Leave blank to use the default scopes.'
+      edit:
+        title: 'Edit application'
+      index:
+        title: 'Your applications'
+        new: 'New Application'
+        name: 'Name'
+        callback_url: 'Callback URL'
+        confidential: 'Confidential?'
+        actions: 'Actions'
+        confidentiality:
+          'yes': 'Yes'
+          'no': 'No'
+      new:
+        title: 'New Application'
+      show:
+        title: 'Application: %{name}'
+        application_id: 'UID'
+        secret: 'Secret'
+        secret_hashed: 'Secret hashed'
+        scopes: 'Scopes'
+        confidential: 'Confidential'
+        callback_urls: 'Callback urls'
+        actions: 'Actions'
+        not_defined: 'Not defined'
+
+    authorizations:
+      buttons:
+        authorize: 'Authorize'
+        deny: 'Deny'
+      error:
+        title: 'An error has occurred'
+      new:
+        title: 'Authorization required'
+        prompt: 'Authorize %{client_name} to use your account?'
+        able_to: 'This application will be able to'
+      show:
+        title: 'Authorization code'
+      form_post:
+        title: 'Submit this form'
+
+    authorized_applications:
+      confirmations:
+        revoke: 'Are you sure?'
+      buttons:
+        revoke: 'Revoke'
+      index:
+        title: 'Your authorized applications'
+        application: 'Application'
+        created_at: 'Created At'
+        date_format: '%Y-%m-%d %H:%M:%S'
+
+    pre_authorization:
+      status: 'Pre-authorization'
+
+    errors:
+      messages:
+        # Common error messages
+        invalid_request:
+          unknown: 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.'
+          missing_param: 'Missing required parameter: %{value}.'
+          request_not_authorized: 'Request need to be authorized. Required parameter for authorizing request is missing or invalid.'
+          invalid_code_challenge: 'Code challenge is required.'
+        invalid_redirect_uri: "The requested redirect uri is malformed or doesn't match client redirect URI."
+        unauthorized_client: 'The client is not authorized to perform this request using this method.'
+        access_denied: 'The resource owner or authorization server denied the request.'
+        invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
+        invalid_code_challenge_method:
+          zero: 'The authorization server does not support PKCE as there are no accepted code_challenge_method values.'
+          one: 'The code_challenge_method must be %{challenge_methods}.'
+          other: 'The code_challenge_method must be one of %{challenge_methods}.'
+        server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'
+        temporarily_unavailable: 'The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server.'
+
+        # Configuration error messages
+        credential_flow_not_configured: 'Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured.'
+        resource_owner_authenticator_not_configured: 'Resource Owner find failed due to Doorkeeper.configure.resource_owner_authenticator being unconfigured.'
+        admin_authenticator_not_configured: 'Access to admin panel is forbidden due to Doorkeeper.configure.admin_authenticator being unconfigured.'
+
+        # Access grant errors
+        unsupported_response_type: 'The authorization server does not support this response type.'
+        unsupported_response_mode: 'The authorization server does not support this response mode.'
+
+        # Access token errors
+        invalid_client: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'
+        invalid_grant: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
+        unsupported_grant_type: 'The authorization grant type is not supported by the authorization server.'
+
+        invalid_token:
+          revoked: "The access token was revoked"
+          expired: "The access token expired"
+          unknown: "The access token is invalid"
+        revoke:
+          unauthorized: "You are not authorized to revoke this token"
+
+        forbidden_token:
+          missing_scope: 'Access to this resource requires scope "%{oauth_scopes}".'
+
+    flash:
+      applications:
+        create:
+          notice: 'Application created.'
+        destroy:
+          notice: 'Application deleted.'
+        update:
+          notice: 'Application updated.'
+      authorized_applications:
+        destroy:
+          notice: 'Application revoked.'
+
+    layouts:
+      admin:
+        title: 'Doorkeeper'
+        nav:
+          oauth2_provider: 'OAuth2 Provider'
+          applications: 'Applications'
+          home: 'Home'
+      application:
+        title: 'OAuth authorization required'

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -95,7 +95,7 @@ en:
         invalid_request:
           unknown: 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.'
           missing_param: 'Missing required parameter: %{value}.'
-          request_not_authorized: 'Request need to be authorized. Required parameter for authorizing request is missing or invalid.'
+          request_not_authorized: 'Request needs to be authorized. Required parameter for authorizing request is missing or invalid.'
           invalid_code_challenge: 'Code challenge is required.'
         invalid_redirect_uri: "The requested redirect uri is malformed or doesn't match client redirect URI."
         unauthorized_client: 'The client is not authorized to perform this request using this method.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Lakeraven::EHR::Engine.routes.draw do
+  use_doorkeeper
   # FHIR R4 Patient resource. The path uses the resource name (Patient,
   # not patients) per FHIR convention. The :identifier param is the
   # opaque pt_-prefixed token from ADR 0004 — never the backend DFN.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,15 @@
 Lakeraven::EHR::Engine.routes.draw do
-  use_doorkeeper
+  # Doorkeeper's controllers live at top-level (Doorkeeper::TokensController etc.).
+  # An isolated engine would otherwise try to resolve them under
+  # Lakeraven::EHR::Doorkeeper::*; the leading-slash absolute paths
+  # tell Rails routing to constantize them at the top level.
+  use_doorkeeper do
+    controllers tokens: "/doorkeeper/tokens",
+                authorizations: "/doorkeeper/authorizations",
+                applications: "/doorkeeper/applications",
+                authorized_applications: "/doorkeeper/authorized_applications",
+                token_info: "/doorkeeper/token_info"
+  end
 
   # SMART App Launch discovery — clients hit this before they have a token.
   get ".well-known/smart-configuration", to: "smart/configuration#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Lakeraven::EHR::Engine.routes.draw do
   use_doorkeeper
+
+  # SMART App Launch discovery — clients hit this before they have a token.
+  get ".well-known/smart-configuration", to: "smart/configuration#show"
+
   # FHIR R4 Patient resource. The path uses the resource name (Patient,
   # not patients) per FHIR convention. The :identifier param is the
   # opaque pt_-prefixed token from ADR 0004 — never the backend DFN.

--- a/db/migrate/20260407234907_create_doorkeeper_tables.rb
+++ b/db/migrate/20260407234907_create_doorkeeper_tables.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+class CreateDoorkeeperTables < ActiveRecord::Migration[8.1]
+  def change
+    create_table :oauth_applications do |t|
+      t.string  :name,    null: false
+      t.string  :uid,     null: false
+      # Remove `null: false` or use conditional constraint if you are planning to use public clients.
+      t.string  :secret,  null: false
+
+      # Remove `null: false` if you are planning to use grant flows
+      # that doesn't require redirect URI to be used during authorization
+      # like Client Credentials flow or Resource Owner Password.
+      t.text    :redirect_uri, null: false
+      t.string  :scopes,       null: false, default: ''
+      t.boolean :confidential, null: false, default: true
+      t.timestamps             null: false
+    end
+
+    add_index :oauth_applications, :uid, unique: true
+
+    create_table :oauth_access_grants do |t|
+      t.references :resource_owner,  null: false
+      t.references :application,     null: false
+      t.string   :token,             null: false
+      t.integer  :expires_in,        null: false
+      t.text     :redirect_uri,      null: false
+      t.string   :scopes,            null: false, default: ''
+      t.datetime :created_at,        null: false
+      t.datetime :revoked_at
+    end
+
+    add_index :oauth_access_grants, :token, unique: true
+    add_foreign_key(
+      :oauth_access_grants,
+      :oauth_applications,
+      column: :application_id
+    )
+
+    create_table :oauth_access_tokens do |t|
+      t.references :resource_owner, index: true
+
+      # Remove `null: false` if you are planning to use Password
+      # Credentials Grant flow that doesn't require an application.
+      t.references :application,    null: false
+
+      # If you use a custom token generator you may need to change this column
+      # from string to text, so that it accepts tokens larger than 255
+      # characters. More info on custom token generators in:
+      # https://github.com/doorkeeper-gem/doorkeeper/tree/v3.0.0.rc1#custom-access-token-generator
+      #
+      # t.text :token, null: false
+      t.string :token, null: false
+
+      t.string   :refresh_token
+      t.integer  :expires_in
+      t.string   :scopes
+      t.datetime :created_at, null: false
+      t.datetime :revoked_at
+
+      # The authorization server MAY issue a new refresh token, in which case
+      # *the client MUST discard the old refresh token* and replace it with the
+      # new refresh token. The authorization server MAY revoke the old
+      # refresh token after issuing a new refresh token to the client.
+      # @see https://datatracker.ietf.org/doc/html/rfc6749#section-6
+      #
+      # Doorkeeper implementation: if there is a `previous_refresh_token` column,
+      # refresh tokens will be revoked after a related access token is used.
+      # If there is no `previous_refresh_token` column, previous tokens are
+      # revoked as soon as a new access token is created.
+      #
+      # Comment out this line if you want refresh tokens to be instantly
+      # revoked after use.
+      t.string   :previous_refresh_token, null: false, default: ""
+    end
+
+    add_index :oauth_access_tokens, :token, unique: true
+
+    # See https://github.com/doorkeeper-gem/doorkeeper/issues/1592
+    if ActiveRecord::Base.connection.adapter_name == "SQLServer"
+      execute <<~SQL.squish
+        CREATE UNIQUE NONCLUSTERED INDEX index_oauth_access_tokens_on_refresh_token ON oauth_access_tokens(refresh_token)
+        WHERE refresh_token IS NOT NULL
+      SQL
+    else
+      add_index :oauth_access_tokens, :refresh_token, unique: true
+    end
+
+    add_foreign_key(
+      :oauth_access_tokens,
+      :oauth_applications,
+      column: :application_id
+    )
+
+    # Uncomment below to ensure a valid reference to the resource owner's table
+    # add_foreign_key :oauth_access_grants, <model>, column: :resource_owner_id
+    # add_foreign_key :oauth_access_tokens, <model>, column: :resource_owner_id
+  end
+end

--- a/features/fhir_smart_authentication.feature
+++ b/features/fhir_smart_authentication.feature
@@ -1,0 +1,35 @@
+Feature: SMART on FHIR authentication
+  As a SMART-on-FHIR client
+  I need a discovery endpoint and OAuth 2.0 token machinery
+  So that I can obtain a Bearer token to call FHIR endpoints
+
+  This feature lands the OAuth 2.0 surface — discovery, authorize,
+  token, revoke, introspect — and the Bearer-token validation
+  concern that FHIR controllers will use. Bearer enforcement on
+  /Patient/:identifier itself comes in a focused follow-up so this
+  PR doesn't have to update the existing us_core_patient_api scenarios.
+
+  Scenario: SMART discovery document is publicly accessible
+    When I GET the SMART discovery document
+    Then the response status is 200
+    And the discovery document advertises an authorization_endpoint
+    And the discovery document advertises a token_endpoint
+    And the discovery document lists S256 as a code_challenge_method
+    And the discovery document lists "patient/Patient.read" in scopes_supported
+    And the discovery document lists "launch-standalone" in capabilities
+
+  Scenario: OAuth token endpoint is mounted under the engine
+    When I POST to the OAuth token endpoint with no parameters
+    Then the response status is 400 or 401
+    And the response body mentions an OAuth error
+
+  Scenario: OAuth authorize endpoint is mounted under the engine
+    When I GET the OAuth authorize endpoint with no parameters
+    Then the response is not a 404
+
+  Scenario: A registered confidential client can mint a system token via client_credentials
+    Given a confidential OAuth client is registered with scopes "system/Patient.read"
+    When I POST to the OAuth token endpoint with grant_type "client_credentials" and the client credentials
+    Then the response status is 200
+    And the response body includes an access_token
+    And the response body includes a token_type of "Bearer"

--- a/features/step_definitions/fhir_smart_authentication_steps.rb
+++ b/features/step_definitions/fhir_smart_authentication_steps.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+When("I GET the SMART discovery document") do
+  get "/lakeraven-ehr/.well-known/smart-configuration"
+end
+
+Then("the discovery document advertises an authorization_endpoint") do
+  assert parsed_body["authorization_endpoint"].to_s.include?("/oauth/authorize")
+end
+
+Then("the discovery document advertises a token_endpoint") do
+  assert parsed_body["token_endpoint"].to_s.include?("/oauth/token")
+end
+
+Then("the discovery document lists S256 as a code_challenge_method") do
+  assert_includes parsed_body["code_challenge_methods_supported"], "S256"
+end
+
+Then("the discovery document lists {string} in scopes_supported") do |scope|
+  assert_includes parsed_body["scopes_supported"], scope
+end
+
+Then("the discovery document lists {string} in capabilities") do |capability|
+  assert_includes parsed_body["capabilities"], capability
+end
+
+When("I POST to the OAuth token endpoint with no parameters") do
+  post "/lakeraven-ehr/oauth/token"
+end
+
+Then("the response status is 400 or 401") do
+  assert [ 400, 401 ].include?(last_response.status), "got #{last_response.status}"
+end
+
+Then("the response body mentions an OAuth error") do
+  body = parsed_body
+  assert body.key?("error") || body.key?("error_description"),
+    "expected an OAuth error response, got #{body.inspect}"
+end
+
+When("I GET the OAuth authorize endpoint with no parameters") do
+  get "/lakeraven-ehr/oauth/authorize"
+end
+
+Then("the response is not a 404") do
+  refute_equal 404, last_response.status
+end
+
+Given('a confidential OAuth client is registered with scopes {string}') do |scopes|
+  @oauth_app = Doorkeeper::Application.create!(
+    name: "cucumber test client",
+    redirect_uri: "https://example.test/callback",
+    scopes: scopes,
+    confidential: true
+  )
+  @client_secret = @oauth_app.plaintext_secret || @oauth_app.secret
+end
+
+When('I POST to the OAuth token endpoint with grant_type {string} and the client credentials') do |grant_type|
+  post "/lakeraven-ehr/oauth/token", {
+    grant_type: grant_type,
+    client_id: @oauth_app.uid,
+    client_secret: @client_secret,
+    scope: @oauth_app.scopes.to_s
+  }
+end
+
+Then("the response body includes an access_token") do
+  refute_nil parsed_body["access_token"]
+end
+
+Then('the response body includes a token_type of {string}') do |token_type|
+  assert_equal token_type, parsed_body["token_type"]
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -20,4 +20,11 @@ World(Minitest::Assertions)
 Before do
   Lakeraven::EHR.reset_configuration!
   Lakeraven::EHR::Current.reset!
+
+  # Stub the SMART resource owner authenticator so OAuth scenarios
+  # that touch /oauth/authorize don't trip the default
+  # NotConfiguredError. Real host applications override this with
+  # a real user lookup.
+  Lakeraven::EHR.configuration.resource_owner_authenticator =
+    ->(_controller) { Struct.new(:id).new(1) }
 end

--- a/lib/lakeraven/ehr/configuration.rb
+++ b/lib/lakeraven/ehr/configuration.rb
@@ -13,9 +13,24 @@ module Lakeraven
     # The adapter is the only required setting at boot.
     class Configuration
       attr_accessor :adapter
+      attr_accessor :resource_owner_authenticator
+      attr_accessor :admin_authenticator
 
       def initialize
         @adapter = nil
+        # Default resource owner authenticator: fail loud. The host
+        # application MUST override this with a lambda that returns
+        # the authenticated user (or redirects). Doorkeeper invokes
+        # this on every authorization request, so leaving it
+        # unconfigured surfaces immediately.
+        @resource_owner_authenticator = ->(_controller) {
+          raise NotConfiguredError,
+            "Lakeraven::EHR.configuration.resource_owner_authenticator must be set " \
+            "by the host application before any SMART authorization request"
+        }
+        # Default admin authenticator: deny everything. The host
+        # overrides if it wants to expose the Doorkeeper admin UI.
+        @admin_authenticator = ->(_controller) { false }
       end
     end
 

--- a/lib/lakeraven/ehr/engine.rb
+++ b/lib/lakeraven/ehr/engine.rb
@@ -11,19 +11,20 @@ module Lakeraven
       # resolves to Lakeraven::EHR::FHIR::PatientSerializer.
       config.before_initialize do
         Rails.autoloaders.each do |loader|
-          loader.inflector.inflect("ehr" => "EHR", "fhir" => "FHIR")
+          loader.inflector.inflect("ehr" => "EHR", "fhir" => "FHIR", "smart" => "SMART")
         end
       end
 
-      # Register EHR and FHIR as ActiveSupport acronyms too. Rails
-      # routing uses its own inflector (not Zeitwerk's) to constantize
-      # controller paths — without this, routes pointing at
-      # "lakeraven/ehr/patients#show" would try to resolve
+      # Register EHR, FHIR, and SMART as ActiveSupport acronyms too.
+      # Rails routing uses its own inflector (not Zeitwerk's) to
+      # constantize controller paths — without this, routes pointing
+      # at "lakeraven/ehr/patients#show" would try to resolve
       # Lakeraven::Ehr::PatientsController and fail.
       initializer "lakeraven_ehr.acronyms", before: :set_autoload_paths do
         ActiveSupport::Inflector.inflections(:en) do |inflect|
           inflect.acronym "EHR"
           inflect.acronym "FHIR"
+          inflect.acronym "SMART"
         end
       end
     end

--- a/lib/lakeraven/ehr/engine.rb
+++ b/lib/lakeraven/ehr/engine.rb
@@ -11,20 +11,25 @@ module Lakeraven
       # resolves to Lakeraven::EHR::FHIR::PatientSerializer.
       config.before_initialize do
         Rails.autoloaders.each do |loader|
-          loader.inflector.inflect("ehr" => "EHR", "fhir" => "FHIR", "smart" => "SMART")
+          loader.inflector.inflect("ehr" => "EHR", "fhir" => "FHIR")
         end
       end
 
-      # Register EHR, FHIR, and SMART as ActiveSupport acronyms too.
-      # Rails routing uses its own inflector (not Zeitwerk's) to
-      # constantize controller paths — without this, routes pointing
-      # at "lakeraven/ehr/patients#show" would try to resolve
+      # Register EHR and FHIR as ActiveSupport acronyms too. Rails
+      # routing uses its own inflector (not Zeitwerk's) to constantize
+      # controller paths — without this, routes pointing at
+      # "lakeraven/ehr/patients#show" would try to resolve
       # Lakeraven::Ehr::PatientsController and fail.
+      #
+      # SMART is intentionally NOT registered as an acronym. The wire
+      # name "SMART" appears in URL paths and the discovery doc, but
+      # the Ruby namespace is Lakeraven::EHR::Smart so that idiomatic
+      # Ruby names like SmartAuthentication still resolve via standard
+      # inflection.
       initializer "lakeraven_ehr.acronyms", before: :set_autoload_paths do
         ActiveSupport::Inflector.inflections(:en) do |inflect|
           inflect.acronym "EHR"
           inflect.acronym "FHIR"
-          inflect.acronym "SMART"
         end
       end
     end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,8 +10,52 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 0) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_07_234907) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
+  create_table "oauth_access_grants", force: :cascade do |t|
+    t.bigint "application_id", null: false
+    t.datetime "created_at", null: false
+    t.integer "expires_in", null: false
+    t.text "redirect_uri", null: false
+    t.bigint "resource_owner_id", null: false
+    t.datetime "revoked_at"
+    t.string "scopes", default: "", null: false
+    t.string "token", null: false
+    t.index ["application_id"], name: "index_oauth_access_grants_on_application_id"
+    t.index ["resource_owner_id"], name: "index_oauth_access_grants_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
+  end
+
+  create_table "oauth_access_tokens", force: :cascade do |t|
+    t.bigint "application_id", null: false
+    t.datetime "created_at", null: false
+    t.integer "expires_in"
+    t.string "previous_refresh_token", default: "", null: false
+    t.string "refresh_token"
+    t.bigint "resource_owner_id"
+    t.datetime "revoked_at"
+    t.string "scopes"
+    t.string "token", null: false
+    t.index ["application_id"], name: "index_oauth_access_tokens_on_application_id"
+    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
+    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
+  end
+
+  create_table "oauth_applications", force: :cascade do |t|
+    t.boolean "confidential", default: true, null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.text "redirect_uri", null: false
+    t.string "scopes", default: "", null: false
+    t.string "secret", null: false
+    t.string "uid", null: false
+    t.datetime "updated_at", null: false
+    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
+  end
+
+  add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
 end

--- a/test/lakeraven/ehr/smart/configuration_controller_test.rb
+++ b/test/lakeraven/ehr/smart/configuration_controller_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::SMART::ConfigurationControllerTest < ActionDispatch::IntegrationTest
+  test "GET /.well-known/smart-configuration returns the discovery document" do
+    get "/lakeraven-ehr/.well-known/smart-configuration"
+    assert_response :ok
+    body = JSON.parse(response.body)
+
+    assert_includes body.keys, "authorization_endpoint"
+    assert_includes body.keys, "token_endpoint"
+    assert_includes body.keys, "capabilities"
+    assert_includes body.keys, "scopes_supported"
+    assert_includes body.keys, "grant_types_supported"
+    assert_includes body.keys, "code_challenge_methods_supported"
+  end
+
+  test "advertised endpoint URLs are absolute and point at engine paths" do
+    get "/lakeraven-ehr/.well-known/smart-configuration"
+    body = JSON.parse(response.body)
+
+    assert_match %r{\Ahttps?://[^/]+/lakeraven-ehr/oauth/authorize\z}, body["authorization_endpoint"]
+    assert_match %r{\Ahttps?://[^/]+/lakeraven-ehr/oauth/token\z}, body["token_endpoint"]
+  end
+
+  test "S256 is the only PKCE method advertised" do
+    get "/lakeraven-ehr/.well-known/smart-configuration"
+    body = JSON.parse(response.body)
+    assert_equal [ "S256" ], body["code_challenge_methods_supported"]
+  end
+
+  test "advertises authorization_code, client_credentials, and refresh_token grant types" do
+    get "/lakeraven-ehr/.well-known/smart-configuration"
+    body = JSON.parse(response.body)
+    assert_equal %w[authorization_code client_credentials refresh_token].sort, body["grant_types_supported"].sort
+  end
+
+  test "scopes_supported includes the SMART vocabulary" do
+    get "/lakeraven-ehr/.well-known/smart-configuration"
+    body = JSON.parse(response.body)
+    assert_includes body["scopes_supported"], "openid"
+    assert_includes body["scopes_supported"], "launch"
+    assert_includes body["scopes_supported"], "launch/patient"
+    assert_includes body["scopes_supported"], "patient/Patient.read"
+    assert_includes body["scopes_supported"], "user/Patient.read"
+    assert_includes body["scopes_supported"], "system/Patient.read"
+  end
+
+  test "capabilities include both standalone and EHR launch" do
+    get "/lakeraven-ehr/.well-known/smart-configuration"
+    body = JSON.parse(response.body)
+    assert_includes body["capabilities"], "launch-standalone"
+    assert_includes body["capabilities"], "launch-ehr"
+  end
+
+  test "discovery endpoint is publicly accessible (no Bearer required)" do
+    get "/lakeraven-ehr/.well-known/smart-configuration"
+    assert_response :ok
+  end
+end

--- a/test/lakeraven/ehr/smart/configuration_controller_test.rb
+++ b/test/lakeraven/ehr/smart/configuration_controller_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class Lakeraven::EHR::SMART::ConfigurationControllerTest < ActionDispatch::IntegrationTest
+class Lakeraven::EHR::Smart::ConfigurationControllerTest < ActionDispatch::IntegrationTest
   test "GET /.well-known/smart-configuration returns the discovery document" do
     get "/lakeraven-ehr/.well-known/smart-configuration"
     assert_response :ok

--- a/test/lakeraven/ehr/smart_authentication_test.rb
+++ b/test/lakeraven/ehr/smart_authentication_test.rb
@@ -18,6 +18,11 @@ class SmartAuthTestController < ::ActionController::API
     return unless authorize_scope!("patient/Patient.read")
     render json: { ok: true }
   end
+
+  def patient_write
+    return unless authorize_scope!("patient/Patient.write")
+    render json: { ok: true }
+  end
 end
 
 class Lakeraven::EHR::SmartAuthenticationTest < ActionDispatch::IntegrationTest
@@ -26,6 +31,7 @@ class Lakeraven::EHR::SmartAuthenticationTest < ActionDispatch::IntegrationTest
     Rails.application.routes.draw do
       get "/_smart_auth_test/show", to: "smart_auth_test#show"
       get "/_smart_auth_test/patient_read", to: "smart_auth_test#patient_read"
+      get "/_smart_auth_test/patient_write", to: "smart_auth_test#patient_write"
     end
 
     @client = Doorkeeper::Application.create!(
@@ -130,6 +136,32 @@ class Lakeraven::EHR::SmartAuthenticationTest < ActionDispatch::IntegrationTest
   test "authorize_scope! accepts system/*.read for any patient resource" do
     token = issue_token(scopes: "system/*.read")
     get "/_smart_auth_test/patient_read", headers: bearer(token)
+    assert_response :ok
+  end
+
+  test "patient/*.read does NOT satisfy a write requirement" do
+    # Regression: a read-only wildcard token must not silently pass a
+    # write authorization check.
+    token = issue_token(scopes: "patient/*.read")
+    get "/_smart_auth_test/patient_write", headers: bearer(token)
+    assert_response :forbidden
+  end
+
+  test "system/*.read does NOT satisfy a write requirement" do
+    token = issue_token(scopes: "system/*.read")
+    get "/_smart_auth_test/patient_write", headers: bearer(token)
+    assert_response :forbidden
+  end
+
+  test "patient/*.write satisfies a patient/Patient.write requirement" do
+    token = issue_token(scopes: "patient/*.write")
+    get "/_smart_auth_test/patient_write", headers: bearer(token)
+    assert_response :ok
+  end
+
+  test "patient/*.* satisfies any patient permission" do
+    token = issue_token(scopes: "patient/*.*")
+    get "/_smart_auth_test/patient_write", headers: bearer(token)
     assert_response :ok
   end
 end

--- a/test/lakeraven/ehr/smart_authentication_test.rb
+++ b/test/lakeraven/ehr/smart_authentication_test.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# A throwaway controller used to exercise SmartAuthentication's
+# behavior in isolation. We don't reuse PatientsController because
+# the test would have to set up an adapter and tenant context just
+# to verify Bearer behavior.
+class SmartAuthTestController < ::ActionController::API
+  include Lakeraven::EHR::SmartAuthentication
+  before_action :authenticate_smart_token!
+
+  def show
+    render json: { ok: true, scopes: current_token.scopes.to_s }
+  end
+
+  def patient_read
+    return unless authorize_scope!("patient/Patient.read")
+    render json: { ok: true }
+  end
+end
+
+class Lakeraven::EHR::SmartAuthenticationTest < ActionDispatch::IntegrationTest
+  setup do
+    Rails.application.routes.disable_clear_and_finalize = true
+    Rails.application.routes.draw do
+      get "/_smart_auth_test/show", to: "smart_auth_test#show"
+      get "/_smart_auth_test/patient_read", to: "smart_auth_test#patient_read"
+    end
+
+    @client = Doorkeeper::Application.create!(
+      name: "test client",
+      redirect_uri: "https://example.test/callback",
+      scopes: "openid patient/Patient.read"
+    )
+  end
+
+  teardown do
+    Rails.application.reload_routes!
+    Rails.application.routes.disable_clear_and_finalize = false
+  end
+
+  def issue_token(scopes:)
+    Doorkeeper::AccessToken.create!(
+      application: @client,
+      resource_owner_id: 1,
+      scopes: scopes,
+      expires_in: 3600
+    )
+  end
+
+  def bearer(token)
+    # With hash_token_secrets enabled, the plaintext token is only
+    # available via #plaintext_token immediately after create.
+    plaintext = token.plaintext_token || token.token
+    { "Authorization" => "Bearer #{plaintext}" }
+  end
+
+  test "missing Authorization header returns 401 OperationOutcome with code login" do
+    get "/_smart_auth_test/show"
+    assert_response :unauthorized
+    body = JSON.parse(response.body)
+    assert_equal "OperationOutcome", body["resourceType"]
+    assert_equal "login", body["issue"].first["code"]
+  end
+
+  test "Authorization header without Bearer scheme returns 401" do
+    get "/_smart_auth_test/show", headers: { "Authorization" => "Basic abc" }
+    assert_response :unauthorized
+    body = JSON.parse(response.body)
+    assert_equal "login", body["issue"].first["code"]
+  end
+
+  test "invalid Bearer token returns 401 OperationOutcome with code login" do
+    get "/_smart_auth_test/show", headers: { "Authorization" => "Bearer not-a-real-token" }
+    assert_response :unauthorized
+    body = JSON.parse(response.body)
+    assert_equal "OperationOutcome", body["resourceType"]
+    assert_equal "login", body["issue"].first["code"]
+  end
+
+  test "valid Bearer token grants access" do
+    token = issue_token(scopes: "openid patient/Patient.read")
+    get "/_smart_auth_test/show", headers: bearer(token)
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert_includes body["scopes"], "patient/Patient.read"
+  end
+
+  test "expired token returns 401" do
+    token = Doorkeeper::AccessToken.create!(
+      application: @client,
+      resource_owner_id: 1,
+      scopes: "openid patient/Patient.read",
+      expires_in: 3600,
+      created_at: 2.hours.ago
+    )
+    get "/_smart_auth_test/show", headers: bearer(token)
+    assert_response :unauthorized
+  end
+
+  test "revoked token returns 401" do
+    token = issue_token(scopes: "openid patient/Patient.read")
+    token.revoke
+    get "/_smart_auth_test/show", headers: bearer(token)
+    assert_response :unauthorized
+  end
+
+  test "authorize_scope! grants access when token has the required scope" do
+    token = issue_token(scopes: "patient/Patient.read")
+    get "/_smart_auth_test/patient_read", headers: bearer(token)
+    assert_response :ok
+  end
+
+  test "authorize_scope! returns 403 OperationOutcome forbidden when scope is missing" do
+    token = issue_token(scopes: "openid")
+    get "/_smart_auth_test/patient_read", headers: bearer(token)
+    assert_response :forbidden
+    body = JSON.parse(response.body)
+    assert_equal "OperationOutcome", body["resourceType"]
+    assert_equal "forbidden", body["issue"].first["code"]
+  end
+
+  test "authorize_scope! accepts a wildcard patient/*.read scope" do
+    token = issue_token(scopes: "patient/*.read")
+    get "/_smart_auth_test/patient_read", headers: bearer(token)
+    assert_response :ok
+  end
+
+  test "authorize_scope! accepts system/*.read for any patient resource" do
+    token = issue_token(scopes: "system/*.read")
+    get "/_smart_auth_test/patient_read", headers: bearer(token)
+    assert_response :ok
+  end
+end


### PR DESCRIPTION
## Summary

Lands the OAuth 2.0 surface for SMART on FHIR. Closes #52.

- **Doorkeeper** installed and configured for SMART (PKCE, refresh tokens, SMART scope vocabulary, 10-minute auth code / 1-hour access token lifetimes per spec)
- **`.well-known/smart-configuration`** discovery endpoint advertising endpoints, scopes, capabilities, and S256 PKCE
- **`Lakeraven::EHR::SmartAuthentication`** controller concern with `authenticate_smart_token!` and `authorize_scope!` helpers; reuses the existing `FHIR::OperationOutcome` builder for 401/403 responses

## Deferred to follow-ups

- Bearer enforcement on `PatientsController` — would touch the existing `us_core_patient_api` Cucumber, better as a focused follow-up PR
- Custom `TokensController` with launch context — lands with #53 (`smart_ehr_launch`)
- `doorkeeper-openid_connect` (JWKS, id_token signing)
- Backend services JWT auth

## Architecture notes

- Doorkeeper runs in `api_only` mode since the engine `ApplicationController` is `ActionController::API`
- `resource_owner_authenticator` and `admin_authenticator` delegate to `Lakeraven::EHR.configuration` hooks so the host application owns user authentication; default lambda raises `NotConfiguredError`
- Doorkeeper controllers are mounted with leading-slash absolute paths (`/doorkeeper/tokens` etc.) so they constantize at the top level rather than under the engine namespace
- `Smart` namespace is intentionally camelCase (not the `SMART` acronym) so `SmartAuthentication` resolves via standard inflection; the wire-level "SMART" name is preserved in URLs and the discovery doc

## Test plan

- [x] `bundle exec rake test` — 114 runs, 225 assertions, 0 failures
- [x] `bundle exec cucumber` — 28 scenarios, 212 steps, all passed
- [x] `bundle exec rubocop` — 45 files, no offenses
- [ ] CI green on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)