### PR TITLE
SMART EHR launch: launch context binding + token response patient field

### DIFF
--- a/app/controllers/concerns/lakeraven/ehr/smart_authentication.rb
+++ b/app/controllers/concerns/lakeraven/ehr/smart_authentication.rb
@@ -57,6 +57,38 @@ module Lakeraven
         false
       end
 
+      # Authorize a FHIR resource read by checking the token against
+      # all three SMART contexts (patient/, user/, system/) plus their
+      # wildcards for the requested resource. Any one of:
+      #
+      #   patient/{Resource}.read | patient/*.read | patient/*.*
+      #   user/{Resource}.read    | user/*.read    | user/*.*
+      #   system/{Resource}.read  | system/*.read  | system/*.*
+      #
+      # is sufficient. Renders 403 OperationOutcome with code
+      # "forbidden" if none match.
+      def authorize_resource_read!(resource_type)
+        return true if can_read?(resource_type)
+
+        render_forbidden("Insufficient scope for #{resource_type} read")
+        false
+      end
+
+      # True if the token holds any read scope for the resource (or
+      # the matching wildcard).
+      def can_read?(resource_type)
+        return false unless current_token
+
+        token_scopes = current_token.scopes.to_s.split
+        allowed = %w[patient user system].flat_map do |ctx|
+          [
+            "#{ctx}/#{resource_type}.read", "#{ctx}/#{resource_type}.*",
+            "#{ctx}/*.read", "#{ctx}/*.*"
+          ]
+        end
+        (token_scopes & allowed).any?
+      end
+
       # Enforce patient-context binding: if the current token was
       # issued with a patient/ scope (i.e. it's bound to a specific
       # patient compartment), the requested patient_identifier must

--- a/app/controllers/concerns/lakeraven/ehr/smart_authentication.rb
+++ b/app/controllers/concerns/lakeraven/ehr/smart_authentication.rb
@@ -57,6 +57,45 @@ module Lakeraven
         false
       end
 
+      # Enforce patient-context binding: if the current token was
+      # issued with a patient/ scope (i.e. it's bound to a specific
+      # patient compartment), the requested patient_identifier must
+      # match the one bound to the token.
+      #
+      # user/ and system/ tokens bypass this check because they're
+      # not patient-scoped.
+      #
+      # Returns true on success; renders a 403 OperationOutcome with
+      # code "forbidden" and returns false on failure.
+      def authorize_patient_context!(requested_patient_identifier)
+        return true unless patient_context_token?
+
+        bound_identifier = current_token_patient_identifier
+        if bound_identifier.nil? || bound_identifier.empty?
+          render_forbidden("Patient context required but not bound to token")
+          return false
+        end
+        if bound_identifier != requested_patient_identifier.to_s
+          render_forbidden("Patient context mismatch")
+          return false
+        end
+        true
+      end
+
+      # The opaque patient identifier (pt_*) bound to the current
+      # token via SMART launch context. Stored on the access token's
+      # resource_owner_id when the token was issued with a patient/
+      # scope.
+      def current_token_patient_identifier
+        return nil unless current_token
+        current_token.resource_owner_id.to_s
+      end
+
+      def patient_context_token?
+        return false unless current_token
+        current_token.scopes.to_s.include?("patient/")
+      end
+
       private
 
       def extract_bearer_token

--- a/app/controllers/lakeraven/ehr/application_controller.rb
+++ b/app/controllers/lakeraven/ehr/application_controller.rb
@@ -6,16 +6,17 @@ module Lakeraven
     #
     # Handles two cross-cutting concerns:
     #
-    # 1. **Tenant context.** Reads X-Tenant-Identifier and
-    #    X-Facility-Identifier from request headers and stuffs them
-    #    into Lakeraven::EHR::Current. SMART auth (#52) will replace
-    #    the header source with the SMART launch context once it
-    #    lands; the rest of the engine doesn't need to care which
-    #    flavor populated Current.
+    # 1. **Tenant context.** Calls the host-supplied tenant_resolver
+    #    on every request, populates Lakeraven::EHR::Current with the
+    #    resolved tenant and facility, and renders a 400 OperationOutcome
+    #    when the resolver returns blank. The default resolvers read
+    #    X-Tenant-Identifier / X-Facility-Identifier headers; host
+    #    SaaS apps override these to extract from a subdomain or any
+    #    other URL-bound source.
     #
-    # 2. **FHIR error rendering.** Standardizes 404, 400, and other
-    #    error responses as application/fhir+json OperationOutcome
-    #    resources rather than the Rails default HTML / JSON.
+    # 2. **FHIR error rendering.** Standardizes 400/404/4xx error
+    #    responses as application/fhir+json OperationOutcome resources
+    #    rather than the Rails default HTML / JSON.
     class ApplicationController < ActionController::API
       FHIR_CONTENT_TYPE = "application/fhir+json"
 
@@ -24,21 +25,18 @@ module Lakeraven
       private
 
       def require_tenant_context!
-        # Strip whitespace before the blank check so a header of " " or
-        # "\t" produces the same 400 OperationOutcome as a missing header
-        # rather than slipping through and producing a 404 downstream.
-        tenant = request.headers["X-Tenant-Identifier"].to_s.strip
-        if tenant.empty?
+        tenant = Lakeraven::EHR.configuration.tenant_resolver.call(request)
+        if tenant.nil? || tenant.to_s.strip.empty?
           render_operation_outcome(
             status: :bad_request,
             severity: "error",
             code: "required",
-            diagnostics: "X-Tenant-Identifier header is required"
+            diagnostics: "Tenant context is required"
           )
           return
         end
         Current.tenant_identifier   = tenant
-        Current.facility_identifier = request.headers["X-Facility-Identifier"].to_s.strip.presence
+        Current.facility_identifier = Lakeraven::EHR.configuration.facility_resolver.call(request)
       end
 
       def render_operation_outcome(status:, severity:, code:, diagnostics: nil)

--- a/app/controllers/lakeraven/ehr/patients_controller.rb
+++ b/app/controllers/lakeraven/ehr/patients_controller.rb
@@ -4,9 +4,19 @@ module Lakeraven
   module EHR
     # FHIR R4 Patient resource controller.
     #
-    # Handles GET /Patient/:identifier (read by opaque token).
-    # Search via GET /Patient?... will land in a follow-up.
+    # GET /Patient/:identifier — read by opaque token.
+    #
+    # Auth: requires a Bearer token (per SmartAuthentication) with a
+    # patient/Patient.read, user/Patient.read, or system/Patient.read
+    # scope. For patient-context tokens (patient/ scope), the bound
+    # patient must match the requested identifier.
     class PatientsController < ApplicationController
+      include SmartAuthentication
+
+      before_action :authenticate_smart_token!
+      before_action :require_patient_read_scope!, only: :show
+      before_action :enforce_patient_context!, only: :show
+
       def show
         record = EHR.adapter.find_patient(
           tenant_identifier: Current.tenant_identifier,
@@ -24,6 +34,18 @@ module Lakeraven
         end
 
         render_fhir(FHIR::PatientSerializer.call(record))
+      end
+
+      private
+
+      # Allow any of patient/Patient.read, user/Patient.read,
+      # system/Patient.read, or their wildcards.
+      def require_patient_read_scope!
+        authorize_resource_read!("Patient")
+      end
+
+      def enforce_patient_context!
+        authorize_patient_context!(params[:identifier])
       end
     end
   end

--- a/app/controllers/lakeraven/ehr/smart/tokens_controller.rb
+++ b/app/controllers/lakeraven/ehr/smart/tokens_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    module Smart
+      # Custom OAuth token controller that adds SMART launch context
+      # (patient + encounter) to the token response when a `launch`
+      # parameter is supplied.
+      #
+      # The host application mints a Lakeraven::EHR::LaunchContext via
+      # LaunchContext.mint(...) before redirecting the user-agent to
+      # the SMART app's launch URL. The app then includes the
+      # `launch` parameter on the eventual /oauth/token request, and
+      # this controller resolves it back to the bound patient/encounter
+      # and merges those identifiers into the JSON response per the
+      # SMART App Launch spec.
+      #
+      # Reference: http://hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html
+      class TokensController < ::Doorkeeper::TokensController
+        def create
+          super
+          merge_launch_context!
+        end
+
+        private
+
+        def merge_launch_context!
+          return unless successful_token_response?
+          launch_token = params[:launch]
+          return if launch_token.blank?
+
+          context = LaunchContext.resolve(launch_token)
+          return unless context
+
+          body = parsed_response_body
+          body["patient"] = context.patient_identifier if context.patient_identifier
+          body["encounter"] = context.encounter_identifier if context.encounter_identifier
+          self.response_body = body.to_json
+        end
+
+        def successful_token_response?
+          status = response.respond_to?(:status) ? response.status : self.status
+          status == 200 || status == :ok
+        end
+
+        def parsed_response_body
+          raw = response_body
+          raw = raw.first if raw.is_a?(Array)
+          JSON.parse(raw.to_s)
+        rescue JSON::ParserError
+          {}
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/lakeraven/ehr/smart/tokens_controller.rb
+++ b/app/controllers/lakeraven/ehr/smart/tokens_controller.rb
@@ -36,8 +36,24 @@ module Lakeraven
           tenant_identifier = Lakeraven::EHR.configuration.tenant_resolver.call(request)
           return if tenant_identifier.nil? || tenant_identifier.to_s.empty?
 
-          context = LaunchContext.resolve(launch_token, tenant_identifier: tenant_identifier)
+          # The OAuth client_id binds the launch to a specific SMART
+          # app. A launch minted for app X can't be redeemed by app Y
+          # even with a stolen launch token.
+          client_id = params[:client_id].to_s
+          return if client_id.empty?
+
+          context = LaunchContext.resolve(
+            launch_token,
+            tenant_identifier: tenant_identifier,
+            oauth_application_uid: client_id
+          )
           return unless context
+
+          # Single-use: mark the context consumed before embedding so
+          # a replay (even from the legitimate client) returns the
+          # token without patient context. consume! returns false if
+          # something else already won the race.
+          return unless context.consume!
 
           body = parsed_response_body
           body["patient"] = context.patient_identifier if context.patient_identifier

--- a/app/controllers/lakeraven/ehr/smart/tokens_controller.rb
+++ b/app/controllers/lakeraven/ehr/smart/tokens_controller.rb
@@ -29,7 +29,14 @@ module Lakeraven
           launch_token = params[:launch]
           return if launch_token.blank?
 
-          context = LaunchContext.resolve(launch_token)
+          # Resolve the tenant from the configured resolver (subdomain,
+          # header, or whatever the host app maps). A launch token
+          # bound to tenant A is only redeemable when the request
+          # arrives on tenant A's surface — per ADR 0003.
+          tenant_identifier = Lakeraven::EHR.configuration.tenant_resolver.call(request)
+          return if tenant_identifier.nil? || tenant_identifier.to_s.empty?
+
+          context = LaunchContext.resolve(launch_token, tenant_identifier: tenant_identifier)
           return unless context
 
           body = parsed_response_body

--- a/app/models/lakeraven/ehr/launch_context.rb
+++ b/app/models/lakeraven/ehr/launch_context.rb
@@ -79,12 +79,23 @@ module Lakeraven
       end
 
       # Mark this context as consumed. Returns true if this call
-      # actually flipped the bit (single-use guarantee), false if the
-      # context was already consumed by an earlier resolve.
+      # actually flipped the bit (single-use guarantee), false if a
+      # parallel request beat us to it.
+      #
+      # The check is atomic: a single SQL UPDATE with a
+      # `consumed_at IS NULL` predicate. Two concurrent redemptions
+      # of the same launch token will see exactly one rows-affected
+      # count of 1; the other gets 0 and returns false.
       def consume!
-        return false if consumed_at.present?
-        update!(consumed_at: Time.current)
-        true
+        rows = self.class
+          .where(id: id, consumed_at: nil)
+          .update_all(consumed_at: Time.current)
+        if rows == 1
+          reload
+          true
+        else
+          false
+        end
       end
 
       def expired?

--- a/app/models/lakeraven/ehr/launch_context.rb
+++ b/app/models/lakeraven/ehr/launch_context.rb
@@ -47,10 +47,15 @@ module Lakeraven
         )
       end
 
-      # Resolve a launch token to its context, or nil if missing/expired.
-      def self.resolve(launch_token)
-        return nil if launch_token.nil? || launch_token.empty?
-        active.find_by(launch_token: launch_token)
+      # Resolve a launch token to its context, or nil if missing,
+      # expired, or bound to a different tenant. Per ADR 0003 the
+      # caller MUST supply a tenant_identifier so a launch token
+      # minted by tenant A can't be replayed inside tenant B's OAuth
+      # flow to leak A's patient context.
+      def self.resolve(launch_token, tenant_identifier:)
+        return nil if launch_token.nil? || launch_token.to_s.empty?
+        return nil if tenant_identifier.nil? || tenant_identifier.to_s.empty?
+        active.find_by(launch_token: launch_token, tenant_identifier: tenant_identifier)
       end
 
       def expired?

--- a/app/models/lakeraven/ehr/launch_context.rb
+++ b/app/models/lakeraven/ehr/launch_context.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+module Lakeraven
+  module EHR
+    # Persistent SMART EHR launch context.
+    #
+    # When the host application initiates an EHR launch, it mints a
+    # LaunchContext that binds a patient (and optionally an encounter)
+    # to an opaque launch token. The token is then passed through the
+    # OAuth authorize → token round-trip and read by the custom
+    # tokens controller, which embeds the patient identifier into the
+    # token response per the SMART App Launch spec.
+    #
+    # Reference: http://hl7.org/fhir/smart-app-launch/app-launch.html
+    class LaunchContext < ApplicationRecord
+      # Default lifetime — long enough for the launch to complete the
+      # OAuth dance, short enough that an abandoned launch doesn't
+      # leave a stale binding lying around.
+      DEFAULT_TTL = 10.minutes
+
+      validates :launch_token, presence: true, uniqueness: true
+      validates :patient_identifier, presence: true
+      validates :tenant_identifier, presence: true
+      validates :expires_at, presence: true
+
+      scope :active, -> { where("expires_at > ?", Time.current) }
+
+      # Mint a new launch context. Returns the persisted record so the
+      # caller can read its launch_token to embed in a redirect URL.
+      #
+      #   ctx = Lakeraven::EHR::LaunchContext.mint(
+      #     tenant_identifier: "tnt_test",
+      #     patient_identifier: "pt_01H...",
+      #     facility_identifier: "fac_main"
+      #   )
+      #   redirect_to "https://app.example.com/launch?launch=#{ctx.launch_token}&iss=..."
+      def self.mint(tenant_identifier:, patient_identifier:, facility_identifier: nil, encounter_identifier: nil, ttl: DEFAULT_TTL)
+        create!(
+          launch_token: generate_launch_token,
+          tenant_identifier: tenant_identifier,
+          patient_identifier: patient_identifier,
+          facility_identifier: facility_identifier,
+          encounter_identifier: encounter_identifier,
+          expires_at: Time.current + ttl
+        )
+      end
+
+      # Resolve a launch token to its context, or nil if missing/expired.
+      def self.resolve(launch_token)
+        return nil if launch_token.nil? || launch_token.empty?
+        active.find_by(launch_token: launch_token)
+      end
+
+      def expired?
+        expires_at <= Time.current
+      end
+
+      def self.generate_launch_token
+        # 32 hex chars of randomness — sufficient entropy that an
+        # attacker can't guess valid tokens within their TTL window.
+        "lc_#{SecureRandom.hex(16)}"
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/launch_context.rb
+++ b/app/models/lakeraven/ehr/launch_context.rb
@@ -23,23 +23,31 @@ module Lakeraven
       validates :launch_token, presence: true, uniqueness: true
       validates :patient_identifier, presence: true
       validates :tenant_identifier, presence: true
+      validates :oauth_application_uid, presence: true
       validates :expires_at, presence: true
 
-      scope :active, -> { where("expires_at > ?", Time.current) }
+      scope :active, -> { where("expires_at > ?", Time.current).where(consumed_at: nil) }
 
       # Mint a new launch context. Returns the persisted record so the
       # caller can read its launch_token to embed in a redirect URL.
       #
       #   ctx = Lakeraven::EHR::LaunchContext.mint(
       #     tenant_identifier: "tnt_test",
+      #     oauth_application_uid: doorkeeper_app.uid,
       #     patient_identifier: "pt_01H...",
       #     facility_identifier: "fac_main"
       #   )
       #   redirect_to "https://app.example.com/launch?launch=#{ctx.launch_token}&iss=..."
-      def self.mint(tenant_identifier:, patient_identifier:, facility_identifier: nil, encounter_identifier: nil, ttl: DEFAULT_TTL)
+      #
+      # oauth_application_uid binds the launch token to a specific
+      # SMART app — only requests authenticated as that client_id can
+      # redeem the token. Without this, a leaked launch could be
+      # replayed by any other registered client.
+      def self.mint(tenant_identifier:, oauth_application_uid:, patient_identifier:, facility_identifier: nil, encounter_identifier: nil, ttl: DEFAULT_TTL)
         create!(
           launch_token: generate_launch_token,
           tenant_identifier: tenant_identifier,
+          oauth_application_uid: oauth_application_uid,
           patient_identifier: patient_identifier,
           facility_identifier: facility_identifier,
           encounter_identifier: encounter_identifier,
@@ -47,15 +55,36 @@ module Lakeraven
         )
       end
 
-      # Resolve a launch token to its context, or nil if missing,
-      # expired, or bound to a different tenant. Per ADR 0003 the
-      # caller MUST supply a tenant_identifier so a launch token
-      # minted by tenant A can't be replayed inside tenant B's OAuth
-      # flow to leak A's patient context.
-      def self.resolve(launch_token, tenant_identifier:)
+      # Resolve a launch token, or nil if missing, expired, already
+      # consumed, bound to a different tenant, or bound to a different
+      # OAuth client.
+      #
+      # Per ADR 0003 the caller MUST supply tenant_identifier — a
+      # launch token minted by tenant A can't be replayed inside
+      # tenant B's OAuth flow.
+      #
+      # Per the launch-token-binding finding on PR #5, the caller MUST
+      # also supply oauth_application_uid (the client_id from the
+      # token request) — a launch token minted for app X can't be
+      # redeemed by app Y.
+      def self.resolve(launch_token, tenant_identifier:, oauth_application_uid:)
         return nil if launch_token.nil? || launch_token.to_s.empty?
         return nil if tenant_identifier.nil? || tenant_identifier.to_s.empty?
-        active.find_by(launch_token: launch_token, tenant_identifier: tenant_identifier)
+        return nil if oauth_application_uid.nil? || oauth_application_uid.to_s.empty?
+        active.find_by(
+          launch_token: launch_token,
+          tenant_identifier: tenant_identifier,
+          oauth_application_uid: oauth_application_uid
+        )
+      end
+
+      # Mark this context as consumed. Returns true if this call
+      # actually flipped the bit (single-use guarantee), false if the
+      # context was already consumed by an earlier resolve.
+      def consume!
+        return false if consumed_at.present?
+        update!(consumed_at: Time.current)
+        true
       end
 
       def expired?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,10 @@ Lakeraven::EHR::Engine.routes.draw do
   # Lakeraven::EHR::Doorkeeper::*; the leading-slash absolute paths
   # tell Rails routing to constantize them at the top level.
   use_doorkeeper do
-    controllers tokens: "/doorkeeper/tokens",
+    # Tokens endpoint uses the engine's custom Smart::TokensController
+    # so SMART launch context (patient + encounter) can be embedded in
+    # the token response.
+    controllers tokens: "smart/tokens",
                 authorizations: "/doorkeeper/authorizations",
                 applications: "/doorkeeper/applications",
                 authorized_applications: "/doorkeeper/authorized_applications",

--- a/db/migrate/20260408000318_create_lakeraven_ehr_launch_contexts.rb
+++ b/db/migrate/20260408000318_create_lakeraven_ehr_launch_contexts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateLakeravenEHRLaunchContexts < ActiveRecord::Migration[8.1]
   def change
     create_table :lakeraven_ehr_launch_contexts do |t|

--- a/db/migrate/20260408000318_create_lakeraven_ehr_launch_contexts.rb
+++ b/db/migrate/20260408000318_create_lakeraven_ehr_launch_contexts.rb
@@ -1,0 +1,17 @@
+class CreateLakeravenEHRLaunchContexts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :lakeraven_ehr_launch_contexts do |t|
+      t.string :launch_token, null: false
+      t.string :patient_identifier, null: false
+      t.string :tenant_identifier, null: false
+      t.string :facility_identifier
+      t.string :encounter_identifier
+      t.datetime :expires_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :lakeraven_ehr_launch_contexts, :launch_token, unique: true
+    add_index :lakeraven_ehr_launch_contexts, :tenant_identifier
+  end
+end

--- a/db/migrate/20260408062502_harden_lakeraven_ehr_launch_contexts.rb
+++ b/db/migrate/20260408062502_harden_lakeraven_ehr_launch_contexts.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class HardenLakeravenEHRLaunchContexts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :lakeraven_ehr_launch_contexts, :oauth_application_uid, :string, null: false, default: ""
+    add_column :lakeraven_ehr_launch_contexts, :consumed_at, :datetime
+
+    # Drop the default after the column is created so future inserts
+    # must specify the OAuth client. The empty-string default exists
+    # only to satisfy the not-null constraint at add_column time on
+    # any existing rows.
+    change_column_default :lakeraven_ehr_launch_contexts, :oauth_application_uid, from: "", to: nil
+
+    add_index :lakeraven_ehr_launch_contexts, :oauth_application_uid
+    add_index :lakeraven_ehr_launch_contexts, :expires_at
+  end
+end

--- a/db/migrate/20260408062502_harden_lakeraven_ehr_launch_contexts.rb
+++ b/db/migrate/20260408062502_harden_lakeraven_ehr_launch_contexts.rb
@@ -5,10 +5,18 @@ class HardenLakeravenEHRLaunchContexts < ActiveRecord::Migration[8.1]
     add_column :lakeraven_ehr_launch_contexts, :oauth_application_uid, :string, null: false, default: ""
     add_column :lakeraven_ehr_launch_contexts, :consumed_at, :datetime
 
-    # Drop the default after the column is created so future inserts
-    # must specify the OAuth client. The empty-string default exists
-    # only to satisfy the not-null constraint at add_column time on
-    # any existing rows.
+    # Defensively delete any pre-hardening rows that carry the
+    # empty-string default. These rows have no OAuth client binding
+    # and can never resolve under the new resolve(... oauth_application_uid:)
+    # contract, so they're dead weight in the table regardless.
+    reversible do |dir|
+      dir.up do
+        execute "DELETE FROM lakeraven_ehr_launch_contexts WHERE oauth_application_uid = ''"
+      end
+    end
+
+    # Drop the default now that the column is populated. Future
+    # inserts must specify the OAuth client explicitly.
     change_column_default :lakeraven_ehr_launch_contexts, :oauth_application_uid, from: "", to: nil
 
     add_index :lakeraven_ehr_launch_contexts, :oauth_application_uid

--- a/db/migrate/20260408063454_change_oauth_access_tokens_resource_owner_id_to_string.rb
+++ b/db/migrate/20260408063454_change_oauth_access_tokens_resource_owner_id_to_string.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# SMART on FHIR uses opaque pt_*-prefixed identifiers for the patient
+# bound to a token. Doorkeeper's default oauth_access_tokens table
+# stores resource_owner_id as a bigint (via t.references), which coerces
+# any non-numeric string to 0. Change the column to a string so the
+# patient identifier round-trips through token issuance + lookup.
+#
+# Same change applies to oauth_access_grants since the authorization
+# code flow also threads patient context.
+class ChangeOauthAccessTokensResourceOwnerIdToString < ActiveRecord::Migration[8.1]
+  def up
+    remove_index :oauth_access_tokens, :resource_owner_id if index_exists?(:oauth_access_tokens, :resource_owner_id)
+    change_column :oauth_access_tokens, :resource_owner_id, :string
+    add_index :oauth_access_tokens, :resource_owner_id
+
+    remove_index :oauth_access_grants, :resource_owner_id if index_exists?(:oauth_access_grants, :resource_owner_id)
+    change_column :oauth_access_grants, :resource_owner_id, :string
+    add_index :oauth_access_grants, :resource_owner_id
+  end
+
+  def down
+    remove_index :oauth_access_tokens, :resource_owner_id if index_exists?(:oauth_access_tokens, :resource_owner_id)
+    change_column :oauth_access_tokens, :resource_owner_id, :bigint, using: "resource_owner_id::bigint"
+    add_index :oauth_access_tokens, :resource_owner_id
+
+    remove_index :oauth_access_grants, :resource_owner_id if index_exists?(:oauth_access_grants, :resource_owner_id)
+    change_column :oauth_access_grants, :resource_owner_id, :bigint, using: "resource_owner_id::bigint"
+    add_index :oauth_access_grants, :resource_owner_id
+  end
+end

--- a/db/migrate/20260408063454_change_oauth_access_tokens_resource_owner_id_to_string.rb
+++ b/db/migrate/20260408063454_change_oauth_access_tokens_resource_owner_id_to_string.rb
@@ -20,12 +20,15 @@ class ChangeOauthAccessTokensResourceOwnerIdToString < ActiveRecord::Migration[8
   end
 
   def down
-    remove_index :oauth_access_tokens, :resource_owner_id if index_exists?(:oauth_access_tokens, :resource_owner_id)
-    change_column :oauth_access_tokens, :resource_owner_id, :bigint, using: "resource_owner_id::bigint"
-    add_index :oauth_access_tokens, :resource_owner_id
-
-    remove_index :oauth_access_grants, :resource_owner_id if index_exists?(:oauth_access_grants, :resource_owner_id)
-    change_column :oauth_access_grants, :resource_owner_id, :bigint, using: "resource_owner_id::bigint"
-    add_index :oauth_access_grants, :resource_owner_id
+    # The forward migration is effectively irreversible once any
+    # opaque pt_*-prefixed identifiers have been written to the
+    # column — the bigint cast would error on the first non-numeric
+    # row. Refuse the rollback rather than fail partway and leave
+    # the schema in a half-changed state. Operators who genuinely
+    # need to roll back must drop the affected rows first.
+    raise ActiveRecord::IrreversibleMigration,
+      "Cannot revert: opaque patient identifiers may already be stored in " \
+      "oauth_access_tokens.resource_owner_id and oauth_access_grants.resource_owner_id. " \
+      "Drop or rewrite affected rows before attempting rollback."
   end
 end

--- a/docs/adr/0005-smart-launch-grant-types.md
+++ b/docs/adr/0005-smart-launch-grant-types.md
@@ -1,0 +1,127 @@
+# ADR 0005: SMART launch grant types
+
+**Status:** Accepted
+**Date:** 2026-04-08
+
+## Context
+
+The SMART App Launch specification describes the EHR launch flow as
+an OAuth 2.0 authorization code grant with a `launch` parameter
+threaded through the authorize → code → token round-trip. The app
+authenticates the user interactively, receives an authorization
+code, and exchanges that code at the token endpoint for an access
+token whose response body carries the patient context.
+
+During the initial port, our test and cucumber coverage for launch
+context embedding uses the `client_credentials` grant instead of
+`authorization_code`. `client_credentials` lets a confidential
+client post to `/oauth/token` with `client_id` + `client_secret`
++ a `launch` parameter, bypassing the browser-driven user consent
+flow entirely. The engine's custom tokens controller merges the
+bound patient/encounter identifiers into the response the same
+way either grant produces.
+
+We chose `client_credentials` for test coverage because the
+`authorization_code` flow requires:
+
+1. A browser-style interactive consent UI (or a test driver that
+   simulates one)
+2. A resource owner authenticator that returns a real user object
+3. A prior authorization code minted by the authorize endpoint
+4. A PKCE verifier round-trip
+
+None of those are available in the engine's test harness today —
+the engine delegates user authentication to the host application
+via the `resource_owner_authenticator` configuration hook, and the
+host will typically wire it to its own sign-in flow.
+
+## Decision
+
+**`client_credentials` + `launch` is supported as a first-class
+transitional mode** for test harnesses, backend-services
+integrations, and host applications that want to programmatically
+bind patient context without driving a user-agent through the
+authorize endpoint. It is **not removed** when production SMART
+support matures.
+
+**`authorization_code` + `launch` will also be supported** and is
+the spec-correct path for browser-driven SMART EHR launch flows.
+It lands in a follow-up PR when the engine grows either its own
+minimal user model or a host-app-provided authorize-flow driver.
+
+Both grants resolve the launch token through the same
+`LaunchContext.resolve` path: tenant-bound, client-bound, and
+single-use. The security properties are identical regardless of
+grant type — the difference is whether the app fetches the token
+through an interactive user-agent round-trip or directly with
+client credentials.
+
+## Rationale
+
+### Why keep `client_credentials` + `launch` permanent
+
+- **Backend services still need launch context.** A SMART Backend
+  Services client (e.g. a bulk export pipeline that needs to know
+  which patient cohort it's authorized against) legitimately uses
+  `client_credentials` and still needs to receive a patient
+  identifier in the token response when a host-mediated launch
+  has bound one.
+
+- **Test harnesses need a non-interactive path.** Driving an
+  authorization-code flow through Rack::Test requires stubbing
+  the authorize endpoint's UI, minting grants programmatically,
+  and threading PKCE verifiers. That adds test complexity without
+  adding coverage — the launch-binding logic doesn't care which
+  grant delivered the request.
+
+- **The security story is the same.** Launch token binding
+  (tenant, client, single-use) runs inside `LaunchContext.resolve`
+  regardless of grant type. A stolen launch token is equally
+  useless to an attacker whether they try to redeem it via
+  `authorization_code` (needs a valid PKCE verifier and auth code)
+  or `client_credentials` (needs the legitimate client's secret).
+
+### Why `authorization_code` + `launch` is still the primary flow
+
+- **SMART App Launch spec conformance.** The spec describes EHR
+  launch in terms of authorization code. Conformance test suites
+  (ONC Inferno) exercise this path. The engine must support it
+  for any site that pursues certification.
+
+- **User consent.** `authorization_code` goes through the
+  authorize endpoint, which runs the host's `resource_owner_authenticator`
+  and can prompt a user to approve the app's scopes. That's the
+  consent moment the spec relies on for HIPAA audit trails.
+
+- **Patient picker replacement.** One of the purposes of EHR
+  launch is to skip the patient-picker step that standalone launch
+  requires. That only makes sense in a context where the user has
+  already authenticated — i.e. through the authorize flow.
+
+## Consequences
+
+### Positive
+
+- Test coverage can exercise the full launch-binding logic without
+  plumbing a fake authorization code flow.
+- Backend services clients have a clear, supported way to receive
+  launch context.
+- The security analysis of launch tokens doesn't have to branch on
+  grant type — the binding checks are uniform.
+
+### Negative
+
+- Two supported paths to the same behavior can mislead integrators.
+  Documentation must make it clear which path SMART apps should
+  use (authorization_code) vs which is for backend services and
+  tests (client_credentials).
+- ONC Inferno conformance still requires the authorization_code
+  path. This ADR doesn't ship that — only declares the intent to
+  add it alongside the existing client_credentials support.
+
+## References
+
+- SMART App Launch Framework: http://hl7.org/fhir/smart-app-launch/app-launch.html
+- SMART Backend Services: http://hl7.org/fhir/smart-app-launch/backend-services.html
+- ADR 0002 — PHI tokenization (why LaunchContext stores opaque
+  identifiers rather than persisting PHI directly)

--- a/features/smart_ehr_launch.feature
+++ b/features/smart_ehr_launch.feature
@@ -1,0 +1,43 @@
+Feature: SMART EHR launch
+  As a SMART-on-FHIR client launched from an EHR
+  I need the EHR to bind a patient context to my launch
+  So that I receive the patient identifier in my access token without
+  prompting the user to pick a patient again
+
+  Background:
+    Given the EHR adapter is the in-memory mock
+    And the current tenant is "tnt_test"
+    And the current facility is "fac_main"
+    And the following patients are registered at facility "fac_main":
+      | display_name | date_of_birth | gender |
+      | DOE,JOHN     | 1980-01-15    | male   |
+    And a confidential OAuth client is registered with scopes "system/Patient.read launch/patient"
+
+  Scenario: Host application mints a launch context bound to a patient
+    Given the host mints a launch context for patient "DOE,JOHN"
+    Then the launch context has a launch_token starting with "lc_"
+    And the launch context binds the tenant "tnt_test"
+
+  Scenario: Token request with a valid launch token returns the patient context
+    Given the host mints a launch context for patient "DOE,JOHN"
+    When I POST to the OAuth token endpoint with grant_type "client_credentials" and the launch token
+    Then the response status is 200
+    And the response body includes an access_token
+    And the response body patient field equals the bound patient_identifier
+
+  Scenario: Token request without launch returns no patient context
+    When I POST to the OAuth token endpoint with grant_type "client_credentials" and the client credentials
+    Then the response status is 200
+    And the response body has no patient field
+
+  Scenario: Token request with an unknown launch token still issues a token but no patient
+    When I POST to the OAuth token endpoint with grant_type "client_credentials" and an unknown launch token
+    Then the response status is 200
+    And the response body has no patient field
+
+  Scenario: Token request with an expired launch token still issues a token but no patient
+    Given the host mints a launch context for patient "DOE,JOHN" that expires in 1 minute
+    And 5 minutes pass
+    When I POST to the OAuth token endpoint with grant_type "client_credentials" and the launch token
+    Then the response status is 200
+    And the response body has no patient field

--- a/features/step_definitions/smart_ehr_launch_steps.rb
+++ b/features/step_definitions/smart_ehr_launch_steps.rb
@@ -9,6 +9,7 @@ Given('the host mints a launch context for patient {string}') do |display_name|
 
   @launch_context = Lakeraven::EHR::LaunchContext.mint(
     tenant_identifier: tenant,
+    oauth_application_uid: @oauth_app.uid,
     patient_identifier: patient[:patient_identifier],
     facility_identifier: Lakeraven::EHR::Current.facility_identifier
   )
@@ -21,6 +22,7 @@ Given('the host mints a launch context for patient {string} that expires in {int
 
   @launch_context = Lakeraven::EHR::LaunchContext.mint(
     tenant_identifier: tenant,
+    oauth_application_uid: @oauth_app.uid,
     patient_identifier: patient[:patient_identifier],
     ttl: minutes.minutes
   )

--- a/features/step_definitions/smart_ehr_launch_steps.rb
+++ b/features/step_definitions/smart_ehr_launch_steps.rb
@@ -46,7 +46,7 @@ When('I POST to the OAuth token endpoint with grant_type {string} and the launch
     client_secret: @client_secret,
     scope: @oauth_app.scopes.to_s,
     launch: @launch_context.launch_token
-  }
+  }, { "HTTP_X_TENANT_IDENTIFIER" => Lakeraven::EHR::Current.tenant_identifier || "tnt_test" }
 end
 
 When('I POST to the OAuth token endpoint with grant_type {string} and an unknown launch token') do |grant_type|
@@ -56,7 +56,7 @@ When('I POST to the OAuth token endpoint with grant_type {string} and an unknown
     client_secret: @client_secret,
     scope: @oauth_app.scopes.to_s,
     launch: "lc_does_not_exist"
-  }
+  }, { "HTTP_X_TENANT_IDENTIFIER" => Lakeraven::EHR::Current.tenant_identifier || "tnt_test" }
 end
 
 Then("the response body has no patient field") do

--- a/features/step_definitions/smart_ehr_launch_steps.rb
+++ b/features/step_definitions/smart_ehr_launch_steps.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "active_support/testing/time_helpers"
+
+Given('the host mints a launch context for patient {string}') do |display_name|
+  tenant = Lakeraven::EHR::Current.tenant_identifier
+  patient = Lakeraven::EHR.adapter.search_patients(tenant_identifier: tenant, name: display_name).first
+  raise "no patient with display_name #{display_name}" unless patient
+
+  @launch_context = Lakeraven::EHR::LaunchContext.mint(
+    tenant_identifier: tenant,
+    patient_identifier: patient[:patient_identifier],
+    facility_identifier: Lakeraven::EHR::Current.facility_identifier
+  )
+end
+
+Given('the host mints a launch context for patient {string} that expires in {int} minute(s)') do |display_name, minutes|
+  tenant = Lakeraven::EHR::Current.tenant_identifier
+  patient = Lakeraven::EHR.adapter.search_patients(tenant_identifier: tenant, name: display_name).first
+  raise "no patient with display_name #{display_name}" unless patient
+
+  @launch_context = Lakeraven::EHR::LaunchContext.mint(
+    tenant_identifier: tenant,
+    patient_identifier: patient[:patient_identifier],
+    ttl: minutes.minutes
+  )
+end
+
+Given('{int} minutes pass') do |minutes|
+  travel(minutes.minutes)
+end
+
+Then('the launch context has a launch_token starting with {string}') do |prefix|
+  assert @launch_context.launch_token.start_with?(prefix),
+    "expected launch_token to start with #{prefix}, got #{@launch_context.launch_token}"
+end
+
+Then('the launch context binds the tenant {string}') do |tenant_identifier|
+  assert_equal tenant_identifier, @launch_context.tenant_identifier
+end
+
+When('I POST to the OAuth token endpoint with grant_type {string} and the launch token') do |grant_type|
+  post "/lakeraven-ehr/oauth/token", {
+    grant_type: grant_type,
+    client_id: @oauth_app.uid,
+    client_secret: @client_secret,
+    scope: @oauth_app.scopes.to_s,
+    launch: @launch_context.launch_token
+  }
+end
+
+When('I POST to the OAuth token endpoint with grant_type {string} and an unknown launch token') do |grant_type|
+  post "/lakeraven-ehr/oauth/token", {
+    grant_type: grant_type,
+    client_id: @oauth_app.uid,
+    client_secret: @client_secret,
+    scope: @oauth_app.scopes.to_s,
+    launch: "lc_does_not_exist"
+  }
+end
+
+Then("the response body has no patient field") do
+  body = parsed_body
+  refute body.key?("patient"), "expected no patient field, got #{body.inspect}"
+end
+
+Then("the response body patient field equals the bound patient_identifier") do
+  assert_equal @launch_context.patient_identifier, parsed_body["patient"]
+end
+
+# travel/travel_to are ActiveSupport::Testing::TimeHelpers methods. Bring
+# them into the cucumber world so the launch-token expiration scenarios
+# can advance the clock.
+World(ActiveSupport::Testing::TimeHelpers)
+
+After do
+  travel_back if Time.respond_to?(:current) && respond_to?(:travel_back)
+end

--- a/features/step_definitions/us_core_patient_api_steps.rb
+++ b/features/step_definitions/us_core_patient_api_steps.rb
@@ -130,6 +130,28 @@ def do_get_patient(identifier)
   headers = {}
   headers["X-Tenant-Identifier"]   = Lakeraven::EHR::Current.tenant_identifier unless @omit_tenant_header
   headers["X-Facility-Identifier"] = Lakeraven::EHR::Current.facility_identifier if Lakeraven::EHR::Current.facility_identifier
+
+  # Mint a Bearer token with system/Patient.read scope so the
+  # SmartAuthentication boundary on PatientsController is satisfied.
+  # The us_core_patient_api scenarios assume an authorized client; the
+  # auth-boundary cases (missing token, wrong scope) live in
+  # fhir_smart_authentication.feature.
+  unless @omit_bearer_token
+    @cucumber_oauth_app ||= Doorkeeper::Application.create!(
+      name: "us-core-patient-cucumber",
+      redirect_uri: "https://example.test/callback",
+      scopes: "system/Patient.read",
+      confidential: true
+    )
+    token = Doorkeeper::AccessToken.create!(
+      application: @cucumber_oauth_app,
+      scopes: "system/Patient.read",
+      expires_in: 3600
+    )
+    plaintext = token.plaintext_token || token.token
+    headers["Authorization"] = "Bearer #{plaintext}"
+  end
+
   rack_env = headers.transform_keys { |k| "HTTP_#{k.upcase.tr('-', '_')}" }
   get "/lakeraven-ehr/Patient/#{identifier}", {}, rack_env
 end
@@ -141,6 +163,8 @@ end
 Before do
   @parsed_body = nil
   @omit_tenant_header = false
+  @omit_bearer_token = false
   @last_requested_identifier = nil
   @other_tenant_identifier = nil
+  @cucumber_oauth_app = nil
 end

--- a/lib/lakeraven/ehr/configuration.rb
+++ b/lib/lakeraven/ehr/configuration.rb
@@ -15,6 +15,8 @@ module Lakeraven
       attr_accessor :adapter
       attr_accessor :resource_owner_authenticator
       attr_accessor :admin_authenticator
+      attr_accessor :tenant_resolver
+      attr_accessor :facility_resolver
 
       def initialize
         @adapter = nil
@@ -31,6 +33,22 @@ module Lakeraven
         # Default admin authenticator: deny everything. The host
         # overrides if it wants to expose the Doorkeeper admin UI.
         @admin_authenticator = ->(_controller) { false }
+
+        # Default tenant resolver: read X-Tenant-Identifier header.
+        # Host SaaS apps override this with subdomain extraction or
+        # any other policy. Receives the request object and returns
+        # an opaque tenant identifier (or nil).
+        @tenant_resolver = ->(request) {
+          value = request.headers["X-Tenant-Identifier"].to_s.strip
+          value.empty? ? nil : value
+        }
+
+        # Default facility resolver: read X-Facility-Identifier header.
+        # May return nil; facility scoping is optional.
+        @facility_resolver = ->(request) {
+          value = request.headers["X-Facility-Identifier"].to_s.strip
+          value.empty? ? nil : value
+        }
       end
     end
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,20 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_08_000318) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_08_062502) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "lakeraven_ehr_launch_contexts", force: :cascade do |t|
+    t.datetime "consumed_at"
     t.datetime "created_at", null: false
     t.string "encounter_identifier"
     t.datetime "expires_at", null: false
     t.string "facility_identifier"
     t.string "launch_token", null: false
+    t.string "oauth_application_uid", null: false
     t.string "patient_identifier", null: false
     t.string "tenant_identifier", null: false
     t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_lakeraven_ehr_launch_contexts_on_expires_at"
     t.index ["launch_token"], name: "index_lakeraven_ehr_launch_contexts_on_launch_token", unique: true
+    t.index ["oauth_application_uid"], name: "index_lakeraven_ehr_launch_contexts_on_oauth_application_uid"
     t.index ["tenant_identifier"], name: "index_lakeraven_ehr_launch_contexts_on_tenant_identifier"
   end
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,9 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_07_234907) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_08_000318) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "lakeraven_ehr_launch_contexts", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "encounter_identifier"
+    t.datetime "expires_at", null: false
+    t.string "facility_identifier"
+    t.string "launch_token", null: false
+    t.string "patient_identifier", null: false
+    t.string "tenant_identifier", null: false
+    t.datetime "updated_at", null: false
+    t.index ["launch_token"], name: "index_lakeraven_ehr_launch_contexts_on_launch_token", unique: true
+    t.index ["tenant_identifier"], name: "index_lakeraven_ehr_launch_contexts_on_tenant_identifier"
+  end
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.bigint "application_id", null: false

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_08_062502) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_08_063454) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -36,7 +36,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_062502) do
     t.datetime "created_at", null: false
     t.integer "expires_in", null: false
     t.text "redirect_uri", null: false
-    t.bigint "resource_owner_id", null: false
+    t.string "resource_owner_id", null: false
     t.datetime "revoked_at"
     t.string "scopes", default: "", null: false
     t.string "token", null: false
@@ -51,7 +51,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_08_062502) do
     t.integer "expires_in"
     t.string "previous_refresh_token", default: "", null: false
     t.string "refresh_token"
-    t.bigint "resource_owner_id"
+    t.string "resource_owner_id"
     t.datetime "revoked_at"
     t.string "scopes"
     t.string "token", null: false

--- a/test/lakeraven/ehr/configuration_test.rb
+++ b/test/lakeraven/ehr/configuration_test.rb
@@ -42,4 +42,59 @@ class Lakeraven::EHR::ConfigurationTest < ActiveSupport::TestCase
     Lakeraven::EHR.reset_configuration!
     assert_nil Lakeraven::EHR.configuration.adapter
   end
+
+  # -- tenant_resolver / facility_resolver -----------------------------------
+
+  class FakeRequest
+    attr_reader :headers, :host
+    def initialize(headers: {}, host: "example.com")
+      @headers = headers
+      @host = host
+    end
+  end
+
+  test "default tenant_resolver reads X-Tenant-Identifier header" do
+    request = FakeRequest.new(headers: { "X-Tenant-Identifier" => "tnt_from_header" })
+    assert_equal "tnt_from_header", Lakeraven::EHR.configuration.tenant_resolver.call(request)
+  end
+
+  test "default tenant_resolver returns nil when header is missing" do
+    request = FakeRequest.new(headers: {})
+    assert_nil Lakeraven::EHR.configuration.tenant_resolver.call(request)
+  end
+
+  test "default tenant_resolver returns nil for whitespace-only header" do
+    request = FakeRequest.new(headers: { "X-Tenant-Identifier" => "   " })
+    assert_nil Lakeraven::EHR.configuration.tenant_resolver.call(request)
+  end
+
+  test "default facility_resolver reads X-Facility-Identifier header" do
+    request = FakeRequest.new(headers: { "X-Facility-Identifier" => "fac_main" })
+    assert_equal "fac_main", Lakeraven::EHR.configuration.facility_resolver.call(request)
+  end
+
+  test "host application can override tenant_resolver with subdomain extraction" do
+    # This locks in the abstraction the production SaaS app relies on:
+    # the engine doesn't care how the host app derives a tenant from
+    # the request, only that the resolver returns a string or nil.
+    Lakeraven::EHR.configure do |config|
+      config.tenant_resolver = ->(request) {
+        sub = request.host.split(".").first
+        sub.start_with?("tnt-") ? sub.delete_prefix("tnt-") : nil
+      }
+    end
+    request = FakeRequest.new(host: "tnt-acme.example.com")
+    assert_equal "acme", Lakeraven::EHR.configuration.tenant_resolver.call(request)
+  end
+
+  test "subdomain resolver returns nil on a host with no tnt- prefix" do
+    Lakeraven::EHR.configure do |config|
+      config.tenant_resolver = ->(request) {
+        sub = request.host.split(".").first
+        sub.start_with?("tnt-") ? sub.delete_prefix("tnt-") : nil
+      }
+    end
+    request = FakeRequest.new(host: "www.example.com")
+    assert_nil Lakeraven::EHR.configuration.tenant_resolver.call(request)
+  end
 end

--- a/test/lakeraven/ehr/launch_context_test.rb
+++ b/test/lakeraven/ehr/launch_context_test.rb
@@ -10,9 +10,23 @@ class Lakeraven::EHR::LaunchContextTest < ActiveSupport::TestCase
   def base_args
     {
       tenant_identifier: "tnt_test",
+      oauth_application_uid: "test-client-uid",
       patient_identifier: "pt_01H8X",
       facility_identifier: "fac_main"
     }
+  end
+
+  def resolve_args(launch_token, overrides = {})
+    [ launch_token, { tenant_identifier: "tnt_test", oauth_application_uid: "test-client-uid" }.merge(overrides) ]
+  end
+
+  def resolve(launch_token, **overrides)
+    Lakeraven::EHR::LaunchContext.resolve(
+      launch_token,
+      tenant_identifier: "tnt_test",
+      oauth_application_uid: "test-client-uid",
+      **overrides
+    )
   end
 
   test "mint creates a persisted record with a launch_token" do
@@ -39,53 +53,73 @@ class Lakeraven::EHR::LaunchContextTest < ActiveSupport::TestCase
   end
 
   test "mint stores all binding fields" do
-    ctx = Lakeraven::EHR::LaunchContext.mint(
-      tenant_identifier: "tnt_test",
-      patient_identifier: "pt_01H8X",
-      facility_identifier: "fac_main",
-      encounter_identifier: "enc_01H8Y"
-    )
+    ctx = Lakeraven::EHR::LaunchContext.mint(**base_args, encounter_identifier: "enc_01H8Y")
     assert_equal "tnt_test", ctx.tenant_identifier
+    assert_equal "test-client-uid", ctx.oauth_application_uid
     assert_equal "pt_01H8X", ctx.patient_identifier
     assert_equal "fac_main", ctx.facility_identifier
     assert_equal "enc_01H8Y", ctx.encounter_identifier
   end
 
-  test "resolve finds an active launch context by token and tenant" do
+  test "resolve finds an active context by token + tenant + client" do
     ctx = Lakeraven::EHR::LaunchContext.mint(**base_args)
-    found = Lakeraven::EHR::LaunchContext.resolve(ctx.launch_token, tenant_identifier: "tnt_test")
-    assert_equal ctx, found
+    assert_equal ctx, resolve(ctx.launch_token)
   end
 
   test "resolve returns nil for unknown token" do
-    assert_nil Lakeraven::EHR::LaunchContext.resolve("lc_unknown", tenant_identifier: "tnt_test")
+    assert_nil resolve("lc_unknown")
   end
 
   test "resolve returns nil for nil and empty launch_token" do
-    assert_nil Lakeraven::EHR::LaunchContext.resolve(nil, tenant_identifier: "tnt_test")
-    assert_nil Lakeraven::EHR::LaunchContext.resolve("", tenant_identifier: "tnt_test")
+    assert_nil resolve(nil)
+    assert_nil resolve("")
   end
 
   test "resolve returns nil for nil and empty tenant_identifier" do
     ctx = Lakeraven::EHR::LaunchContext.mint(**base_args)
-    assert_nil Lakeraven::EHR::LaunchContext.resolve(ctx.launch_token, tenant_identifier: nil)
-    assert_nil Lakeraven::EHR::LaunchContext.resolve(ctx.launch_token, tenant_identifier: "")
+    assert_nil resolve(ctx.launch_token, tenant_identifier: nil)
+    assert_nil resolve(ctx.launch_token, tenant_identifier: "")
+  end
+
+  test "resolve returns nil for nil and empty oauth_application_uid" do
+    ctx = Lakeraven::EHR::LaunchContext.mint(**base_args)
+    assert_nil resolve(ctx.launch_token, oauth_application_uid: nil)
+    assert_nil resolve(ctx.launch_token, oauth_application_uid: "")
   end
 
   test "resolve returns nil when the token belongs to a different tenant" do
-    # Regression: a launch token minted for tnt_test must not resolve
-    # when the request arrives on tnt_other's surface. Per ADR 0003 a
-    # launch bound to one tenant can't be redeemed inside another
-    # tenant's OAuth flow.
+    # Cross-tenant: a launch minted for tnt_test is not redeemable on
+    # tnt_other's surface.
     ctx = Lakeraven::EHR::LaunchContext.mint(**base_args)
-    assert_nil Lakeraven::EHR::LaunchContext.resolve(ctx.launch_token, tenant_identifier: "tnt_other")
+    assert_nil resolve(ctx.launch_token, tenant_identifier: "tnt_other")
+  end
+
+  test "resolve returns nil when the token belongs to a different OAuth client" do
+    # Cross-client: a launch minted for app A is not redeemable by app B
+    # even within the same tenant. A leaked launch token is useless to
+    # any other registered client.
+    ctx = Lakeraven::EHR::LaunchContext.mint(**base_args)
+    assert_nil resolve(ctx.launch_token, oauth_application_uid: "different-client-uid")
   end
 
   test "resolve returns nil for an expired context" do
     ctx = Lakeraven::EHR::LaunchContext.mint(**base_args, ttl: 5.minutes)
     travel_to(Time.current + 6.minutes) do
-      assert_nil Lakeraven::EHR::LaunchContext.resolve(ctx.launch_token, tenant_identifier: "tnt_test")
+      assert_nil resolve(ctx.launch_token)
     end
+  end
+
+  test "consume! marks the context consumed and resolve returns nil afterward" do
+    ctx = Lakeraven::EHR::LaunchContext.mint(**base_args)
+    assert ctx.consume!
+    assert ctx.reload.consumed_at.present?
+    assert_nil resolve(ctx.launch_token)
+  end
+
+  test "consume! returns false on a second call (single-use guarantee)" do
+    ctx = Lakeraven::EHR::LaunchContext.mint(**base_args)
+    assert ctx.consume!
+    refute ctx.consume!
   end
 
   test "expired? returns true after ttl elapses" do
@@ -99,6 +133,7 @@ class Lakeraven::EHR::LaunchContextTest < ActiveSupport::TestCase
     refute Lakeraven::EHR::LaunchContext.new(
       launch_token: "lc_x",
       tenant_identifier: "tnt_test",
+      oauth_application_uid: "test-client-uid",
       expires_at: 10.minutes.from_now
     ).valid?
   end
@@ -106,6 +141,16 @@ class Lakeraven::EHR::LaunchContextTest < ActiveSupport::TestCase
   test "validation rejects records missing tenant_identifier" do
     refute Lakeraven::EHR::LaunchContext.new(
       launch_token: "lc_x",
+      oauth_application_uid: "test-client-uid",
+      patient_identifier: "pt_01H8X",
+      expires_at: 10.minutes.from_now
+    ).valid?
+  end
+
+  test "validation rejects records missing oauth_application_uid" do
+    refute Lakeraven::EHR::LaunchContext.new(
+      launch_token: "lc_x",
+      tenant_identifier: "tnt_test",
       patient_identifier: "pt_01H8X",
       expires_at: 10.minutes.from_now
     ).valid?
@@ -117,6 +162,7 @@ class Lakeraven::EHR::LaunchContextTest < ActiveSupport::TestCase
       launch_token: ctx.launch_token,
       patient_identifier: "pt_other",
       tenant_identifier: "tnt_test",
+      oauth_application_uid: "test-client-uid",
       expires_at: 10.minutes.from_now
     )
     refute duplicate.valid?

--- a/test/lakeraven/ehr/launch_context_test.rb
+++ b/test/lakeraven/ehr/launch_context_test.rb
@@ -51,25 +51,40 @@ class Lakeraven::EHR::LaunchContextTest < ActiveSupport::TestCase
     assert_equal "enc_01H8Y", ctx.encounter_identifier
   end
 
-  test "resolve finds an active launch context by token" do
+  test "resolve finds an active launch context by token and tenant" do
     ctx = Lakeraven::EHR::LaunchContext.mint(**base_args)
-    found = Lakeraven::EHR::LaunchContext.resolve(ctx.launch_token)
+    found = Lakeraven::EHR::LaunchContext.resolve(ctx.launch_token, tenant_identifier: "tnt_test")
     assert_equal ctx, found
   end
 
   test "resolve returns nil for unknown token" do
-    assert_nil Lakeraven::EHR::LaunchContext.resolve("lc_unknown")
+    assert_nil Lakeraven::EHR::LaunchContext.resolve("lc_unknown", tenant_identifier: "tnt_test")
   end
 
-  test "resolve returns nil for nil and empty inputs" do
-    assert_nil Lakeraven::EHR::LaunchContext.resolve(nil)
-    assert_nil Lakeraven::EHR::LaunchContext.resolve("")
+  test "resolve returns nil for nil and empty launch_token" do
+    assert_nil Lakeraven::EHR::LaunchContext.resolve(nil, tenant_identifier: "tnt_test")
+    assert_nil Lakeraven::EHR::LaunchContext.resolve("", tenant_identifier: "tnt_test")
+  end
+
+  test "resolve returns nil for nil and empty tenant_identifier" do
+    ctx = Lakeraven::EHR::LaunchContext.mint(**base_args)
+    assert_nil Lakeraven::EHR::LaunchContext.resolve(ctx.launch_token, tenant_identifier: nil)
+    assert_nil Lakeraven::EHR::LaunchContext.resolve(ctx.launch_token, tenant_identifier: "")
+  end
+
+  test "resolve returns nil when the token belongs to a different tenant" do
+    # Regression: a launch token minted for tnt_test must not resolve
+    # when the request arrives on tnt_other's surface. Per ADR 0003 a
+    # launch bound to one tenant can't be redeemed inside another
+    # tenant's OAuth flow.
+    ctx = Lakeraven::EHR::LaunchContext.mint(**base_args)
+    assert_nil Lakeraven::EHR::LaunchContext.resolve(ctx.launch_token, tenant_identifier: "tnt_other")
   end
 
   test "resolve returns nil for an expired context" do
     ctx = Lakeraven::EHR::LaunchContext.mint(**base_args, ttl: 5.minutes)
     travel_to(Time.current + 6.minutes) do
-      assert_nil Lakeraven::EHR::LaunchContext.resolve(ctx.launch_token)
+      assert_nil Lakeraven::EHR::LaunchContext.resolve(ctx.launch_token, tenant_identifier: "tnt_test")
     end
   end
 

--- a/test/lakeraven/ehr/launch_context_test.rb
+++ b/test/lakeraven/ehr/launch_context_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::LaunchContextTest < ActiveSupport::TestCase
+  setup do
+    Lakeraven::EHR::LaunchContext.delete_all
+  end
+
+  def base_args
+    {
+      tenant_identifier: "tnt_test",
+      patient_identifier: "pt_01H8X",
+      facility_identifier: "fac_main"
+    }
+  end
+
+  test "mint creates a persisted record with a launch_token" do
+    ctx = Lakeraven::EHR::LaunchContext.mint(**base_args)
+    assert ctx.persisted?
+    assert ctx.launch_token.present?
+    assert ctx.launch_token.start_with?("lc_")
+  end
+
+  test "mint sets expires_at to ttl from now" do
+    freeze = Time.utc(2026, 4, 7, 12, 0, 0)
+    travel_to(freeze) do
+      ctx = Lakeraven::EHR::LaunchContext.mint(**base_args, ttl: 5.minutes)
+      assert_equal freeze + 5.minutes, ctx.expires_at
+    end
+  end
+
+  test "mint defaults ttl to 10 minutes" do
+    freeze = Time.utc(2026, 4, 7, 12, 0, 0)
+    travel_to(freeze) do
+      ctx = Lakeraven::EHR::LaunchContext.mint(**base_args)
+      assert_equal freeze + 10.minutes, ctx.expires_at
+    end
+  end
+
+  test "mint stores all binding fields" do
+    ctx = Lakeraven::EHR::LaunchContext.mint(
+      tenant_identifier: "tnt_test",
+      patient_identifier: "pt_01H8X",
+      facility_identifier: "fac_main",
+      encounter_identifier: "enc_01H8Y"
+    )
+    assert_equal "tnt_test", ctx.tenant_identifier
+    assert_equal "pt_01H8X", ctx.patient_identifier
+    assert_equal "fac_main", ctx.facility_identifier
+    assert_equal "enc_01H8Y", ctx.encounter_identifier
+  end
+
+  test "resolve finds an active launch context by token" do
+    ctx = Lakeraven::EHR::LaunchContext.mint(**base_args)
+    found = Lakeraven::EHR::LaunchContext.resolve(ctx.launch_token)
+    assert_equal ctx, found
+  end
+
+  test "resolve returns nil for unknown token" do
+    assert_nil Lakeraven::EHR::LaunchContext.resolve("lc_unknown")
+  end
+
+  test "resolve returns nil for nil and empty inputs" do
+    assert_nil Lakeraven::EHR::LaunchContext.resolve(nil)
+    assert_nil Lakeraven::EHR::LaunchContext.resolve("")
+  end
+
+  test "resolve returns nil for an expired context" do
+    ctx = Lakeraven::EHR::LaunchContext.mint(**base_args, ttl: 5.minutes)
+    travel_to(Time.current + 6.minutes) do
+      assert_nil Lakeraven::EHR::LaunchContext.resolve(ctx.launch_token)
+    end
+  end
+
+  test "expired? returns true after ttl elapses" do
+    ctx = Lakeraven::EHR::LaunchContext.mint(**base_args, ttl: 5.minutes)
+    travel_to(Time.current + 6.minutes) do
+      assert ctx.reload.expired?
+    end
+  end
+
+  test "validation rejects records missing patient_identifier" do
+    refute Lakeraven::EHR::LaunchContext.new(
+      launch_token: "lc_x",
+      tenant_identifier: "tnt_test",
+      expires_at: 10.minutes.from_now
+    ).valid?
+  end
+
+  test "validation rejects records missing tenant_identifier" do
+    refute Lakeraven::EHR::LaunchContext.new(
+      launch_token: "lc_x",
+      patient_identifier: "pt_01H8X",
+      expires_at: 10.minutes.from_now
+    ).valid?
+  end
+
+  test "launch_token uniqueness is enforced" do
+    ctx = Lakeraven::EHR::LaunchContext.mint(**base_args)
+    duplicate = Lakeraven::EHR::LaunchContext.new(
+      launch_token: ctx.launch_token,
+      patient_identifier: "pt_other",
+      tenant_identifier: "tnt_test",
+      expires_at: 10.minutes.from_now
+    )
+    refute duplicate.valid?
+  end
+
+  test "minted launch_tokens are unique across calls" do
+    tokens = 10.times.map { Lakeraven::EHR::LaunchContext.mint(**base_args).launch_token }
+    assert_equal tokens.uniq.length, tokens.length
+  end
+end

--- a/test/lakeraven/ehr/patients_controller_test.rb
+++ b/test/lakeraven/ehr/patients_controller_test.rb
@@ -188,4 +188,23 @@ class Lakeraven::EHR::PatientsControllerTest < ActionDispatch::IntegrationTest
     body = JSON.parse(response.body)
     assert_equal "forbidden", body["issue"].first["code"]
   end
+
+  test "custom tenant_resolver overrides the default header reader" do
+    # Integration lock-in: a host application override (subdomain,
+    # JWT claim, anything) replaces the default header read and
+    # flows through ApplicationController + Current + the adapter
+    # call without any code changes to the engine.
+    Lakeraven::EHR.configure do |config|
+      config.tenant_resolver = ->(_request) { "tnt_test" }
+      config.facility_resolver = ->(_request) { "fac_main" }
+    end
+    # NO X-Tenant-Identifier header — the resolver hard-codes it.
+    token = issue_token(scopes: "system/Patient.read")
+    plaintext = token.plaintext_token || token.token
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}",
+        headers: { "Authorization" => "Bearer #{plaintext}" }
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert_equal "Patient", body["resourceType"]
+  end
 end

--- a/test/lakeraven/ehr/patients_controller_test.rb
+++ b/test/lakeraven/ehr/patients_controller_test.rb
@@ -6,6 +6,10 @@ class Lakeraven::EHR::PatientsControllerTest < ActionDispatch::IntegrationTest
   setup do
     Lakeraven::EHR.reset_configuration!
     Lakeraven::EHR::Current.reset!
+    Doorkeeper::AccessToken.delete_all
+    Doorkeeper::AccessGrant.delete_all
+    Doorkeeper::Application.delete_all
+
     @adapter = Lakeraven::EHR::Adapters::MockAdapter.new
     Lakeraven::EHR.configure { |c| c.adapter = @adapter }
 
@@ -22,6 +26,13 @@ class Lakeraven::EHR::PatientsControllerTest < ActionDispatch::IntegrationTest
       system: "http://hl7.org/fhir/sid/us-ssn",
       value: "111-11-1111"
     )
+
+    @oauth_app = Doorkeeper::Application.create!(
+      name: "test client",
+      redirect_uri: "https://example.test/callback",
+      scopes: "system/Patient.read patient/Patient.read",
+      confidential: true
+    )
   end
 
   teardown do
@@ -29,14 +40,26 @@ class Lakeraven::EHR::PatientsControllerTest < ActionDispatch::IntegrationTest
     Lakeraven::EHR::Current.reset!
   end
 
-  def tenant_headers(facility: "fac_main")
-    headers = { "X-Tenant-Identifier" => "tnt_test" }
+  def issue_token(scopes: "system/Patient.read", patient: nil)
+    Doorkeeper::AccessToken.create!(
+      application: @oauth_app,
+      resource_owner_id: patient,
+      scopes: scopes,
+      expires_in: 3600
+    )
+  end
+
+  def auth_headers(token: nil, tenant: "tnt_test", facility: "fac_main", scopes: "system/Patient.read", patient: nil)
+    token ||= issue_token(scopes: scopes, patient: patient)
+    plaintext = token.plaintext_token || token.token
+    headers = { "Authorization" => "Bearer #{plaintext}" }
+    headers["X-Tenant-Identifier"] = tenant if tenant
     headers["X-Facility-Identifier"] = facility if facility
     headers
   end
 
   test "GET /Patient/:identifier returns 200 with the FHIR Patient resource" do
-    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: tenant_headers
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: auth_headers
     assert_response :ok
     assert_equal "application/fhir+json", response.media_type
     body = JSON.parse(response.body)
@@ -45,26 +68,26 @@ class Lakeraven::EHR::PatientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "response includes US Core profile in meta.profile" do
-    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: tenant_headers
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: auth_headers
     body = JSON.parse(response.body)
     assert_includes body.dig("meta", "profile"), "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
   end
 
   test "response includes name family + given parsed from display_name" do
-    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: tenant_headers
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: auth_headers
     body = JSON.parse(response.body)
     assert_equal "DOE", body["name"].first["family"]
     assert_includes body["name"].first["given"], "JOHN"
   end
 
   test "response includes the SSN identifier round-tripped" do
-    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: tenant_headers
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: auth_headers
     body = JSON.parse(response.body)
     assert_includes body["identifier"], { "system" => "http://hl7.org/fhir/sid/us-ssn", "value" => "111-11-1111" }
   end
 
   test "unknown patient identifier returns 404 OperationOutcome" do
-    get "/lakeraven-ehr/Patient/pt_does_not_exist", headers: tenant_headers
+    get "/lakeraven-ehr/Patient/pt_does_not_exist", headers: auth_headers
     assert_response :not_found
     assert_equal "application/fhir+json", response.media_type
     body = JSON.parse(response.body)
@@ -79,7 +102,7 @@ class Lakeraven::EHR::PatientsControllerTest < ActionDispatch::IntegrationTest
       tenant_identifier: "tnt_other", facility_identifier: "fac_main",
       display_name: "OTHER,PERSON", date_of_birth: Date.new(1990, 1, 1), gender: "male"
     )
-    get "/lakeraven-ehr/Patient/#{other_identifier}", headers: tenant_headers
+    get "/lakeraven-ehr/Patient/#{other_identifier}", headers: auth_headers
     assert_response :not_found
   end
 
@@ -106,10 +129,63 @@ class Lakeraven::EHR::PatientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "Current is reset after the request so state doesn't leak across actions" do
-    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: tenant_headers
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: auth_headers
     assert_response :ok
     # ActiveSupport::CurrentAttributes auto-resets after the request
     # via the railtie integration. We just verify it didn't carry over.
     assert_nil Lakeraven::EHR::Current.tenant_identifier
+  end
+
+  # -- SMART auth boundary ---------------------------------------------------
+
+  test "request without Bearer token returns 401 OperationOutcome login" do
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}",
+        headers: { "X-Tenant-Identifier" => "tnt_test" }
+    assert_response :unauthorized
+    body = JSON.parse(response.body)
+    assert_equal "OperationOutcome", body["resourceType"]
+    assert_equal "login", body["issue"].first["code"]
+  end
+
+  test "request with token missing read scope returns 403 forbidden" do
+    headers = auth_headers(scopes: "openid")
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: headers
+    assert_response :forbidden
+    body = JSON.parse(response.body)
+    assert_equal "forbidden", body["issue"].first["code"]
+  end
+
+  test "system/Patient.read scope grants access" do
+    headers = auth_headers(scopes: "system/Patient.read")
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: headers
+    assert_response :ok
+  end
+
+  test "user/Patient.read scope grants access" do
+    headers = auth_headers(scopes: "user/Patient.read")
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: headers
+    assert_response :ok
+  end
+
+  test "patient/Patient.read with matching bound patient grants access" do
+    headers = auth_headers(scopes: "patient/Patient.read", patient: @patient_identifier)
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: headers
+    assert_response :ok
+  end
+
+  test "patient/Patient.read with mismatched bound patient returns 403 forbidden" do
+    headers = auth_headers(scopes: "patient/Patient.read", patient: "pt_other")
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: headers
+    assert_response :forbidden
+    body = JSON.parse(response.body)
+    assert_equal "forbidden", body["issue"].first["code"]
+  end
+
+  test "patient/Patient.read with no bound patient returns 403 forbidden" do
+    headers = auth_headers(scopes: "patient/Patient.read", patient: nil)
+    get "/lakeraven-ehr/Patient/#{@patient_identifier}", headers: headers
+    assert_response :forbidden
+    body = JSON.parse(response.body)
+    assert_equal "forbidden", body["issue"].first["code"]
   end
 end

--- a/test/lakeraven/ehr/smart/tokens_controller_test.rb
+++ b/test/lakeraven/ehr/smart/tokens_controller_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::Smart::TokensControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    Lakeraven::EHR::LaunchContext.delete_all
+    Doorkeeper::Application.delete_all
+
+    @client = Doorkeeper::Application.create!(
+      name: "test client",
+      redirect_uri: "https://example.test/callback",
+      scopes: "system/Patient.read launch/patient",
+      confidential: true
+    )
+    @client_secret = @client.plaintext_secret || @client.secret
+  end
+
+  def post_token(params = {})
+    post "/lakeraven-ehr/oauth/token", params: {
+      grant_type: "client_credentials",
+      client_id: @client.uid,
+      client_secret: @client_secret,
+      scope: "system/Patient.read"
+    }.merge(params)
+  end
+
+  test "client_credentials without launch returns a normal token response" do
+    post_token
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert body["access_token"].present?
+    refute body.key?("patient"), "expected no patient field without launch context"
+  end
+
+  test "client_credentials with a valid launch token embeds patient in the response" do
+    ctx = Lakeraven::EHR::LaunchContext.mint(
+      tenant_identifier: "tnt_test",
+      patient_identifier: "pt_01H8X"
+    )
+    post_token(launch: ctx.launch_token)
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert body["access_token"].present?
+    assert_equal "pt_01H8X", body["patient"]
+  end
+
+  test "client_credentials with an unknown launch token returns the token without patient" do
+    post_token(launch: "lc_does_not_exist")
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert body["access_token"].present?
+    refute body.key?("patient")
+  end
+
+  test "client_credentials with an expired launch token returns the token without patient" do
+    ctx = Lakeraven::EHR::LaunchContext.mint(
+      tenant_identifier: "tnt_test",
+      patient_identifier: "pt_01H8X",
+      ttl: 1.minute
+    )
+    travel_to(Time.current + 5.minutes) do
+      post_token(launch: ctx.launch_token)
+      assert_response :ok
+      body = JSON.parse(response.body)
+      refute body.key?("patient")
+    end
+  end
+
+  test "client_credentials with launch context including encounter embeds both" do
+    ctx = Lakeraven::EHR::LaunchContext.mint(
+      tenant_identifier: "tnt_test",
+      patient_identifier: "pt_01H8X",
+      encounter_identifier: "enc_01H8Y"
+    )
+    post_token(launch: ctx.launch_token)
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert_equal "pt_01H8X", body["patient"]
+    assert_equal "enc_01H8Y", body["encounter"]
+  end
+
+  test "token_type is preserved as Bearer when launch is embedded" do
+    ctx = Lakeraven::EHR::LaunchContext.mint(
+      tenant_identifier: "tnt_test",
+      patient_identifier: "pt_01H8X"
+    )
+    post_token(launch: ctx.launch_token)
+    body = JSON.parse(response.body)
+    assert_equal "Bearer", body["token_type"]
+  end
+
+  test "request without launch still passes other token fields through" do
+    post_token
+    body = JSON.parse(response.body)
+    assert body["expires_in"].present?
+    assert_equal "Bearer", body["token_type"]
+    assert body["scope"].include?("system/Patient.read")
+  end
+end

--- a/test/lakeraven/ehr/smart/tokens_controller_test.rb
+++ b/test/lakeraven/ehr/smart/tokens_controller_test.rb
@@ -18,13 +18,16 @@ class Lakeraven::EHR::Smart::TokensControllerTest < ActionDispatch::IntegrationT
     @client_secret = @client.plaintext_secret || @client.secret
   end
 
-  def post_token(params = {})
-    post "/lakeraven-ehr/oauth/token", params: {
-      grant_type: "client_credentials",
-      client_id: @client.uid,
-      client_secret: @client_secret,
-      scope: "system/Patient.read"
-    }.merge(params)
+  def post_token(params = {}, tenant: "tnt_test")
+    headers = tenant ? { "X-Tenant-Identifier" => tenant } : {}
+    post "/lakeraven-ehr/oauth/token",
+         params: {
+           grant_type: "client_credentials",
+           client_id: @client.uid,
+           client_secret: @client_secret,
+           scope: "system/Patient.read"
+         }.merge(params),
+         headers: headers
   end
 
   test "client_credentials without launch returns a normal token response" do
@@ -40,7 +43,7 @@ class Lakeraven::EHR::Smart::TokensControllerTest < ActionDispatch::IntegrationT
       tenant_identifier: "tnt_test",
       patient_identifier: "pt_01H8X"
     )
-    post_token(launch: ctx.launch_token)
+    post_token({ launch: ctx.launch_token })
     assert_response :ok
     body = JSON.parse(response.body)
     assert body["access_token"].present?
@@ -48,7 +51,7 @@ class Lakeraven::EHR::Smart::TokensControllerTest < ActionDispatch::IntegrationT
   end
 
   test "client_credentials with an unknown launch token returns the token without patient" do
-    post_token(launch: "lc_does_not_exist")
+    post_token({ launch: "lc_does_not_exist" })
     assert_response :ok
     body = JSON.parse(response.body)
     assert body["access_token"].present?
@@ -62,7 +65,7 @@ class Lakeraven::EHR::Smart::TokensControllerTest < ActionDispatch::IntegrationT
       ttl: 1.minute
     )
     travel_to(Time.current + 5.minutes) do
-      post_token(launch: ctx.launch_token)
+      post_token({ launch: ctx.launch_token })
       assert_response :ok
       body = JSON.parse(response.body)
       refute body.key?("patient")
@@ -75,7 +78,7 @@ class Lakeraven::EHR::Smart::TokensControllerTest < ActionDispatch::IntegrationT
       patient_identifier: "pt_01H8X",
       encounter_identifier: "enc_01H8Y"
     )
-    post_token(launch: ctx.launch_token)
+    post_token({ launch: ctx.launch_token })
     assert_response :ok
     body = JSON.parse(response.body)
     assert_equal "pt_01H8X", body["patient"]
@@ -87,7 +90,7 @@ class Lakeraven::EHR::Smart::TokensControllerTest < ActionDispatch::IntegrationT
       tenant_identifier: "tnt_test",
       patient_identifier: "pt_01H8X"
     )
-    post_token(launch: ctx.launch_token)
+    post_token({ launch: ctx.launch_token })
     body = JSON.parse(response.body)
     assert_equal "Bearer", body["token_type"]
   end
@@ -98,5 +101,21 @@ class Lakeraven::EHR::Smart::TokensControllerTest < ActionDispatch::IntegrationT
     assert body["expires_in"].present?
     assert_equal "Bearer", body["token_type"]
     assert body["scope"].include?("system/Patient.read")
+  end
+
+  test "launch token from another tenant does not embed patient context" do
+    # Regression: a launch token minted in tnt_other must not embed
+    # its patient into a token response issued on tnt_test's surface.
+    # The resolver reads the request's tenant; LaunchContext.resolve
+    # enforces the binding.
+    ctx = Lakeraven::EHR::LaunchContext.mint(
+      tenant_identifier: "tnt_other",
+      patient_identifier: "pt_foreign"
+    )
+    post_token({ launch: ctx.launch_token }, tenant: "tnt_test")
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert body["access_token"].present?
+    refute body.key?("patient"), "expected no patient field on cross-tenant launch"
   end
 end

--- a/test/lakeraven/ehr/smart/tokens_controller_test.rb
+++ b/test/lakeraven/ehr/smart/tokens_controller_test.rb
@@ -30,6 +30,15 @@ class Lakeraven::EHR::Smart::TokensControllerTest < ActionDispatch::IntegrationT
          headers: headers
   end
 
+  def mint_for_client(**overrides)
+    Lakeraven::EHR::LaunchContext.mint(
+      tenant_identifier: "tnt_test",
+      oauth_application_uid: @client.uid,
+      patient_identifier: "pt_01H8X",
+      **overrides
+    )
+  end
+
   test "client_credentials without launch returns a normal token response" do
     post_token
     assert_response :ok
@@ -39,10 +48,7 @@ class Lakeraven::EHR::Smart::TokensControllerTest < ActionDispatch::IntegrationT
   end
 
   test "client_credentials with a valid launch token embeds patient in the response" do
-    ctx = Lakeraven::EHR::LaunchContext.mint(
-      tenant_identifier: "tnt_test",
-      patient_identifier: "pt_01H8X"
-    )
+    ctx = mint_for_client
     post_token({ launch: ctx.launch_token })
     assert_response :ok
     body = JSON.parse(response.body)
@@ -59,11 +65,7 @@ class Lakeraven::EHR::Smart::TokensControllerTest < ActionDispatch::IntegrationT
   end
 
   test "client_credentials with an expired launch token returns the token without patient" do
-    ctx = Lakeraven::EHR::LaunchContext.mint(
-      tenant_identifier: "tnt_test",
-      patient_identifier: "pt_01H8X",
-      ttl: 1.minute
-    )
+    ctx = mint_for_client(ttl: 1.minute)
     travel_to(Time.current + 5.minutes) do
       post_token({ launch: ctx.launch_token })
       assert_response :ok
@@ -73,11 +75,7 @@ class Lakeraven::EHR::Smart::TokensControllerTest < ActionDispatch::IntegrationT
   end
 
   test "client_credentials with launch context including encounter embeds both" do
-    ctx = Lakeraven::EHR::LaunchContext.mint(
-      tenant_identifier: "tnt_test",
-      patient_identifier: "pt_01H8X",
-      encounter_identifier: "enc_01H8Y"
-    )
+    ctx = mint_for_client(encounter_identifier: "enc_01H8Y")
     post_token({ launch: ctx.launch_token })
     assert_response :ok
     body = JSON.parse(response.body)
@@ -86,10 +84,7 @@ class Lakeraven::EHR::Smart::TokensControllerTest < ActionDispatch::IntegrationT
   end
 
   test "token_type is preserved as Bearer when launch is embedded" do
-    ctx = Lakeraven::EHR::LaunchContext.mint(
-      tenant_identifier: "tnt_test",
-      patient_identifier: "pt_01H8X"
-    )
+    ctx = mint_for_client
     post_token({ launch: ctx.launch_token })
     body = JSON.parse(response.body)
     assert_equal "Bearer", body["token_type"]
@@ -104,12 +99,11 @@ class Lakeraven::EHR::Smart::TokensControllerTest < ActionDispatch::IntegrationT
   end
 
   test "launch token from another tenant does not embed patient context" do
-    # Regression: a launch token minted in tnt_other must not embed
-    # its patient into a token response issued on tnt_test's surface.
-    # The resolver reads the request's tenant; LaunchContext.resolve
-    # enforces the binding.
+    # Cross-tenant: a launch minted in tnt_other can't bleed its
+    # patient into a token issued on tnt_test's surface.
     ctx = Lakeraven::EHR::LaunchContext.mint(
       tenant_identifier: "tnt_other",
+      oauth_application_uid: @client.uid,
       patient_identifier: "pt_foreign"
     )
     post_token({ launch: ctx.launch_token }, tenant: "tnt_test")
@@ -117,5 +111,52 @@ class Lakeraven::EHR::Smart::TokensControllerTest < ActionDispatch::IntegrationT
     body = JSON.parse(response.body)
     assert body["access_token"].present?
     refute body.key?("patient"), "expected no patient field on cross-tenant launch"
+  end
+
+  test "launch token bound to a different client does not embed patient context" do
+    # Cross-client: a launch minted for app B is useless when redeemed
+    # by app A even if both belong to the same tenant.
+    other_client = Doorkeeper::Application.create!(
+      name: "other client",
+      redirect_uri: "https://example.test/callback",
+      scopes: "system/Patient.read launch/patient",
+      confidential: true
+    )
+    ctx = Lakeraven::EHR::LaunchContext.mint(
+      tenant_identifier: "tnt_test",
+      oauth_application_uid: other_client.uid,
+      patient_identifier: "pt_foreign"
+    )
+    post_token({ launch: ctx.launch_token })
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert body["access_token"].present?
+    refute body.key?("patient"), "expected no patient field on cross-client launch"
+  end
+
+  test "launch token is single-use: a replay returns the token without patient context" do
+    ctx = mint_for_client
+
+    post_token({ launch: ctx.launch_token })
+    first_body = JSON.parse(response.body)
+    assert_equal "pt_01H8X", first_body["patient"]
+
+    post_token({ launch: ctx.launch_token })
+    second_body = JSON.parse(response.body)
+    assert second_body["access_token"].present?
+    refute second_body.key?("patient"), "second redemption must not return patient context"
+  end
+
+  test "missing tenant header drops the launch context but still issues a token" do
+    ctx = mint_for_client
+    post_token({ launch: ctx.launch_token }, tenant: nil)
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert body["access_token"].present?
+    refute body.key?("patient")
+    # Single-use guarantee: with no tenant, we don't even attempt
+    # the resolve, so the context stays unconsumed and a follow-up
+    # request with the right tenant header still gets the patient.
+    assert_nil ctx.reload.consumed_at
   end
 end

--- a/test/lakeraven/ehr/smart/tokens_controller_test.rb
+++ b/test/lakeraven/ehr/smart/tokens_controller_test.rb
@@ -5,6 +5,8 @@ require "test_helper"
 class Lakeraven::EHR::Smart::TokensControllerTest < ActionDispatch::IntegrationTest
   setup do
     Lakeraven::EHR::LaunchContext.delete_all
+    Doorkeeper::AccessToken.delete_all
+    Doorkeeper::AccessGrant.delete_all
     Doorkeeper::Application.delete_all
 
     @client = Doorkeeper::Application.create!(

--- a/test/lakeraven/ehr/smart_authentication_test.rb
+++ b/test/lakeraven/ehr/smart_authentication_test.rb
@@ -23,6 +23,11 @@ class SmartAuthTestController < ::ActionController::API
     return unless authorize_scope!("patient/Patient.write")
     render json: { ok: true }
   end
+
+  def patient_context
+    return unless authorize_patient_context!(params[:identifier])
+    render json: { ok: true, identifier: params[:identifier] }
+  end
 end
 
 class Lakeraven::EHR::SmartAuthenticationTest < ActionDispatch::IntegrationTest
@@ -32,6 +37,7 @@ class Lakeraven::EHR::SmartAuthenticationTest < ActionDispatch::IntegrationTest
       get "/_smart_auth_test/show", to: "smart_auth_test#show"
       get "/_smart_auth_test/patient_read", to: "smart_auth_test#patient_read"
       get "/_smart_auth_test/patient_write", to: "smart_auth_test#patient_write"
+      get "/_smart_auth_test/patient_context/:identifier", to: "smart_auth_test#patient_context"
     end
 
     @client = Doorkeeper::Application.create!(
@@ -163,5 +169,50 @@ class Lakeraven::EHR::SmartAuthenticationTest < ActionDispatch::IntegrationTest
     token = issue_token(scopes: "patient/*.*")
     get "/_smart_auth_test/patient_write", headers: bearer(token)
     assert_response :ok
+  end
+
+  # -- authorize_patient_context! --------------------------------------------
+
+  def issue_patient_token(patient_identifier:, scopes: "patient/Patient.read")
+    Doorkeeper::AccessToken.create!(
+      application: @client,
+      resource_owner_id: patient_identifier,
+      scopes: scopes,
+      expires_in: 3600
+    )
+  end
+
+  test "authorize_patient_context! grants access when token patient matches request" do
+    token = issue_patient_token(patient_identifier: "pt_01H8X")
+    get "/_smart_auth_test/patient_context/pt_01H8X", headers: bearer(token)
+    assert_response :ok
+  end
+
+  test "authorize_patient_context! returns 403 forbidden on patient mismatch" do
+    token = issue_patient_token(patient_identifier: "pt_01H8X")
+    get "/_smart_auth_test/patient_context/pt_other", headers: bearer(token)
+    assert_response :forbidden
+    body = JSON.parse(response.body)
+    assert_equal "forbidden", body["issue"].first["code"]
+  end
+
+  test "authorize_patient_context! bypasses the check for system tokens" do
+    token = issue_token(scopes: "system/Patient.read")
+    get "/_smart_auth_test/patient_context/pt_01H8X", headers: bearer(token)
+    assert_response :ok
+  end
+
+  test "authorize_patient_context! bypasses the check for user tokens" do
+    token = issue_token(scopes: "user/Patient.read")
+    get "/_smart_auth_test/patient_context/pt_01H8X", headers: bearer(token)
+    assert_response :ok
+  end
+
+  test "authorize_patient_context! returns 403 when patient scope token has no bound patient" do
+    token = issue_patient_token(patient_identifier: "")
+    get "/_smart_auth_test/patient_context/pt_01H8X", headers: bearer(token)
+    assert_response :forbidden
+    body = JSON.parse(response.body)
+    assert_equal "forbidden", body["issue"].first["code"]
   end
 end


### PR DESCRIPTION
## Summary

Adds the SMART EHR launch flow. Closes #53.

- **`Lakeraven::EHR::LaunchContext`** model — host applications mint a launch token bound to a patient (and optionally encounter) inside a tenant. Opaque `lc_*` token, 10-minute default TTL, unique-indexed.
- **`Smart::TokensController`** extends `Doorkeeper::TokensController` to embed `patient` (and `encounter`) into the JSON token response when the request includes a `launch` parameter that resolves to an active context.
- Routes updated to point `/oauth/token` at the engine's custom controller.

## Flow

1. Host application chooses a patient and calls `Lakeraven::EHR::LaunchContext.mint(tenant_identifier:, patient_identifier:)`
2. Host redirects user-agent to the SMART app's launch URL with `launch=<token>&iss=<base>`
3. App eventually calls `/oauth/token` with `launch=<token>` alongside the OAuth params
4. The custom tokens controller resolves the launch token and merges `patient: <pt_*>` into the response

## Architecture notes

- The launch token is a server-side opaque reference, not a self-describing payload. Stateful binding makes the engine resistant to launch-context confusion attacks (a stateless launch parameter that isn't signed can be forged to bind any patient).
- The host application owns the choice of patient. The engine just persists the binding and embeds it.
- Per ADR 0002, no PHI in the LaunchContext row — just the opaque `pt_*` token.
- Per ADR 0003, every LaunchContext is tenant-scoped via `tenant_identifier`.

## Test plan

- [x] `bundle exec rake test` — 138 runs, 266 assertions, 0 failures
- [x] `bundle exec cucumber` — 33 scenarios, all passed
- [x] `bundle exec rubocop` — 51 files, no offenses
- [ ] CI green on GitHub Actions

## Commits

1. Add `LaunchContext` model + 13 unit tests
2. Embed SMART launch context in token response (custom `Smart::TokensController` + 7 integration tests)
3. Add `smart_ehr_launch` Cucumber feature (5 scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)