### PR TITLE
Add Patient model, PatientName, expanded FHIR serializer + deserializer

### DIFF
--- a/app/models/lakeraven/ehr/patient.rb
+++ b/app/models/lakeraven/ehr/patient.rb
@@ -105,8 +105,8 @@ module Lakeraven
         FHIR::PatientSerializer.call(to_serializer_hash)
       end
 
-      def self.from_fhir_attributes(fhir_resource)
-        FHIR::PatientDeserializer.call(fhir_resource)
+      def self.from_fhir(fhir_resource)
+        new(**FHIR::PatientDeserializer.call(fhir_resource))
       end
 
       def to_param

--- a/app/models/lakeraven/ehr/patient.rb
+++ b/app/models/lakeraven/ehr/patient.rb
@@ -8,16 +8,20 @@ module Lakeraven
     # This is the canonical Patient for lakeraven-ehr host apps. It provides:
     # - RPMS/VistA attribute set (DFN, name in LAST,FIRST format, etc.)
     # - Composite field syncing (name ↔ first_name/last_name, dob ↔ born_on)
-    # - FHIR R4 serialization via Fhir::PatientSerializer
-    # - FHIR R4 deserialization via Fhir::PatientDeserializer
+    # - FHIR R4 serialization via FHIR::PatientSerializer
+    # - FHIR R4 deserialization via FHIR::PatientDeserializer
     # - US Core race/ethnicity + IHS tribal + SOGI extensions
     #
-    # Host apps (rpms_redux, lakeraven-ehr-saas) subclass this to wire
-    # gateway persistence and host-specific behavior.
+    # Host apps subclass this to wire gateway persistence and
+    # host-specific behavior.
     class Patient
       include ActiveModel::Model
       include ActiveModel::Attributes
       include ActiveModel::Validations
+
+      # Opaque identifier per ADR 0004. Set by the adapter; not derived
+      # from dfn or any backend-native key.
+      attribute :patient_identifier, :string
 
       # RPMS/VistA core demographics
       attribute :dfn, :integer
@@ -106,14 +110,14 @@ module Lakeraven
       end
 
       def to_param
-        dfn.to_s
+        patient_identifier || dfn.to_s
       end
 
       private
 
       def to_serializer_hash
         {
-          patient_identifier: dfn.present? ? "rpms-#{dfn}" : nil,
+          patient_identifier: patient_identifier || dfn&.to_s,
           display_name: name,
           date_of_birth: dob || birth_date,
           gender: gender || sex,

--- a/app/models/lakeraven/ehr/patient.rb
+++ b/app/models/lakeraven/ehr/patient.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # Clinical patient identity model. ActiveModel-based (no database) —
+    # demographics flow through the configured adapter at request time.
+    #
+    # This is the canonical Patient for lakeraven-ehr host apps. It provides:
+    # - RPMS/VistA attribute set (DFN, name in LAST,FIRST format, etc.)
+    # - Composite field syncing (name ↔ first_name/last_name, dob ↔ born_on)
+    # - FHIR R4 serialization via Fhir::PatientSerializer
+    # - FHIR R4 deserialization via Fhir::PatientDeserializer
+    # - US Core race/ethnicity + IHS tribal + SOGI extensions
+    #
+    # Host apps (rpms_redux, lakeraven-ehr-saas) subclass this to wire
+    # gateway persistence and host-specific behavior.
+    class Patient
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Validations
+
+      # RPMS/VistA core demographics
+      attribute :dfn, :integer
+      attribute :name, :string
+      attribute :ssn, :string
+      attribute :dob, :date
+      attribute :sex, :string
+      attribute :gender, :string
+      attribute :age, :integer
+      attribute :race, :string
+      attribute :address, :string
+      attribute :address_line1, :string
+      attribute :city, :string
+      attribute :state, :string
+      attribute :zip_code, :string
+      attribute :phone, :string
+
+      # Derived name parts (synced with name)
+      attribute :first_name, :string
+      attribute :last_name, :string
+      attribute :born_on, :date
+      attribute :birth_date, :date
+
+      # IHS/PRC fields
+      attribute :tribal_affiliation, :string
+      attribute :tribal_enrollment_number, :string
+      attribute :service_area, :string
+      attribute :coverage_type, :string
+
+      # SOGI (USCDI v3 / ONC §170.315(a)(15))
+      attribute :sexual_orientation, :string
+      attribute :gender_identity, :string
+
+      validates :sex, inclusion: { in: %w[M F U] }, allow_nil: true
+
+      def initialize(attributes = {})
+        super
+        sync_composite_fields
+      end
+
+      # ----------------------------------------------------------------
+      # Composite field syncing
+      # ----------------------------------------------------------------
+
+      def sync_composite_fields
+        self.born_on ||= dob
+        self.dob ||= born_on
+
+        if first_name.present? && last_name.present? && name.blank?
+          self.name = "#{last_name},#{first_name}"
+        end
+
+        if name.present? && first_name.blank? && last_name.blank?
+          pn = patient_name
+          self.last_name = pn.last_name
+          self.first_name = pn.first_name
+        end
+      end
+
+      # ----------------------------------------------------------------
+      # Name formatting (delegates to PatientName value object)
+      # ----------------------------------------------------------------
+
+      def patient_name
+        PatientName.new(name: name, first_name: first_name, last_name: last_name)
+      end
+
+      def display_name
+        patient_name.display
+      end
+
+      def formal_name
+        patient_name.formal
+      end
+
+      # ----------------------------------------------------------------
+      # FHIR serialization
+      # ----------------------------------------------------------------
+
+      def to_fhir
+        FHIR::PatientSerializer.call(to_serializer_hash)
+      end
+
+      def self.from_fhir_attributes(fhir_resource)
+        FHIR::PatientDeserializer.call(fhir_resource)
+      end
+
+      def to_param
+        dfn.to_s
+      end
+
+      private
+
+      def to_serializer_hash
+        {
+          patient_identifier: dfn.present? ? "rpms-#{dfn}" : nil,
+          display_name: name,
+          date_of_birth: dob || birth_date,
+          gender: gender || sex,
+          dfn: dfn,
+          ssn: ssn,
+          address_line1: address_line1 || address,
+          city: city,
+          state: state,
+          zip_code: zip_code,
+          phone: phone,
+          race: race,
+          tribal_affiliation: tribal_affiliation,
+          tribal_enrollment_number: tribal_enrollment_number,
+          sexual_orientation: sexual_orientation,
+          gender_identity: gender_identity,
+          identifiers: []
+        }
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/patient_name.rb
+++ b/app/models/lakeraven/ehr/patient_name.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # Value object for VistA-style patient names. Parses "LAST,FIRST MI"
+    # and provides display/formal/FHIR formatting. Immutable after
+    # construction — use a new instance when the name changes.
+    #
+    # Accepts either VistA format (name:) or separate parts
+    # (first_name:, last_name:). If both are given, vista name wins.
+    class PatientName
+      attr_reader :family, :given, :text
+
+      def initialize(name: nil, first_name: nil, last_name: nil)
+        if name.present? && name.include?(",")
+          parts = name.split(",", 2)
+          @family = parts[0]&.strip
+          given_str = parts[1]&.strip
+          @given = given_str.present? ? given_str.split(/\s+/) : []
+          @text = name
+        elsif first_name.present? || last_name.present?
+          @family = last_name.to_s.strip.presence
+          @given = first_name.present? ? [ first_name.to_s.strip ] : []
+          @text = [ @family, @given.first ].compact.join(",")
+        else
+          @family = nil
+          @given = []
+          @text = name.to_s
+        end
+        freeze
+      end
+
+      # "John Doe" — UI display
+      def display
+        parts = []
+        parts << given.map(&:capitalize).join(" ") if given.any?
+        parts << family&.capitalize if family.present?
+        parts.join(" ").presence || text
+      end
+
+      # "Doe, John A" — clinical documents
+      def formal
+        return text unless family.present?
+
+        capitalized_family = family.capitalize
+        if given.any?
+          capitalized_given = given.map(&:capitalize).join(" ")
+          "#{capitalized_family}, #{capitalized_given}"
+        else
+          capitalized_family
+        end
+      end
+
+      # "DOE,JOHN A" — VistA/MUMPS format
+      def vista_format
+        text
+      end
+
+      # Derived first_name (first given name)
+      def first_name
+        given.first&.capitalize
+      end
+
+      # Derived last_name (family name, capitalized)
+      def last_name
+        family&.capitalize
+      end
+
+      # FHIR HumanName hash
+      def to_fhir
+        return { text: text } unless family.present?
+        result = { use: "official", family: family, given: given }
+        result[:text] = text if text.present?
+        result
+      end
+    end
+  end
+end

--- a/app/services/lakeraven/ehr/fhir/patient_deserializer.rb
+++ b/app/services/lakeraven/ehr/fhir/patient_deserializer.rb
@@ -38,7 +38,14 @@ module Lakeraven
           family = dig_from(name_obj, :family)
           given = dig_from(name_obj, :given)
           given_str = given.is_a?(Array) ? given.join(" ") : given
-          given_str.present? ? "#{family},#{given_str}" : family
+
+          if family.present? && given_str.present?
+            "#{family},#{given_str}"
+          elsif family.present?
+            family
+          elsif given_str.present?
+            given_str
+          end
         end
 
         def extract_birth_date
@@ -56,11 +63,13 @@ module Lakeraven
           end
         end
 
+        SSN_SYSTEM = "http://hl7.org/fhir/sid/us-ssn"
+
         def extract_ssn
           ids = dig(:identifier)
           return nil unless ids.is_a?(Array)
 
-          ssn_id = ids.find { |id| dig_from(id, :system).to_s.include?("ssn") }
+          ssn_id = ids.find { |id| dig_from(id, :system).to_s == SSN_SYSTEM }
           dig_from(ssn_id, :value)
         end
 

--- a/app/services/lakeraven/ehr/fhir/patient_deserializer.rb
+++ b/app/services/lakeraven/ehr/fhir/patient_deserializer.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    module FHIR
+      # Extracts Patient attributes from a FHIR R4 Patient resource (Hash
+      # or object with dot-access). Returns a plain Hash suitable for
+      # Patient.new(attrs).
+      class PatientDeserializer
+        def self.call(fhir_resource)
+          new(fhir_resource).extract
+        end
+
+        def initialize(fhir_resource)
+          @r = fhir_resource
+        end
+
+        def extract
+          {
+            name: extract_name,
+            dob: extract_birth_date,
+            birth_date: extract_birth_date,
+            sex: map_gender_to_sex,
+            ssn: extract_ssn
+          }.compact
+        end
+
+        private
+
+        def extract_name
+          names = dig(:name)
+          return nil unless names.is_a?(Array) && names.any?
+
+          name_obj = names.first
+          text = dig_from(name_obj, :text)
+          return text if text.present?
+
+          family = dig_from(name_obj, :family)
+          given = dig_from(name_obj, :given)
+          given_str = given.is_a?(Array) ? given.join(" ") : given
+          given_str.present? ? "#{family},#{given_str}" : family
+        end
+
+        def extract_birth_date
+          val = dig(:birthDate)
+          val.present? ? Date.parse(val.to_s) : nil
+        rescue Date::Error
+          nil
+        end
+
+        def map_gender_to_sex
+          case dig(:gender).to_s.downcase
+          when "male" then "M"
+          when "female" then "F"
+          else "U"
+          end
+        end
+
+        def extract_ssn
+          ids = dig(:identifier)
+          return nil unless ids.is_a?(Array)
+
+          ssn_id = ids.find { |id| dig_from(id, :system).to_s.include?("ssn") }
+          dig_from(ssn_id, :value)
+        end
+
+        # Flexible accessor: supports both Hash (symbol/string) and
+        # dot-access objects (OpenStruct, FHIR models).
+        def dig(key)
+          if @r.is_a?(Hash)
+            @r[key.to_sym] || @r[key.to_s]
+          elsif @r.respond_to?(key)
+            @r.send(key)
+          end
+        end
+
+        def dig_from(obj, key)
+          return nil unless obj
+          if obj.is_a?(Hash)
+            obj[key.to_sym] || obj[key.to_s]
+          elsif obj.respond_to?(key)
+            obj.send(key)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/lakeraven/ehr/fhir/patient_serializer.rb
+++ b/app/services/lakeraven/ehr/fhir/patient_serializer.rb
@@ -77,17 +77,18 @@ module Lakeraven
         # Gender
         # ----------------------------------------------------------------
 
+        # FHIR R4 administrative-gender: male | female | other | unknown.
+        # VistA/RPMS uses single-char M/F/U — map those to FHIR codes.
+        # Anything already in the FHIR code set passes through; anything
+        # else normalizes to "unknown" so the resource always validates.
         def gender_value
           raw = (@record[:gender] || @record[:sex]).to_s
-          case raw.upcase
-          when "M" then "male"
-          when "F" then "female"
-          when "MALE" then "male"
-          when "FEMALE" then "female"
-          when "OTHER" then "other"
-          else
-            %w[male female other unknown].include?(raw) ? raw : "unknown"
-          end
+          # VistA single-char codes
+          return "male" if raw == "M"
+          return "female" if raw == "F"
+          # Already FHIR-compliant (lowercase)
+          return raw if %w[male female other unknown].include?(raw)
+          "unknown"
         end
 
         # ----------------------------------------------------------------

--- a/app/services/lakeraven/ehr/fhir/patient_serializer.rb
+++ b/app/services/lakeraven/ehr/fhir/patient_serializer.rb
@@ -4,19 +4,30 @@ module Lakeraven
   module EHR
     module FHIR
       # Serializes an adapter patient hash to a US Core conformant
-      # FHIR R4 Patient resource.
+      # FHIR R4 Patient resource with IHS tribal and SOGI extensions.
       #
-      # The input is the public_view shape returned by Adapters::Base
-      # implementations: opaque patient_identifier, display_name in
-      # "FAMILY,GIVEN" form, date_of_birth, gender, identifiers array.
+      # The input is a Hash with symbol keys matching the adapter's
+      # public_view shape. All keys are optional except :display_name.
       #
-      # The output is a Hash whose keys are symbols matching the FHIR
-      # JSON shape; the controller renders it as application/fhir+json.
-      #
-      # No PHI persistence happens here per ADR 0002 — this serializer
-      # is pure: hash in, hash out.
+      # No PHI persistence happens here per ADR 0002 — pure transform.
       class PatientSerializer
         US_CORE_PROFILE = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+
+        # CDC Race & Ethnicity code system OID
+        RACE_CODE_SYSTEM = "urn:oid:2.16.840.1.113883.6.238"
+
+        RACE_CODE_MAP = {
+          "AMERICAN INDIAN OR ALASKA NATIVE" => { code: "1002-5", display: "American Indian or Alaska Native" },
+          "AMERICAN INDIAN" => { code: "1002-5", display: "American Indian or Alaska Native" },
+          "ALASKA NATIVE" => { code: "1002-5", display: "American Indian or Alaska Native" },
+          "ASIAN" => { code: "2028-9", display: "Asian" },
+          "BLACK OR AFRICAN AMERICAN" => { code: "2054-5", display: "Black or African American" },
+          "BLACK" => { code: "2054-5", display: "Black or African American" },
+          "NATIVE HAWAIIAN OR OTHER PACIFIC ISLANDER" => { code: "2076-8", display: "Native Hawaiian or Other Pacific Islander" },
+          "WHITE" => { code: "2106-3", display: "White" },
+          "OTHER" => { code: "2131-1", display: "Other Race" },
+          "UNKNOWN" => { code: "UNK", display: "Unknown" }
+        }.freeze
 
         def self.call(record)
           new(record).to_h
@@ -35,43 +46,161 @@ module Lakeraven
             gender: gender_value
           }
           resource[:birthDate] = format_date(@record[:date_of_birth]) if @record[:date_of_birth]
+
           identifiers = build_identifiers
           resource[:identifier] = identifiers if identifiers.any?
+
+          addresses = build_addresses
+          resource[:address] = addresses if addresses.any?
+
+          telecoms = build_telecoms
+          resource[:telecom] = telecoms if telecoms.any?
+
+          extensions = build_extensions
+          resource[:extension] = extensions if extensions.any?
+
           resource
         end
 
         private
 
-        # Parses VistA-style "FAMILY,GIVEN MIDDLE" into a FHIR HumanName.
-        # Falls back to a single text element when the value doesn't
-        # contain a comma — handles mononyms and adapter-supplied names
-        # we don't recognize the format of.
+        # ----------------------------------------------------------------
+        # Name
+        # ----------------------------------------------------------------
+
         def build_name
-          display = @record[:display_name].to_s
-          return { text: display } unless display.include?(",")
-
-          family, rest = display.split(",", 2)
-          given = rest.to_s.strip.split(/\s+/).reject(&:empty?)
-          { family: family, given: given }
+          pn = PatientName.new(name: @record[:display_name])
+          pn.to_fhir
         end
 
-        # FHIR R4 administrative-gender code set: male | female | other |
-        # unknown. The adapter is expected to supply one of these; if
-        # something else (or nil) comes through, render as "unknown" so
-        # the resource is still valid.
+        # ----------------------------------------------------------------
+        # Gender
+        # ----------------------------------------------------------------
+
         def gender_value
-          value = @record[:gender].to_s
-          %w[male female other unknown].include?(value) ? value : "unknown"
+          raw = (@record[:gender] || @record[:sex]).to_s
+          case raw.upcase
+          when "M" then "male"
+          when "F" then "female"
+          when "MALE" then "male"
+          when "FEMALE" then "female"
+          when "OTHER" then "other"
+          else
+            %w[male female other unknown].include?(raw) ? raw : "unknown"
+          end
         end
+
+        # ----------------------------------------------------------------
+        # Identifiers
+        # ----------------------------------------------------------------
+
+        def build_identifiers
+          ids = (@record[:identifiers] || []).map do |id|
+            { system: id[:system], value: id[:value] }
+          end
+
+          # DFN identifiers (VA OID + IHS system)
+          if @record[:dfn].present?
+            ids << { use: "usual",
+                     system: "urn:oid:2.16.840.1.113883.4.349",
+                     value: @record[:dfn].to_s }
+            ids << { use: "official",
+                     system: "http://ihs.gov/rpms/patient-id",
+                     value: @record[:dfn].to_s }
+          end
+
+          # SSN
+          if @record[:ssn].present?
+            ids << { use: "secondary",
+                     system: "http://hl7.org/fhir/sid/us-ssn",
+                     value: @record[:ssn] }
+          end
+
+          ids
+        end
+
+        # ----------------------------------------------------------------
+        # Address
+        # ----------------------------------------------------------------
+
+        def build_addresses
+          addr = @record[:address_line1]
+          return [] if addr.blank?
+
+          [ { use: "home",
+              line: [ addr ],
+              city: @record[:city],
+              state: @record[:state],
+              postalCode: @record[:zip_code],
+              country: "US" }.compact ]
+        end
+
+        # ----------------------------------------------------------------
+        # Telecom
+        # ----------------------------------------------------------------
+
+        def build_telecoms
+          return [] if @record[:phone].blank?
+
+          [ { system: "phone", value: @record[:phone], use: "home" } ]
+        end
+
+        # ----------------------------------------------------------------
+        # Extensions
+        # ----------------------------------------------------------------
+
+        def build_extensions
+          exts = []
+
+          exts << build_us_core_race if @record[:race].present?
+          exts << build_us_core_ethnicity
+          exts << simple_extension("https://ihs.gov/fhir/StructureDefinition/tribal-affiliation",
+            @record[:tribal_affiliation])
+          exts << simple_extension("https://ihs.gov/fhir/StructureDefinition/tribal-enrollment-number",
+            @record[:tribal_enrollment_number])
+          exts << simple_extension("http://hl7.org/fhir/StructureDefinition/patient-sexualOrientation",
+            @record[:sexual_orientation])
+          exts << simple_extension("http://hl7.org/fhir/StructureDefinition/patient-genderIdentity",
+            @record[:gender_identity])
+
+          exts.compact
+        end
+
+        def build_us_core_race
+          race_upper = @record[:race].to_s.upcase.strip
+          mapped = RACE_CODE_MAP[race_upper]
+
+          sub = []
+          if mapped
+            sub << { url: "ombCategory",
+                     valueCoding: { system: RACE_CODE_SYSTEM,
+                                    code: mapped[:code],
+                                    display: mapped[:display] } }
+            sub << { url: "text", valueString: mapped[:display] }
+          else
+            sub << { url: "text", valueString: @record[:race] }
+          end
+
+          { url: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+            extension: sub }
+        end
+
+        def build_us_core_ethnicity
+          { url: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+            extension: [ { url: "text", valueString: "Unknown" } ] }
+        end
+
+        def simple_extension(url, value)
+          return nil if value.blank?
+          { url: url, valueString: value }
+        end
+
+        # ----------------------------------------------------------------
+        # Utilities
+        # ----------------------------------------------------------------
 
         def format_date(date)
           date.is_a?(Date) ? date.iso8601 : Date.parse(date.to_s).iso8601
-        end
-
-        def build_identifiers
-          (@record[:identifiers] || []).map do |id|
-            { system: id[:system], value: id[:value] }
-          end
         end
       end
     end

--- a/features/patient_model.feature
+++ b/features/patient_model.feature
@@ -15,6 +15,13 @@ Feature: Patient clinical identity model
     And the patient display_name should be "John A Doe"
     And the patient formal_name should be "Doe, John A"
 
+  Scenario: Create a patient from a single-token name (no comma)
+    Given a patient with name "CHER"
+    Then the patient display_name should be "CHER"
+    And the patient formal_name should be "CHER"
+    And the patient first_name should be blank
+    And the patient last_name should be blank
+
   Scenario: Create a patient from separate name parts
     Given a patient with first_name "Jane" and last_name "Smith"
     Then the patient name should be "Smith,Jane"
@@ -38,10 +45,10 @@ Feature: Patient clinical identity model
     And the FHIR name given should include "JOHN"
 
   Scenario: to_fhir includes DFN and SSN identifiers
-    Given a patient with dfn 12345 and ssn "123-45-6789"
+    Given a patient with dfn 12345 and ssn "000-00-0000"
     When I serialize the patient to FHIR
     Then the FHIR identifiers should include system "urn:oid:2.16.840.1.113883.4.349" with value "12345"
-    And the FHIR identifiers should include system "http://hl7.org/fhir/sid/us-ssn" with value "123-45-6789"
+    And the FHIR identifiers should include system "http://hl7.org/fhir/sid/us-ssn" with value "000-00-0000"
 
   Scenario: to_fhir includes address and telecom
     Given a patient with address "123 Main St" city "Toppenish" state "WA" zip "98948" phone "555-1234"
@@ -98,9 +105,11 @@ Feature: Patient clinical identity model
   # FHIR DESERIALIZATION
   # ===========================================================================
 
-  Scenario: from_fhir_attributes extracts demographics
+  Scenario: from_fhir builds a Patient from a FHIR resource
     Given a FHIR Patient resource with family "DOE" given "JOHN" gender "male" birthDate "1980-01-15"
-    When I extract attributes from the FHIR resource
-    Then the extracted name should be "DOE,JOHN"
+    When I build a patient from the FHIR resource
+    Then the patient name should be "DOE,JOHN"
+    And the patient last_name should be "Doe"
+    And the patient first_name should be "John"
     And the extracted sex should be "M"
     And the extracted dob should be "1980-01-15"

--- a/features/patient_model.feature
+++ b/features/patient_model.feature
@@ -1,0 +1,106 @@
+Feature: Patient clinical identity model
+  As a clinical application
+  I need a Patient model that stores demographics, formats names, and
+  serializes to FHIR R4 with US Core + IHS extensions
+  So that I can interoperate with EHRs per ONC § 170.315(g)(10)
+
+  # ===========================================================================
+  # ATTRIBUTES AND COMPOSITE FIELD SYNCING
+  # ===========================================================================
+
+  Scenario: Create a patient from VistA name format
+    Given a patient with name "DOE,JOHN A"
+    Then the patient last_name should be "Doe"
+    And the patient first_name should be "John"
+    And the patient display_name should be "John A Doe"
+    And the patient formal_name should be "Doe, John A"
+
+  Scenario: Create a patient from separate name parts
+    Given a patient with first_name "Jane" and last_name "Smith"
+    Then the patient name should be "Smith,Jane"
+    And the patient display_name should be "Jane Smith"
+
+  Scenario: Patient syncs dob and born_on
+    Given a patient with dob "1980-01-15"
+    Then the patient born_on should be "1980-01-15"
+
+  # ===========================================================================
+  # FHIR SERIALIZATION — US Core Patient
+  # ===========================================================================
+
+  Scenario: to_fhir emits a US Core Patient resource
+    Given a patient with name "DOE,JOHN" and dob "1980-01-15" and sex "M"
+    When I serialize the patient to FHIR
+    Then the FHIR resourceType should be "Patient"
+    And the FHIR gender should be "male"
+    And the FHIR birthDate should be "1980-01-15"
+    And the FHIR name family should be "DOE"
+    And the FHIR name given should include "JOHN"
+
+  Scenario: to_fhir includes DFN and SSN identifiers
+    Given a patient with dfn 12345 and ssn "123-45-6789"
+    When I serialize the patient to FHIR
+    Then the FHIR identifiers should include system "urn:oid:2.16.840.1.113883.4.349" with value "12345"
+    And the FHIR identifiers should include system "http://hl7.org/fhir/sid/us-ssn" with value "123-45-6789"
+
+  Scenario: to_fhir includes address and telecom
+    Given a patient with address "123 Main St" city "Toppenish" state "WA" zip "98948" phone "555-1234"
+    When I serialize the patient to FHIR
+    Then the FHIR address line should be "123 Main St"
+    And the FHIR address city should be "Toppenish"
+    And the FHIR telecom value should be "555-1234"
+
+  # ===========================================================================
+  # FHIR EXTENSIONS — US Core Race / Ethnicity
+  # ===========================================================================
+
+  Scenario: to_fhir includes US Core race extension
+    Given a patient with race "AMERICAN INDIAN OR ALASKA NATIVE"
+    When I serialize the patient to FHIR
+    Then the FHIR extensions should include a US Core race extension
+    And the race ombCategory code should be "1002-5"
+
+  Scenario: to_fhir includes US Core ethnicity extension (default unknown)
+    Given a patient with name "DOE,JOHN" and sex "M"
+    When I serialize the patient to FHIR
+    Then the FHIR extensions should include a US Core ethnicity extension
+    And the ethnicity text should be "Unknown"
+
+  # ===========================================================================
+  # FHIR EXTENSIONS — IHS Tribal
+  # ===========================================================================
+
+  Scenario: to_fhir includes tribal affiliation extension
+    Given a patient with tribal_affiliation "Enrolled Member"
+    When I serialize the patient to FHIR
+    Then the FHIR extensions should include url "https://ihs.gov/fhir/StructureDefinition/tribal-affiliation"
+
+  Scenario: to_fhir includes tribal enrollment number extension
+    Given a patient with tribal_enrollment_number "ENR-12345"
+    When I serialize the patient to FHIR
+    Then the FHIR extensions should include url "https://ihs.gov/fhir/StructureDefinition/tribal-enrollment-number"
+
+  # ===========================================================================
+  # FHIR EXTENSIONS — SOGI (USCDI v3)
+  # ===========================================================================
+
+  Scenario: to_fhir includes sexual orientation extension
+    Given a patient with sexual_orientation "Straight or heterosexual"
+    When I serialize the patient to FHIR
+    Then the FHIR extensions should include url "http://hl7.org/fhir/StructureDefinition/patient-sexualOrientation"
+
+  Scenario: to_fhir includes gender identity extension
+    Given a patient with gender_identity "Identifies as male"
+    When I serialize the patient to FHIR
+    Then the FHIR extensions should include url "http://hl7.org/fhir/StructureDefinition/patient-genderIdentity"
+
+  # ===========================================================================
+  # FHIR DESERIALIZATION
+  # ===========================================================================
+
+  Scenario: from_fhir_attributes extracts demographics
+    Given a FHIR Patient resource with family "DOE" given "JOHN" gender "male" birthDate "1980-01-15"
+    When I extract attributes from the FHIR resource
+    Then the extracted name should be "DOE,JOHN"
+    And the extracted sex should be "M"
+    And the extracted dob should be "1980-01-15"

--- a/features/step_definitions/patient_model_steps.rb
+++ b/features/step_definitions/patient_model_steps.rb
@@ -68,6 +68,14 @@ Then("the patient first_name should be {string}") do |expected|
   assert_equal expected, @patient.first_name
 end
 
+Then("the patient first_name should be blank") do
+  assert_nil @patient.first_name
+end
+
+Then("the patient last_name should be blank") do
+  assert_nil @patient.last_name
+end
+
 Then("the patient display_name should be {string}") do |expected|
   assert_equal expected, @patient.display_name
 end
@@ -168,18 +176,14 @@ Given("a FHIR Patient resource with family {string} given {string} gender {strin
   }
 end
 
-When("I extract attributes from the FHIR resource") do
-  @extracted = Lakeraven::EHR::FHIR::PatientDeserializer.call(@fhir_input)
-end
-
-Then("the extracted name should be {string}") do |expected|
-  assert_equal expected, @extracted[:name]
+When("I build a patient from the FHIR resource") do
+  @patient = Lakeraven::EHR::Patient.from_fhir(@fhir_input)
 end
 
 Then("the extracted sex should be {string}") do |expected|
-  assert_equal expected, @extracted[:sex]
+  assert_equal expected, @patient.sex
 end
 
 Then("the extracted dob should be {string}") do |expected|
-  assert_equal Date.parse(expected), @extracted[:dob]
+  assert_equal Date.parse(expected), @patient.dob
 end

--- a/features/step_definitions/patient_model_steps.rb
+++ b/features/step_definitions/patient_model_steps.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+# Patient model step definitions.
+
+def build_patient(**attrs)
+  defaults = { sex: "M" }
+  Lakeraven::EHR::Patient.new(**defaults.merge(attrs))
+end
+
+# ── Creation ──
+
+Given("a patient with name {string}") do |name|
+  @patient = build_patient(name: name)
+end
+
+Given("a patient with first_name {string} and last_name {string}") do |first, last|
+  @patient = build_patient(first_name: first, last_name: last)
+end
+
+Given("a patient with dob {string}") do |dob|
+  @patient = build_patient(name: "TEST,PATIENT", dob: Date.parse(dob))
+end
+
+Given("a patient with name {string} and dob {string} and sex {string}") do |name, dob, sex|
+  @patient = build_patient(name: name, dob: Date.parse(dob), sex: sex)
+end
+
+Given("a patient with dfn {int} and ssn {string}") do |dfn, ssn|
+  @patient = build_patient(name: "TEST,PATIENT", dfn: dfn, ssn: ssn)
+end
+
+Given("a patient with address {string} city {string} state {string} zip {string} phone {string}") do |addr, city, state, zip, phone|
+  @patient = build_patient(name: "TEST,PATIENT", address_line1: addr,
+    city: city, state: state, zip_code: zip, phone: phone)
+end
+
+Given("a patient with race {string}") do |race|
+  @patient = build_patient(name: "TEST,PATIENT", race: race)
+end
+
+Given("a patient with name {string} and sex {string}") do |name, sex|
+  @patient = build_patient(name: name, sex: sex)
+end
+
+Given("a patient with tribal_affiliation {string}") do |value|
+  @patient = build_patient(name: "TEST,PATIENT", tribal_affiliation: value)
+end
+
+Given("a patient with tribal_enrollment_number {string}") do |value|
+  @patient = build_patient(name: "TEST,PATIENT", tribal_enrollment_number: value)
+end
+
+Given("a patient with sexual_orientation {string}") do |value|
+  @patient = build_patient(name: "TEST,PATIENT", sexual_orientation: value)
+end
+
+Given("a patient with gender_identity {string}") do |value|
+  @patient = build_patient(name: "TEST,PATIENT", gender_identity: value)
+end
+
+# ── Attribute assertions ──
+
+Then("the patient last_name should be {string}") do |expected|
+  assert_equal expected, @patient.last_name
+end
+
+Then("the patient first_name should be {string}") do |expected|
+  assert_equal expected, @patient.first_name
+end
+
+Then("the patient display_name should be {string}") do |expected|
+  assert_equal expected, @patient.display_name
+end
+
+Then("the patient formal_name should be {string}") do |expected|
+  assert_equal expected, @patient.formal_name
+end
+
+Then("the patient name should be {string}") do |expected|
+  assert_equal expected, @patient.name
+end
+
+Then("the patient born_on should be {string}") do |expected|
+  assert_equal Date.parse(expected), @patient.born_on
+end
+
+# ── FHIR serialization ──
+
+When("I serialize the patient to FHIR") do
+  @fhir = @patient.to_fhir
+end
+
+Then("the FHIR resourceType should be {string}") do |expected|
+  assert_equal expected, @fhir[:resourceType]
+end
+
+Then("the FHIR gender should be {string}") do |expected|
+  assert_equal expected, @fhir[:gender]
+end
+
+Then("the FHIR birthDate should be {string}") do |expected|
+  assert_equal expected, @fhir[:birthDate]
+end
+
+Then("the FHIR name family should be {string}") do |expected|
+  assert_equal expected, @fhir[:name].first[:family]
+end
+
+Then("the FHIR name given should include {string}") do |expected|
+  assert_includes @fhir[:name].first[:given], expected
+end
+
+Then("the FHIR identifiers should include system {string} with value {string}") do |system, value|
+  match = @fhir[:identifier].find { |id| id[:system] == system && id[:value] == value }
+  refute_nil match, "expected identifier with system=#{system} value=#{value} in #{@fhir[:identifier]}"
+end
+
+Then("the FHIR address line should be {string}") do |expected|
+  assert_equal expected, @fhir[:address].first[:line].first
+end
+
+Then("the FHIR address city should be {string}") do |expected|
+  assert_equal expected, @fhir[:address].first[:city]
+end
+
+Then("the FHIR telecom value should be {string}") do |expected|
+  assert_equal expected, @fhir[:telecom].first[:value]
+end
+
+# ── Extension assertions ──
+
+Then("the FHIR extensions should include a US Core race extension") do
+  url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+  @race_ext = @fhir[:extension].find { |e| e[:url] == url }
+  refute_nil @race_ext, "expected US Core race extension"
+end
+
+Then("the race ombCategory code should be {string}") do |expected|
+  omb = @race_ext[:extension].find { |e| e[:url] == "ombCategory" }
+  refute_nil omb, "expected ombCategory sub-extension"
+  assert_equal expected, omb[:valueCoding][:code]
+end
+
+Then("the FHIR extensions should include a US Core ethnicity extension") do
+  url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+  @eth_ext = @fhir[:extension].find { |e| e[:url] == url }
+  refute_nil @eth_ext, "expected US Core ethnicity extension"
+end
+
+Then("the ethnicity text should be {string}") do |expected|
+  text = @eth_ext[:extension].find { |e| e[:url] == "text" }
+  assert_equal expected, text[:valueString]
+end
+
+Then("the FHIR extensions should include url {string}") do |url|
+  match = @fhir[:extension].find { |e| e[:url] == url }
+  refute_nil match, "expected extension with url=#{url}"
+end
+
+# ── Deserialization ──
+
+Given("a FHIR Patient resource with family {string} given {string} gender {string} birthDate {string}") do |family, given, gender, birth_date|
+  @fhir_input = {
+    resourceType: "Patient",
+    name: [ { family: family, given: [ given ] } ],
+    gender: gender,
+    birthDate: birth_date
+  }
+end
+
+When("I extract attributes from the FHIR resource") do
+  @extracted = Lakeraven::EHR::FHIR::PatientDeserializer.call(@fhir_input)
+end
+
+Then("the extracted name should be {string}") do |expected|
+  assert_equal expected, @extracted[:name]
+end
+
+Then("the extracted sex should be {string}") do |expected|
+  assert_equal expected, @extracted[:sex]
+end
+
+Then("the extracted dob should be {string}") do |expected|
+  assert_equal Date.parse(expected), @extracted[:dob]
+end

--- a/test/lakeraven/ehr/adapters/mock_adapter_test.rb
+++ b/test/lakeraven/ehr/adapters/mock_adapter_test.rb
@@ -113,7 +113,7 @@ class Lakeraven::EHR::Adapters::MockAdapterTest < ActiveSupport::TestCase
     @adapter.seed_patient(
       tenant_identifier: "tnt_test", facility_identifier: "fac_main",
       display_name: "DOE,JOHN", date_of_birth: Date.new(1980, 1, 15), gender: "male",
-      identifiers: [ { system: "http://hl7.org/fhir/sid/us-ssn", value: "123-45-6789" } ]
+      identifiers: [ { system: "http://hl7.org/fhir/sid/us-ssn", value: "000-00-0000" } ]
     )
     @adapter.seed_patient(
       tenant_identifier: "tnt_test", facility_identifier: "fac_main",
@@ -123,7 +123,7 @@ class Lakeraven::EHR::Adapters::MockAdapterTest < ActiveSupport::TestCase
     results = @adapter.search_patients(
       tenant_identifier: "tnt_test",
       identifier_system: "http://hl7.org/fhir/sid/us-ssn",
-      identifier_value: "123-45-6789"
+      identifier_value: "000-00-0000"
     )
     assert_equal 1, results.length
     assert_equal "DOE,JOHN", results.first[:display_name]
@@ -147,11 +147,11 @@ class Lakeraven::EHR::Adapters::MockAdapterTest < ActiveSupport::TestCase
   test "search by identifier returns nothing when value doesn't match" do
     @adapter.seed_patient(tenant_identifier: "tnt_test", facility_identifier: "fac_main",
                           display_name: "DOE,JOHN", date_of_birth: Date.new(1980, 1, 15), gender: "male",
-                          identifiers: [ { system: "http://hl7.org/fhir/sid/us-ssn", value: "123-45-6789" } ])
+                          identifiers: [ { system: "http://hl7.org/fhir/sid/us-ssn", value: "000-00-0000" } ])
     results = @adapter.search_patients(
       tenant_identifier: "tnt_test",
       identifier_system: "http://hl7.org/fhir/sid/us-ssn",
-      identifier_value: "000-00-0000"
+      identifier_value: "999-99-9999"
     )
     assert_empty results
   end

--- a/test/lakeraven/ehr/fhir/patient_deserializer_test.rb
+++ b/test/lakeraven/ehr/fhir/patient_deserializer_test.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::FHIR::PatientDeserializerTest < ActiveSupport::TestCase
+  Deserializer = Lakeraven::EHR::FHIR::PatientDeserializer
+
+  def base_resource
+    {
+      resourceType: "Patient",
+      name: [ { family: "DOE", given: [ "JOHN" ] } ],
+      gender: "male",
+      birthDate: "1980-01-15",
+      identifier: [
+        { system: "http://hl7.org/fhir/sid/us-ssn", value: "000-00-0000" }
+      ]
+    }
+  end
+
+  # ── Name extraction ──
+
+  test "extracts name as VistA FAMILY,GIVEN format" do
+    assert_equal "DOE,JOHN", Deserializer.call(base_resource)[:name]
+  end
+
+  test "joins multiple given names" do
+    resource = base_resource.merge(name: [ { family: "DOE", given: [ "JOHN", "A" ] } ])
+    assert_equal "DOE,JOHN A", Deserializer.call(resource)[:name]
+  end
+
+  test "prefers text field when present" do
+    resource = base_resource.merge(name: [ { text: "DOE,JOHN A", family: "DOE", given: [ "JOHN" ] } ])
+    assert_equal "DOE,JOHN A", Deserializer.call(resource)[:name]
+  end
+
+  test "returns family only when given is absent" do
+    resource = base_resource.merge(name: [ { family: "DOE" } ])
+    assert_equal "DOE", Deserializer.call(resource)[:name]
+  end
+
+  test "returns nil name when name array is missing" do
+    resource = base_resource.except(:name)
+    assert_nil Deserializer.call(resource)[:name]
+  end
+
+  test "returns nil name when name array is empty" do
+    resource = base_resource.merge(name: [])
+    assert_nil Deserializer.call(resource)[:name]
+  end
+
+  # ── Gender → sex mapping ──
+
+  test "maps male to M" do
+    assert_equal "M", Deserializer.call(base_resource)[:sex]
+  end
+
+  test "maps female to F" do
+    resource = base_resource.merge(gender: "female")
+    assert_equal "F", Deserializer.call(resource)[:sex]
+  end
+
+  test "maps unknown gender to U" do
+    resource = base_resource.merge(gender: "unknown")
+    assert_equal "U", Deserializer.call(resource)[:sex]
+  end
+
+  test "maps other gender to U" do
+    resource = base_resource.merge(gender: "other")
+    assert_equal "U", Deserializer.call(resource)[:sex]
+  end
+
+  test "maps nil gender to U" do
+    resource = base_resource.except(:gender)
+    assert_equal "U", Deserializer.call(resource)[:sex]
+  end
+
+  # ── Birth date ──
+
+  test "parses birthDate as Date" do
+    assert_equal Date.new(1980, 1, 15), Deserializer.call(base_resource)[:dob]
+  end
+
+  test "returns nil for missing birthDate" do
+    resource = base_resource.except(:birthDate)
+    assert_nil Deserializer.call(resource)[:dob]
+  end
+
+  test "returns nil for invalid birthDate" do
+    resource = base_resource.merge(birthDate: "not-a-date")
+    assert_nil Deserializer.call(resource)[:dob]
+  end
+
+  # ── SSN ──
+
+  test "extracts SSN by system URI" do
+    assert_equal "000-00-0000", Deserializer.call(base_resource)[:ssn]
+  end
+
+  test "returns nil SSN when no identifiers present" do
+    resource = base_resource.except(:identifier)
+    assert_nil Deserializer.call(resource)[:ssn]
+  end
+
+  test "returns nil SSN when no SSN identifier in array" do
+    resource = base_resource.merge(identifier: [
+      { system: "http://example.com/mrn", value: "12345" }
+    ])
+    assert_nil Deserializer.call(resource)[:ssn]
+  end
+
+  # ── String-keyed hashes ──
+
+  test "works with string-keyed hash" do
+    resource = {
+      "resourceType" => "Patient",
+      "name" => [ { "family" => "DOE", "given" => [ "JOHN" ] } ],
+      "gender" => "female",
+      "birthDate" => "1990-06-01"
+    }
+    result = Deserializer.call(resource)
+    assert_equal "DOE,JOHN", result[:name]
+    assert_equal "F", result[:sex]
+    assert_equal Date.new(1990, 6, 1), result[:dob]
+  end
+
+  # ── Dot-access objects ──
+
+  test "works with OpenStruct-style objects" do
+    NameEntry = Struct.new(:family, :given, :text, keyword_init: true) unless defined?(NameEntry)
+    FhirPatient = Struct.new(:name, :gender, :birthDate, :identifier, keyword_init: true) unless defined?(FhirPatient)
+
+    name_obj = NameEntry.new(family: "DOE", given: [ "JANE" ], text: nil)
+    resource = FhirPatient.new(
+      name: [ name_obj ],
+      gender: "female",
+      birthDate: "1990-06-01",
+      identifier: nil
+    )
+    result = Deserializer.call(resource)
+    assert_equal "DOE,JANE", result[:name]
+    assert_equal "F", result[:sex]
+  end
+end


### PR DESCRIPTION
## Summary
- `Lakeraven::EHR::Patient` ActiveModel with full RPMS demographics, composite field syncing, FHIR serialization
- `Lakeraven::EHR::PatientName` value object for VistA name parsing + display/formal formatting
- Expanded `Fhir::PatientSerializer` (79 → 210 LOC): DFN/SSN identifiers, address, telecom, US Core race/ethnicity, IHS tribal affiliation/enrollment, SOGI extensions
- New `Fhir::PatientDeserializer`: extracts name/dob/sex/ssn from FHIR Patient resources
- `Patient.from_fhir(resource)` returns a Patient instance (not a raw Hash)
- 14 BDD scenarios + 19 deserializer unit tests covering the full surface

Closes #8

## Context

Phase 1 of archiving rpms_redux: the engine now owns the canonical Patient clinical identity model. rpms_redux's Patient.rb (846 lines, flog 819.8) can become a thin shim that subclasses `Lakeraven::EHR::Patient`.

## Test plan
- [x] 14 BDD scenarios in features/patient_model.feature pass (including single-token name)
- [x] 19 PatientDeserializer unit tests (name, gender, date, SSN edge cases)
- [x] Full suite: 235 Minitest, 54 Cucumber scenarios — all green
- [x] No regressions in existing US Core Patient API, SMART auth, PHI audit features
- [x] SSN test values use SSA-invalid patterns (000-00-0000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)