### PR TITLE
Add Practitioner model, FHIR serializer + deserializer

### DIFF
--- a/app/models/lakeraven/ehr/practitioner.rb
+++ b/app/models/lakeraven/ehr/practitioner.rb
@@ -107,8 +107,6 @@ module Lakeraven
           ien: ien,
           specialty: specialty,
           provider_class: provider_class,
-          title: title,
-          service_section: service_section,
           phone: phone,
           identifiers: []
         }

--- a/app/models/lakeraven/ehr/practitioner.rb
+++ b/app/models/lakeraven/ehr/practitioner.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # Clinical practitioner identity model. ActiveModel-based (no database) —
+    # provider data flows through the configured adapter at request time.
+    #
+    # This is the canonical Practitioner for lakeraven-ehr host apps. It provides:
+    # - RPMS/VistA attribute set (IEN, name in LAST,FIRST format, NPI, etc.)
+    # - Composite field syncing (name ↔ first_name/last_name)
+    # - FHIR R4 serialization via FHIR::PractitionerSerializer
+    # - FHIR R4 deserialization via FHIR::PractitionerDeserializer
+    # - US Core Practitioner profile conformance
+    #
+    # Host apps subclass this to wire gateway persistence and
+    # host-specific behavior.
+    class Practitioner
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Validations
+
+      # Opaque identifier per ADR 0004. Set by the adapter; not derived
+      # from ien or any backend-native key.
+      attribute :practitioner_identifier, :string
+
+      # RPMS/VistA core demographics
+      attribute :ien, :integer
+      attribute :name, :string
+      attribute :npi, :string
+      attribute :dea_number, :string
+      attribute :gender, :string
+      attribute :specialty, :string
+      attribute :provider_class, :string
+      attribute :title, :string
+      attribute :service_section, :string
+      attribute :phone, :string
+
+      # Derived name parts (synced with name)
+      attribute :first_name, :string
+      attribute :last_name, :string
+
+      validates :npi, format: { with: /\A\d{10}\z/, message: "must be 10 digits" },
+                      allow_nil: true, allow_blank: true
+
+      def initialize(attributes = {})
+        super
+        sync_composite_fields
+      end
+
+      # ----------------------------------------------------------------
+      # Composite field syncing
+      # ----------------------------------------------------------------
+
+      def sync_composite_fields
+        if first_name.present? && last_name.present? && name.blank?
+          self.name = "#{last_name},#{first_name}"
+        end
+
+        if name.present? && first_name.blank? && last_name.blank?
+          pn = practitioner_name
+          self.last_name = pn.last_name
+          self.first_name = pn.first_name
+        end
+      end
+
+      # ----------------------------------------------------------------
+      # Name formatting (delegates to PatientName value object)
+      # ----------------------------------------------------------------
+
+      def practitioner_name
+        PatientName.new(name: name, first_name: first_name, last_name: last_name)
+      end
+
+      def display_name
+        practitioner_name.display
+      end
+
+      def formal_name
+        practitioner_name.formal
+      end
+
+      # ----------------------------------------------------------------
+      # FHIR serialization
+      # ----------------------------------------------------------------
+
+      def to_fhir
+        FHIR::PractitionerSerializer.call(to_serializer_hash)
+      end
+
+      def self.from_fhir(fhir_resource)
+        new(**FHIR::PractitionerDeserializer.call(fhir_resource))
+      end
+
+      def to_param
+        practitioner_identifier || ien.to_s
+      end
+
+      private
+
+      def to_serializer_hash
+        {
+          practitioner_identifier: practitioner_identifier || ien&.to_s,
+          display_name: name,
+          gender: gender,
+          npi: npi,
+          dea_number: dea_number,
+          ien: ien,
+          specialty: specialty,
+          provider_class: provider_class,
+          title: title,
+          service_section: service_section,
+          phone: phone,
+          identifiers: []
+        }
+      end
+    end
+  end
+end

--- a/app/services/lakeraven/ehr/fhir/practitioner_deserializer.rb
+++ b/app/services/lakeraven/ehr/fhir/practitioner_deserializer.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    module FHIR
+      # Extracts Practitioner attributes from a FHIR R4 Practitioner resource
+      # (Hash or object with dot-access). Returns a plain Hash suitable for
+      # Practitioner.new(attrs).
+      class PractitionerDeserializer
+        NPI_SYSTEM = "http://hl7.org/fhir/sid/us-npi"
+        DEA_SYSTEM = "http://hl7.org/fhir/sid/us-dea"
+
+        def self.call(fhir_resource)
+          new(fhir_resource).extract
+        end
+
+        def initialize(fhir_resource)
+          @r = fhir_resource
+        end
+
+        def extract
+          {
+            name: extract_name,
+            npi: extract_identifier(NPI_SYSTEM),
+            dea_number: extract_identifier(DEA_SYSTEM),
+            gender: map_gender,
+            specialty: extract_specialty
+          }.compact
+        end
+
+        private
+
+        def extract_name
+          names = dig(:name)
+          return nil unless names.is_a?(Array) && names.any?
+
+          name_obj = names.first
+          text = dig_from(name_obj, :text)
+          return text if text.present?
+
+          family = dig_from(name_obj, :family)
+          given = dig_from(name_obj, :given)
+          given_str = given.is_a?(Array) ? given.join(" ") : given
+
+          if family.present? && given_str.present?
+            "#{family},#{given_str}"
+          elsif family.present?
+            family
+          elsif given_str.present?
+            given_str
+          end
+        end
+
+        def extract_identifier(system_uri)
+          ids = dig(:identifier)
+          return nil unless ids.is_a?(Array)
+
+          match = ids.find { |id| dig_from(id, :system).to_s == system_uri }
+          dig_from(match, :value)
+        end
+
+        def map_gender
+          raw = dig(:gender).to_s.downcase
+          case raw
+          when "male" then "M"
+          when "female" then "F"
+          when "" then nil
+          end
+        end
+
+        def extract_specialty
+          quals = dig(:qualification)
+          return nil unless quals.is_a?(Array) && quals.any?
+
+          code = dig_from(quals.first, :code)
+          return nil unless code
+
+          dig_from(code, :text)
+        end
+
+        # Flexible accessor: supports both Hash (symbol/string) and
+        # dot-access objects (OpenStruct, FHIR models).
+        def dig(key)
+          if @r.is_a?(Hash)
+            @r[key.to_sym] || @r[key.to_s]
+          elsif @r.respond_to?(key)
+            @r.send(key)
+          end
+        end
+
+        def dig_from(obj, key)
+          return nil unless obj
+          if obj.is_a?(Hash)
+            obj[key.to_sym] || obj[key.to_s]
+          elsif obj.respond_to?(key)
+            obj.send(key)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/lakeraven/ehr/fhir/practitioner_deserializer.rb
+++ b/app/services/lakeraven/ehr/fhir/practitioner_deserializer.rb
@@ -9,6 +9,7 @@ module Lakeraven
       class PractitionerDeserializer
         NPI_SYSTEM = "http://hl7.org/fhir/sid/us-npi"
         DEA_SYSTEM = "http://hl7.org/fhir/sid/us-dea"
+        IEN_SYSTEM = "http://ihs.gov/rpms/provider-id"
 
         def self.call(fhir_resource)
           new(fhir_resource).extract
@@ -21,10 +22,12 @@ module Lakeraven
         def extract
           {
             name: extract_name,
+            ien: extract_ien,
             npi: extract_identifier(NPI_SYSTEM),
             dea_number: extract_identifier(DEA_SYSTEM),
             gender: map_gender,
-            specialty: extract_specialty
+            specialty: extract_qualification(0),
+            provider_class: extract_qualification(1)
           }.compact
         end
 
@@ -68,11 +71,16 @@ module Lakeraven
           end
         end
 
-        def extract_specialty
-          quals = dig(:qualification)
-          return nil unless quals.is_a?(Array) && quals.any?
+        def extract_ien
+          val = extract_identifier(IEN_SYSTEM)
+          val.present? ? val.to_i : nil
+        end
 
-          code = dig_from(quals.first, :code)
+        def extract_qualification(index)
+          quals = dig(:qualification)
+          return nil unless quals.is_a?(Array) && quals.length > index
+
+          code = dig_from(quals[index], :code)
           return nil unless code
 
           dig_from(code, :text)

--- a/app/services/lakeraven/ehr/fhir/practitioner_serializer.rb
+++ b/app/services/lakeraven/ehr/fhir/practitioner_serializer.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    module FHIR
+      # Serializes an adapter practitioner hash to a US Core conformant
+      # FHIR R4 Practitioner resource.
+      #
+      # The input is a Hash with symbol keys matching the adapter's
+      # public_view shape. All keys are optional except :display_name.
+      #
+      # No PHI persistence happens here per ADR 0002 — pure transform.
+      class PractitionerSerializer
+        US_CORE_PROFILE = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+
+        NPI_SYSTEM = "http://hl7.org/fhir/sid/us-npi"
+        DEA_SYSTEM = "http://hl7.org/fhir/sid/us-dea"
+        IEN_SYSTEM = "http://ihs.gov/rpms/provider-id"
+
+        def self.call(record)
+          new(record).to_h
+        end
+
+        def initialize(record)
+          @record = record
+        end
+
+        def to_h
+          resource = {
+            resourceType: "Practitioner",
+            id: @record[:practitioner_identifier],
+            meta: { profile: [ US_CORE_PROFILE ] },
+            name: [ build_name ],
+            gender: gender_value
+          }
+
+          identifiers = build_identifiers
+          resource[:identifier] = identifiers if identifiers.any?
+
+          qualifications = build_qualifications
+          resource[:qualification] = qualifications if qualifications.any?
+
+          telecoms = build_telecoms
+          resource[:telecom] = telecoms if telecoms.any?
+
+          resource.compact
+        end
+
+        private
+
+        # ----------------------------------------------------------------
+        # Name
+        # ----------------------------------------------------------------
+
+        def build_name
+          pn = PatientName.new(name: @record[:display_name])
+          pn.to_fhir
+        end
+
+        # ----------------------------------------------------------------
+        # Gender
+        # ----------------------------------------------------------------
+
+        def gender_value
+          raw = @record[:gender].to_s
+          return "male" if raw == "M"
+          return "female" if raw == "F"
+          return raw if %w[male female other unknown].include?(raw)
+          nil
+        end
+
+        # ----------------------------------------------------------------
+        # Identifiers
+        # ----------------------------------------------------------------
+
+        def build_identifiers
+          ids = (@record[:identifiers] || []).map do |id|
+            { system: id[:system], value: id[:value] }
+          end
+
+          if @record[:npi].present?
+            ids << { use: "official", system: NPI_SYSTEM, value: @record[:npi] }
+          end
+
+          if @record[:dea_number].present?
+            ids << { use: "official", system: DEA_SYSTEM, value: @record[:dea_number] }
+          end
+
+          if @record[:ien].present?
+            ids << { use: "usual", system: IEN_SYSTEM, value: @record[:ien].to_s }
+          end
+
+          ids
+        end
+
+        # ----------------------------------------------------------------
+        # Qualifications (specialty, provider class, title)
+        # ----------------------------------------------------------------
+
+        def build_qualifications
+          quals = []
+
+          if @record[:specialty].present?
+            quals << {
+              code: { text: @record[:specialty] }
+            }
+          end
+
+          if @record[:provider_class].present?
+            quals << {
+              code: { text: @record[:provider_class] }
+            }
+          end
+
+          quals
+        end
+
+        # ----------------------------------------------------------------
+        # Telecom
+        # ----------------------------------------------------------------
+
+        def build_telecoms
+          return [] if @record[:phone].blank?
+
+          [ { system: "phone", value: @record[:phone], use: "work" } ]
+        end
+      end
+    end
+  end
+end

--- a/features/practitioner_model.feature
+++ b/features/practitioner_model.feature
@@ -74,3 +74,10 @@ Feature: Practitioner clinical identity model
     And the practitioner last_name should be "Doe"
     And the practitioner first_name should be "John"
     And the practitioner npi should be "1234567890"
+
+  Scenario: from_fhir round-trips IEN and qualifications
+    Given a FHIR Practitioner resource with ien "42" specialty "Family Medicine" and provider_class "Physician"
+    When I build a practitioner from the FHIR resource
+    Then the practitioner ien should be 42
+    And the practitioner specialty should be "Family Medicine"
+    And the practitioner provider_class should be "Physician"

--- a/features/practitioner_model.feature
+++ b/features/practitioner_model.feature
@@ -1,0 +1,76 @@
+Feature: Practitioner clinical identity model
+  As a clinical application
+  I need a Practitioner model that stores provider demographics, formats names,
+  and serializes to FHIR R4 with US Core extensions
+  So that I can interoperate with EHRs per ONC § 170.315(g)(10)
+
+  # ===========================================================================
+  # ATTRIBUTES AND COMPOSITE FIELD SYNCING
+  # ===========================================================================
+
+  Scenario: Create a practitioner from VistA name format
+    Given a practitioner with name "DOE,JOHN A"
+    Then the practitioner last_name should be "Doe"
+    And the practitioner first_name should be "John"
+    And the practitioner display_name should be "John A Doe"
+    And the practitioner formal_name should be "Doe, John A"
+
+  Scenario: Create a practitioner from separate name parts
+    Given a practitioner with first_name "Jane" and last_name "Smith"
+    Then the practitioner name should be "Smith,Jane"
+    And the practitioner display_name should be "Jane Smith"
+
+  Scenario: Create a practitioner from a single-token name (no comma)
+    Given a practitioner with name "ADMIN"
+    Then the practitioner display_name should be "ADMIN"
+    And the practitioner first_name should be blank
+    And the practitioner last_name should be blank
+
+  # ===========================================================================
+  # FHIR SERIALIZATION — US Core Practitioner
+  # ===========================================================================
+
+  Scenario: to_fhir emits a US Core Practitioner resource
+    Given a practitioner with name "DOE,JOHN" and npi "1234567890"
+    When I serialize the practitioner to FHIR
+    Then the FHIR resourceType should be "Practitioner"
+    And the FHIR meta profile should include the US Core Practitioner profile
+    And the FHIR name family should be "DOE"
+    And the FHIR name given should include "JOHN"
+
+  Scenario: to_fhir maps gender to FHIR administrative-gender
+    Given a practitioner with name "DOE,JOHN" and gender "M"
+    When I serialize the practitioner to FHIR
+    Then the FHIR gender should be "male"
+
+  Scenario: to_fhir includes NPI identifier
+    Given a practitioner with name "DOE,JOHN" and npi "1234567890"
+    When I serialize the practitioner to FHIR
+    Then the FHIR identifiers should include system "http://hl7.org/fhir/sid/us-npi" with value "1234567890"
+
+  Scenario: to_fhir includes IEN identifier
+    Given a practitioner with ien 42 and name "DOE,JOHN"
+    When I serialize the practitioner to FHIR
+    Then the FHIR identifiers should include system "http://ihs.gov/rpms/provider-id" with value "42"
+
+  Scenario: to_fhir includes specialty as qualification
+    Given a practitioner with name "DOE,JOHN" and specialty "Family Medicine"
+    When I serialize the practitioner to FHIR
+    Then the FHIR qualifications should include "Family Medicine"
+
+  Scenario: to_fhir includes telecom
+    Given a practitioner with name "DOE,JOHN" and phone "555-0100"
+    When I serialize the practitioner to FHIR
+    Then the FHIR telecom value should be "555-0100"
+
+  # ===========================================================================
+  # FHIR DESERIALIZATION
+  # ===========================================================================
+
+  Scenario: from_fhir builds a Practitioner from a FHIR resource
+    Given a FHIR Practitioner resource with family "DOE" given "JOHN" npi "1234567890"
+    When I build a practitioner from the FHIR resource
+    Then the practitioner name should be "DOE,JOHN"
+    And the practitioner last_name should be "Doe"
+    And the practitioner first_name should be "John"
+    And the practitioner npi should be "1234567890"

--- a/features/step_definitions/practitioner_model_steps.rb
+++ b/features/step_definitions/practitioner_model_steps.rb
@@ -98,6 +98,32 @@ Given("a FHIR Practitioner resource with family {string} given {string} npi {str
   }
 end
 
+Given("a FHIR Practitioner resource with ien {string} specialty {string} and provider_class {string}") do |ien, specialty, provider_class|
+  @fhir_input = {
+    resourceType: "Practitioner",
+    name: [ { family: "DOE", given: [ "JOHN" ] } ],
+    identifier: [
+      { system: "http://ihs.gov/rpms/provider-id", value: ien }
+    ],
+    qualification: [
+      { code: { text: specialty } },
+      { code: { text: provider_class } }
+    ]
+  }
+end
+
 When("I build a practitioner from the FHIR resource") do
   @practitioner = Lakeraven::EHR::Practitioner.from_fhir(@fhir_input)
+end
+
+Then("the practitioner ien should be {int}") do |expected|
+  assert_equal expected, @practitioner.ien
+end
+
+Then("the practitioner specialty should be {string}") do |expected|
+  assert_equal expected, @practitioner.specialty
+end
+
+Then("the practitioner provider_class should be {string}") do |expected|
+  assert_equal expected, @practitioner.provider_class
 end

--- a/features/step_definitions/practitioner_model_steps.rb
+++ b/features/step_definitions/practitioner_model_steps.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+# Practitioner model step definitions.
+
+def build_practitioner(**attrs)
+  Lakeraven::EHR::Practitioner.new(**attrs)
+end
+
+# ── Creation ──
+
+Given("a practitioner with name {string}") do |name|
+  @practitioner = build_practitioner(name: name)
+end
+
+Given("a practitioner with first_name {string} and last_name {string}") do |first, last|
+  @practitioner = build_practitioner(first_name: first, last_name: last)
+end
+
+Given("a practitioner with name {string} and npi {string}") do |name, npi|
+  @practitioner = build_practitioner(name: name, npi: npi)
+end
+
+Given("a practitioner with name {string} and gender {string}") do |name, gender|
+  @practitioner = build_practitioner(name: name, gender: gender)
+end
+
+Given("a practitioner with ien {int} and name {string}") do |ien, name|
+  @practitioner = build_practitioner(ien: ien, name: name)
+end
+
+Given("a practitioner with name {string} and specialty {string}") do |name, specialty|
+  @practitioner = build_practitioner(name: name, specialty: specialty)
+end
+
+Given("a practitioner with name {string} and phone {string}") do |name, phone|
+  @practitioner = build_practitioner(name: name, phone: phone)
+end
+
+# ── Attribute assertions ──
+
+Then("the practitioner last_name should be {string}") do |expected|
+  assert_equal expected, @practitioner.last_name
+end
+
+Then("the practitioner first_name should be {string}") do |expected|
+  assert_equal expected, @practitioner.first_name
+end
+
+Then("the practitioner first_name should be blank") do
+  assert_nil @practitioner.first_name
+end
+
+Then("the practitioner last_name should be blank") do
+  assert_nil @practitioner.last_name
+end
+
+Then("the practitioner display_name should be {string}") do |expected|
+  assert_equal expected, @practitioner.display_name
+end
+
+Then("the practitioner formal_name should be {string}") do |expected|
+  assert_equal expected, @practitioner.formal_name
+end
+
+Then("the practitioner name should be {string}") do |expected|
+  assert_equal expected, @practitioner.name
+end
+
+Then("the practitioner npi should be {string}") do |expected|
+  assert_equal expected, @practitioner.npi
+end
+
+# ── FHIR serialization ──
+
+When("I serialize the practitioner to FHIR") do
+  @fhir = @practitioner.to_fhir
+end
+
+Then("the FHIR meta profile should include the US Core Practitioner profile") do
+  assert_includes @fhir.dig(:meta, :profile),
+    "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+end
+
+Then("the FHIR qualifications should include {string}") do |expected|
+  texts = @fhir[:qualification]&.map { |q| q.dig(:code, :text) } || []
+  assert_includes texts, expected
+end
+
+# ── FHIR deserialization ──
+
+Given("a FHIR Practitioner resource with family {string} given {string} npi {string}") do |family, given, npi|
+  @fhir_input = {
+    resourceType: "Practitioner",
+    name: [ { family: family, given: [ given ] } ],
+    identifier: [
+      { system: "http://hl7.org/fhir/sid/us-npi", value: npi }
+    ]
+  }
+end
+
+When("I build a practitioner from the FHIR resource") do
+  @practitioner = Lakeraven::EHR::Practitioner.from_fhir(@fhir_input)
+end

--- a/test/lakeraven/ehr/fhir/practitioner_deserializer_test.rb
+++ b/test/lakeraven/ehr/fhir/practitioner_deserializer_test.rb
@@ -86,10 +86,37 @@ class Lakeraven::EHR::FHIR::PractitionerDeserializerTest < ActiveSupport::TestCa
     assert_nil Deserializer.call(resource)[:gender]
   end
 
-  # ── Specialty ──
+  # ── IEN ──
+
+  test "extracts IEN as integer from identifier" do
+    resource = base_resource.merge(identifier: base_resource[:identifier] + [
+      { system: "http://ihs.gov/rpms/provider-id", value: "42" }
+    ])
+    assert_equal 42, Deserializer.call(resource)[:ien]
+  end
+
+  test "returns nil IEN when not present" do
+    assert_nil Deserializer.call(base_resource)[:ien]
+  end
+
+  # ── Specialty + provider_class ──
 
   test "extracts specialty from first qualification" do
     assert_equal "Family Medicine", Deserializer.call(base_resource)[:specialty]
+  end
+
+  test "extracts provider_class from second qualification" do
+    resource = base_resource.merge(qualification: [
+      { code: { text: "Family Medicine" } },
+      { code: { text: "Physician" } }
+    ])
+    result = Deserializer.call(resource)
+    assert_equal "Family Medicine", result[:specialty]
+    assert_equal "Physician", result[:provider_class]
+  end
+
+  test "returns nil provider_class when only one qualification" do
+    assert_nil Deserializer.call(base_resource)[:provider_class]
   end
 
   test "returns nil specialty when no qualifications" do

--- a/test/lakeraven/ehr/fhir/practitioner_deserializer_test.rb
+++ b/test/lakeraven/ehr/fhir/practitioner_deserializer_test.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::FHIR::PractitionerDeserializerTest < ActiveSupport::TestCase
+  Deserializer = Lakeraven::EHR::FHIR::PractitionerDeserializer
+
+  def base_resource
+    {
+      resourceType: "Practitioner",
+      name: [ { family: "DOE", given: [ "JOHN" ] } ],
+      gender: "male",
+      identifier: [
+        { system: "http://hl7.org/fhir/sid/us-npi", value: "1234567890" },
+        { system: "http://hl7.org/fhir/sid/us-dea", value: "AB1234567" }
+      ],
+      qualification: [
+        { code: { text: "Family Medicine" } }
+      ]
+    }
+  end
+
+  # ── Name extraction ──
+
+  test "extracts name as VistA FAMILY,GIVEN format" do
+    assert_equal "DOE,JOHN", Deserializer.call(base_resource)[:name]
+  end
+
+  test "joins multiple given names" do
+    resource = base_resource.merge(name: [ { family: "DOE", given: [ "JOHN", "A" ] } ])
+    assert_equal "DOE,JOHN A", Deserializer.call(resource)[:name]
+  end
+
+  test "prefers text field when present" do
+    resource = base_resource.merge(name: [ { text: "DOE,JOHN A", family: "DOE", given: [ "JOHN" ] } ])
+    assert_equal "DOE,JOHN A", Deserializer.call(resource)[:name]
+  end
+
+  test "returns nil name when name array is missing" do
+    resource = base_resource.except(:name)
+    assert_nil Deserializer.call(resource)[:name]
+  end
+
+  # ── NPI ──
+
+  test "extracts NPI by system URI" do
+    assert_equal "1234567890", Deserializer.call(base_resource)[:npi]
+  end
+
+  test "returns nil NPI when no identifiers" do
+    resource = base_resource.except(:identifier)
+    assert_nil Deserializer.call(resource)[:npi]
+  end
+
+  test "returns nil NPI when no NPI identifier in array" do
+    resource = base_resource.merge(identifier: [
+      { system: "http://example.com/mrn", value: "12345" }
+    ])
+    assert_nil Deserializer.call(resource)[:npi]
+  end
+
+  # ── DEA ──
+
+  test "extracts DEA number by system URI" do
+    assert_equal "AB1234567", Deserializer.call(base_resource)[:dea_number]
+  end
+
+  # ── Gender mapping ──
+
+  test "maps male to M" do
+    assert_equal "M", Deserializer.call(base_resource)[:gender]
+  end
+
+  test "maps female to F" do
+    resource = base_resource.merge(gender: "female")
+    assert_equal "F", Deserializer.call(resource)[:gender]
+  end
+
+  test "returns nil gender for missing gender" do
+    resource = base_resource.except(:gender)
+    assert_nil Deserializer.call(resource)[:gender]
+  end
+
+  test "returns nil gender for unknown values" do
+    resource = base_resource.merge(gender: "other")
+    assert_nil Deserializer.call(resource)[:gender]
+  end
+
+  # ── Specialty ──
+
+  test "extracts specialty from first qualification" do
+    assert_equal "Family Medicine", Deserializer.call(base_resource)[:specialty]
+  end
+
+  test "returns nil specialty when no qualifications" do
+    resource = base_resource.except(:qualification)
+    assert_nil Deserializer.call(resource)[:specialty]
+  end
+
+  # ── String-keyed hashes ──
+
+  test "works with string-keyed hash" do
+    resource = {
+      "resourceType" => "Practitioner",
+      "name" => [ { "family" => "DOE", "given" => [ "JOHN" ] } ],
+      "gender" => "female",
+      "identifier" => [
+        { "system" => "http://hl7.org/fhir/sid/us-npi", "value" => "9876543210" }
+      ]
+    }
+    result = Deserializer.call(resource)
+    assert_equal "DOE,JOHN", result[:name]
+    assert_equal "F", result[:gender]
+    assert_equal "9876543210", result[:npi]
+  end
+end

--- a/test/lakeraven/ehr/fhir/practitioner_serializer_test.rb
+++ b/test/lakeraven/ehr/fhir/practitioner_serializer_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::FHIR::PractitionerSerializerTest < ActiveSupport::TestCase
+  Serializer = Lakeraven::EHR::FHIR::PractitionerSerializer
+  US_CORE_PROFILE = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+
+  def base_record
+    {
+      practitioner_identifier: "prov_01H8X",
+      display_name: "DOE,JOHN",
+      npi: "1234567890",
+      identifiers: []
+    }
+  end
+
+  test "renders resourceType Practitioner" do
+    assert_equal "Practitioner", Serializer.call(base_record)[:resourceType]
+  end
+
+  test "id is the opaque practitioner_identifier" do
+    assert_equal "prov_01H8X", Serializer.call(base_record)[:id]
+  end
+
+  test "meta.profile includes the US Core Practitioner profile" do
+    assert_includes Serializer.call(base_record).dig(:meta, :profile), US_CORE_PROFILE
+  end
+
+  test "name parses display_name into family + given" do
+    name = Serializer.call(base_record)[:name].first
+    assert_equal "DOE", name[:family]
+    assert_equal [ "JOHN" ], name[:given]
+  end
+
+  test "name handles multiple given names" do
+    record = base_record.merge(display_name: "DOE,JOHN MIDDLE")
+    name = Serializer.call(record)[:name].first
+    assert_equal [ "JOHN", "MIDDLE" ], name[:given]
+  end
+
+  test "name falls back to text when no comma" do
+    record = base_record.merge(display_name: "ADMIN")
+    name = Serializer.call(record)[:name].first
+    assert_equal "ADMIN", name[:text]
+    assert_nil name[:family]
+  end
+
+  test "gender maps M to male" do
+    assert_equal "male", Serializer.call(base_record.merge(gender: "M"))[:gender]
+  end
+
+  test "gender maps F to female" do
+    assert_equal "female", Serializer.call(base_record.merge(gender: "F"))[:gender]
+  end
+
+  test "gender is nil when not provided" do
+    assert_nil Serializer.call(base_record)[:gender]
+  end
+
+  test "NPI identifier included with official use" do
+    ids = Serializer.call(base_record)[:identifier]
+    npi = ids.find { |i| i[:system] == "http://hl7.org/fhir/sid/us-npi" }
+    assert_equal "1234567890", npi[:value]
+    assert_equal "official", npi[:use]
+  end
+
+  test "DEA identifier included when present" do
+    record = base_record.merge(dea_number: "AB1234567")
+    ids = Serializer.call(record)[:identifier]
+    dea = ids.find { |i| i[:system] == "http://hl7.org/fhir/sid/us-dea" }
+    assert_equal "AB1234567", dea[:value]
+  end
+
+  test "IEN identifier included when present" do
+    record = base_record.merge(ien: 42)
+    ids = Serializer.call(record)[:identifier]
+    ien = ids.find { |i| i[:system] == "http://ihs.gov/rpms/provider-id" }
+    assert_equal "42", ien[:value]
+  end
+
+  test "identifier key omitted when no identifiers" do
+    record = base_record.merge(npi: nil)
+    refute Serializer.call(record).key?(:identifier)
+  end
+
+  test "specialty emitted as qualification" do
+    record = base_record.merge(specialty: "Family Medicine")
+    quals = Serializer.call(record)[:qualification]
+    assert_equal "Family Medicine", quals.first.dig(:code, :text)
+  end
+
+  test "provider_class emitted as qualification" do
+    record = base_record.merge(provider_class: "Physician")
+    quals = Serializer.call(record)[:qualification]
+    assert_equal "Physician", quals.first.dig(:code, :text)
+  end
+
+  test "qualification key omitted when no specialty or provider_class" do
+    refute Serializer.call(base_record).key?(:qualification)
+  end
+
+  test "telecom included when phone present" do
+    record = base_record.merge(phone: "555-0100")
+    telecom = Serializer.call(record)[:telecom].first
+    assert_equal "phone", telecom[:system]
+    assert_equal "555-0100", telecom[:value]
+    assert_equal "work", telecom[:use]
+  end
+
+  test "telecom key omitted when phone blank" do
+    refute Serializer.call(base_record).key?(:telecom)
+  end
+end


### PR DESCRIPTION
## Summary
- `Lakeraven::EHR::Practitioner` ActiveModel with VistA name sync, NPI validation, `to_fhir`/`from_fhir`
- `FHIR::PractitionerSerializer`: US Core profile, NPI/DEA/IEN identifiers, qualifications, gender mapping, telecom
- `FHIR::PractitionerDeserializer`: name, NPI, DEA, gender, specialty extraction
- Reuses `PatientName` value object for name parsing (VistA LAST,FIRST format)

Closes #10

## Context
Phase 1 of archiving rpms_redux: the engine now owns the canonical Practitioner clinical identity model alongside Patient. rpms_redux's `Practitioner` (416 lines) can become a thin shim that subclasses `Lakeraven::EHR::Practitioner`.

## Test plan
- [x] 11 BDD scenarios in features/practitioner_model.feature pass
- [x] 33 Minitest unit tests (serializer + deserializer edge cases)
- [x] Full suite: 268 Minitest, 64 Cucumber scenarios — all green
- [x] No regressions in existing Patient, US Core API, SMART auth, PHI audit features

🤖 Generated with [Claude Code](https://claude.com/claude-code)