### PR TITLE
Patient model + gateway backed by rpms-rpc DataMapper

### DIFF
--- a/app/controllers/lakeraven/ehr/application_controller.rb
+++ b/app/controllers/lakeraven/ehr/application_controller.rb
@@ -1,6 +1,33 @@
+# frozen_string_literal: true
+
 module Lakeraven
-  module Ehr
-    class ApplicationController < ActionController::Base
+  module EHR
+    class ApplicationController < ActionController::API
+      FHIR_CONTENT_TYPE = "application/fhir+json"
+
+      private
+
+      def render_operation_outcome(status:, severity:, code:, diagnostics: nil)
+        outcome = {
+          resourceType: "OperationOutcome",
+          issue: [ { severity: severity, code: code, diagnostics: diagnostics }.compact ]
+        }
+        render json: outcome, status: status, content_type: FHIR_CONTENT_TYPE
+      end
+
+      def render_fhir(resource, status: :ok)
+        render json: resource, status: status, content_type: FHIR_CONTENT_TYPE
+      end
+
+      def render_bundle(entries, type: "searchset")
+        bundle = {
+          resourceType: "Bundle",
+          type: type,
+          total: entries.length,
+          entry: entries.map { |e| { resource: e } }
+        }
+        render json: bundle, status: :ok, content_type: FHIR_CONTENT_TYPE
+      end
     end
   end
 end

--- a/app/controllers/lakeraven/ehr/patients_controller.rb
+++ b/app/controllers/lakeraven/ehr/patients_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class PatientsController < ApplicationController
+      def index
+        patients = if params[:name].present?
+          Patient.search(params[:name])
+        else
+          Patient.search("")
+        end
+
+        render_bundle(patients.map(&:to_fhir))
+      end
+
+      def show
+        patient = Patient.find_by_dfn(params[:dfn])
+
+        if patient.nil?
+          render_operation_outcome(
+            status: :not_found,
+            severity: "error",
+            code: "not-found",
+            diagnostics: "Patient not found"
+          )
+          return
+        end
+
+        render_fhir(patient.to_fhir)
+      end
+    end
+  end
+end

--- a/app/controllers/lakeraven/ehr/practitioners_controller.rb
+++ b/app/controllers/lakeraven/ehr/practitioners_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class PractitionersController < ApplicationController
+      def index
+        practitioners = if params[:name].present?
+          Practitioner.search(params[:name])
+        else
+          Practitioner.search("")
+        end
+
+        render_bundle(practitioners.map(&:to_fhir))
+      end
+
+      def show
+        practitioner = Practitioner.find_by_ien(params[:ien])
+
+        if practitioner.nil?
+          render_operation_outcome(
+            status: :not_found,
+            severity: "error",
+            code: "not-found",
+            diagnostics: "Practitioner not found"
+          )
+          return
+        end
+
+        render_fhir(practitioner.to_fhir)
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/base_gateway.rb
+++ b/app/gateways/lakeraven/ehr/base_gateway.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class BaseGateway
+      class << self
+        def rpc_client
+          if Rails.env.test?
+            GatewayFactory.gateway
+          else
+            @rpc_client ||= GatewayFactory.gateway
+          end
+        end
+
+        def reset_rpc_client!
+          @rpc_client = nil
+        end
+
+        private
+
+        def empty_response?(response)
+          response.nil? || response.empty?
+        end
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/patient_gateway.rb
+++ b/app/gateways/lakeraven/ehr/patient_gateway.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rpms_rpc/mappings"
+
+module Lakeraven
+  module EHR
+    class PatientGateway < BaseGateway
+      class << self
+        # Find a patient by DFN.
+        # Calls ORWPT SELECT + ORWPT ID INFO, merges into one hash,
+        # returns a Patient model instance.
+        def find(dfn)
+          response = rpc_client.call_rpc("ORWPT SELECT", dfn.to_s)
+          return nil if empty_response?(response)
+
+          attrs = RpmsRpc::DataMapper[:patient_select].parse_one(response, extras: { dfn: dfn.to_i })
+          return nil unless attrs
+
+          id_response = rpc_client.call_rpc("ORWPT ID INFO", dfn.to_s)
+          unless empty_response?(id_response)
+            extended = RpmsRpc::DataMapper[:patient_id_info].parse_one(id_response)
+            attrs.merge!(extended) if extended
+          end
+
+          Patient.new(**attrs)
+        end
+
+        # Search patients by name. Returns array of Patient stubs (dfn + name only).
+        def search(name_pattern)
+          response = rpc_client.call_rpc("ORWPT LIST ALL", name_pattern, "1")
+          return [] if empty_response?(response)
+
+          RpmsRpc::DataMapper[:patient_list].parse_many(response).map do |attrs|
+            Patient.new(**attrs)
+          end
+        end
+
+        # Find patient by SSN.
+        def find_by_ssn(ssn)
+          response = rpc_client.call_rpc("ORWPT FULLSSN", ssn)
+          return nil if empty_response?(response)
+
+          attrs = RpmsRpc::DataMapper[:patient_ssn].parse_one(response)
+          attrs ? Patient.new(**attrs) : nil
+        end
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/practitioner_gateway.rb
+++ b/app/gateways/lakeraven/ehr/practitioner_gateway.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rpms_rpc/mappings"
+
+module Lakeraven
+  module EHR
+    class PractitionerGateway < BaseGateway
+      class << self
+        def find(ien)
+          response = rpc_client.call_rpc("ORWU USERINFO", ien.to_s)
+          return nil if empty_response?(response)
+
+          attrs = RpmsRpc::DataMapper[:practitioner_info].parse_one(response, extras: { ien: ien.to_i })
+          return nil unless attrs
+          return nil if attrs[:name] == "-1"
+
+          Practitioner.new(**attrs)
+        end
+
+        def search(name_pattern)
+          response = rpc_client.call_rpc("ORWU NEWPERS", name_pattern, "1")
+          return [] if empty_response?(response)
+
+          RpmsRpc::DataMapper[:practitioner_list].parse_many(response).filter_map do |attrs|
+            next if attrs[:name].blank?
+            Practitioner.new(**attrs)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/patient.rb
+++ b/app/models/lakeraven/ehr/patient.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # Patient model — ActiveModel-based, backed by RPMS via PatientGateway.
+    #
+    # Faithful port from rpms_redux Patient. All data flows through RPC;
+    # no database tables.
+    class Patient
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      # RPMS/VistA core demographics
+      attribute :dfn, :integer
+      attribute :name, :string
+      attribute :ssn, :string
+      attribute :dob, :date
+      attribute :sex, :string
+      attribute :age, :integer
+      attribute :race, :string
+      attribute :address_line1, :string
+      attribute :city, :string
+      attribute :state, :string
+      attribute :zip_code, :string
+      attribute :phone, :string
+
+      # Derived name parts
+      attribute :first_name, :string
+      attribute :last_name, :string
+
+      # IHS/PRC fields
+      attribute :tribal_affiliation, :string
+      attribute :tribal_enrollment_number, :string
+      attribute :service_area, :string
+      attribute :coverage_type, :string
+
+      # -- Class methods (AR-like) -------------------------------------------
+
+      def self.find_by_dfn(dfn)
+        return nil unless dfn.present? && dfn.to_i > 0
+        PatientGateway.find(dfn.to_i)
+      end
+
+      def self.search(name_pattern)
+        PatientGateway.search(name_pattern.to_s)
+      end
+
+      def self.find_by_ssn(ssn)
+        return nil if ssn.blank?
+        PatientGateway.find_by_ssn(ssn.to_s)
+      end
+
+      # -- Initialize with composite field sync ------------------------------
+
+      def initialize(attributes = {})
+        super
+        sync_composite_fields
+      end
+
+      # -- Name helpers ------------------------------------------------------
+
+      def display_name
+        return name if name.blank?
+        parts = name.split(",")
+        last = parts[0]&.strip
+        first = parts[1]&.strip
+        first.present? ? "#{first} #{last}" : last
+      end
+
+      def formal_name
+        return name if name.blank?
+        parts = name.split(",")
+        if parts.length >= 2
+          last = parts[0]&.strip&.split&.map(&:capitalize)&.join(" ")
+          first = parts[1]&.strip&.split&.map(&:capitalize)&.join(" ")
+          "#{last}, #{first}"
+        else
+          name.split.map(&:capitalize).join(" ")
+        end
+      end
+
+      def to_param
+        dfn.to_s
+      end
+
+      # -- FHIR serialization -----------------------------------------------
+
+      def to_fhir
+        FHIR::PatientSerializer.call(self)
+      end
+
+      private
+
+      def sync_composite_fields
+        if first_name.present? && last_name.present? && name.blank?
+          self.name = "#{last_name},#{first_name}"
+        end
+
+        if name.present? && first_name.blank? && last_name.blank?
+          parts = name.split(",")
+          self.last_name = parts[0]&.strip&.capitalize
+          self.first_name = parts[1]&.strip&.capitalize if parts.length > 1
+        end
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/practitioner.rb
+++ b/app/models/lakeraven/ehr/practitioner.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # Practitioner model — ActiveModel-based, backed by RPMS via PractitionerGateway.
+    class Practitioner
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :ien, :integer
+      attribute :name, :string
+      attribute :npi, :string
+      attribute :dea_number, :string
+      attribute :specialty, :string
+      attribute :provider_class, :string
+      attribute :title, :string
+      attribute :service_section, :string
+      attribute :phone, :string
+
+      # Derived name parts
+      attribute :first_name, :string
+      attribute :last_name, :string
+
+      # -- Class methods -----------------------------------------------------
+
+      def self.find_by_ien(ien)
+        return nil unless ien.present? && ien.to_i > 0
+        PractitionerGateway.find(ien.to_i)
+      end
+
+      def self.search(name_pattern)
+        PractitionerGateway.search(name_pattern.to_s)
+      end
+
+      # -- Initialize --------------------------------------------------------
+
+      def initialize(attributes = {})
+        super
+        sync_composite_fields
+      end
+
+      # -- Name helpers ------------------------------------------------------
+
+      def display_name
+        return name if name.blank?
+        parts = name.split(",")
+        last = parts[0]&.strip
+        first = parts[1]&.strip
+        first.present? ? "#{first} #{last}" : last
+      end
+
+      def to_param
+        ien.to_s
+      end
+
+      # -- FHIR serialization -----------------------------------------------
+
+      def to_fhir
+        FHIR::PractitionerSerializer.call(self)
+      end
+
+      private
+
+      def sync_composite_fields
+        if first_name.present? && last_name.present? && name.blank?
+          self.name = "#{last_name},#{first_name}"
+        end
+
+        if name.present? && first_name.blank? && last_name.blank?
+          parts = name.split(",")
+          self.last_name = parts[0]&.strip&.capitalize
+          self.first_name = parts[1]&.strip&.capitalize if parts.length > 1
+        end
+      end
+    end
+  end
+end

--- a/app/services/lakeraven/ehr/fhir/patient_serializer.rb
+++ b/app/services/lakeraven/ehr/fhir/patient_serializer.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    module FHIR
+      # Serializes a Patient model to a US Core conformant FHIR R4 Patient hash.
+      class PatientSerializer
+        US_CORE_PROFILE = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+
+        def self.call(patient)
+          new(patient).to_h
+        end
+
+        def initialize(patient)
+          @p = patient
+        end
+
+        def to_h
+          resource = {
+            resourceType: "Patient",
+            id: @p.dfn.to_s,
+            meta: { profile: [ US_CORE_PROFILE ] },
+            name: [ build_name ],
+            gender: gender_value
+          }
+          resource[:birthDate] = @p.dob.iso8601 if @p.dob
+
+          ids = build_identifiers
+          resource[:identifier] = ids if ids.any?
+
+          addrs = build_addresses
+          resource[:address] = addrs if addrs.any?
+
+          telecoms = build_telecoms
+          resource[:telecom] = telecoms if telecoms.any?
+
+          resource
+        end
+
+        private
+
+        def build_name
+          return {} if @p.name.blank?
+          parts = @p.name.split(",")
+          family = parts[0]&.strip
+          given = parts[1]&.strip&.split(" ") || []
+          { use: "official", family: family, given: given }
+        end
+
+        def gender_value
+          case @p.sex
+          when "M" then "male"
+          when "F" then "female"
+          else "unknown"
+          end
+        end
+
+        def build_identifiers
+          ids = []
+          if @p.dfn.present?
+            ids << { use: "usual", system: "urn:oid:2.16.840.1.113883.4.349", value: @p.dfn.to_s }
+          end
+          if @p.ssn.present?
+            ids << { use: "secondary", system: "http://hl7.org/fhir/sid/us-ssn", value: @p.ssn }
+          end
+          ids
+        end
+
+        def build_addresses
+          return [] if @p.address_line1.blank?
+          [ { use: "home", line: [ @p.address_line1 ], city: @p.city,
+              state: @p.state, postalCode: @p.zip_code, country: "US" }.compact ]
+        end
+
+        def build_telecoms
+          return [] if @p.phone.blank?
+          [ { system: "phone", value: @p.phone, use: "home" } ]
+        end
+      end
+    end
+  end
+end

--- a/app/services/lakeraven/ehr/fhir/practitioner_serializer.rb
+++ b/app/services/lakeraven/ehr/fhir/practitioner_serializer.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    module FHIR
+      class PractitionerSerializer
+        US_CORE_PROFILE = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+
+        def self.call(practitioner)
+          new(practitioner).to_h
+        end
+
+        def initialize(practitioner)
+          @p = practitioner
+        end
+
+        def to_h
+          resource = {
+            resourceType: "Practitioner",
+            id: @p.ien.to_s,
+            meta: { profile: [ US_CORE_PROFILE ] },
+            name: [ build_name ]
+          }
+
+          ids = build_identifiers
+          resource[:identifier] = ids if ids.any?
+
+          telecoms = build_telecoms
+          resource[:telecom] = telecoms if telecoms.any?
+
+          quals = build_qualifications
+          resource[:qualification] = quals if quals.any?
+
+          resource
+        end
+
+        private
+
+        def build_name
+          return {} if @p.name.blank?
+          parts = @p.name.split(",")
+          family = parts[0]&.strip
+          given = parts[1]&.strip&.split(" ") || []
+          { use: "official", family: family, given: given }
+        end
+
+        def build_identifiers
+          ids = []
+          if @p.npi.present?
+            ids << { system: "http://hl7.org/fhir/sid/us-npi", value: @p.npi }
+          end
+          if @p.ien.present?
+            ids << { use: "usual", system: "http://ihs.gov/rpms/provider-id", value: @p.ien.to_s }
+          end
+          ids
+        end
+
+        def build_telecoms
+          return [] if @p.phone.blank?
+          [ { system: "phone", value: @p.phone, use: "work" } ]
+        end
+
+        def build_qualifications
+          return [] if @p.specialty.blank?
+          [ { code: { text: @p.specialty } } ]
+        end
+      end
+    end
+  end
+end

--- a/app/services/lakeraven/ehr/gateway_factory.rb
+++ b/app/services/lakeraven/ehr/gateway_factory.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Factory for selecting gateway adapters.
+#
+# Rails.env gates the safety boundary:
+#   - production  → always RPC
+#   - test        → always mock (unless RPC_TEST_MODE overrides)
+#   - development → RPC by default, RPMS_INTEGRATION_MODE=mock for mock
+module Lakeraven
+  module EHR
+    class GatewayFactory
+      class ConfigurationError < StandardError; end
+
+      VALID_RPC_MODES = %w[rpms_rpc rpc vista_rpc].freeze
+      VALID_MODES = (VALID_RPC_MODES + %w[mock]).freeze
+      VALID_PROTOCOLS = %w[cia xwb bmx].freeze
+
+      def self.gateway
+        return test_gateway if Rails.env.test?
+        return production_gateway if Rails.env.production?
+
+        development_gateway
+      end
+
+      def self.rpc_mode?
+        return false if Rails.env.test?
+        return true if Rails.env.production?
+        ENV["RPMS_INTEGRATION_MODE"] != "mock"
+      end
+
+      private_class_method def self.production_gateway
+        rpc_client_instance
+      end
+
+      private_class_method def self.development_gateway
+        mode = ENV["RPMS_INTEGRATION_MODE"]
+        case mode
+        when *VALID_RPC_MODES, nil then rpc_client_instance
+        when "mock" then mock_gateway_adapter
+        else
+          raise ConfigurationError, "Unknown RPMS_INTEGRATION_MODE: '#{mode}'. Valid: #{VALID_MODES.join(', ')}"
+        end
+      end
+
+      private_class_method def self.test_gateway
+        case ENV.fetch("RPC_TEST_MODE", "mock")
+        when "protocol", "real" then rpc_client_instance
+        else mock_gateway_adapter
+        end
+      end
+
+      private_class_method def self.rpc_client_instance
+        case ENV.fetch("RPC_PROTOCOL", "cia").downcase
+        when "bmx" then RpmsRpc::BmxClient.instance
+        when "cia", "xwb" then RpmsRpc::CiaClient.instance
+        else
+          raise ConfigurationError, "Unknown RPC_PROTOCOL: '#{ENV['RPC_PROTOCOL']}'. Valid: #{VALID_PROTOCOLS.join(', ')}"
+        end
+      end
+
+      private_class_method def self.mock_gateway_adapter
+        require_relative "../../../../test/support/mock_gateway_adapter"
+        MockGatewayAdapter.instance
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,5 @@
+# frozen_string_literal: true
+
 Lakeraven::EHR::Engine.routes.draw do
+  resources :patients, path: "Patient", only: [ :index, :show ], param: :dfn
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@
 
 Lakeraven::EHR::Engine.routes.draw do
   resources :patients, path: "Patient", only: [ :index, :show ], param: :dfn
+  resources :practitioners, path: "Practitioner", only: [ :index, :show ], param: :ien
 end

--- a/test/controllers/lakeraven/ehr/patients_controller_test.rb
+++ b/test/controllers/lakeraven/ehr/patients_controller_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::PatientsControllerTest < ActionDispatch::IntegrationTest
+  # MockGatewayAdapter seeds patients DFN 1-3.
+
+  test "GET /Patient/:dfn returns 200 with FHIR Patient" do
+    get "/lakeraven-ehr/Patient/1"
+    assert_response :ok
+    assert_equal "application/fhir+json", response.media_type
+    body = JSON.parse(response.body)
+    assert_equal "Patient", body["resourceType"]
+    assert_equal "1", body["id"]
+  end
+
+  test "response includes US Core profile" do
+    get "/lakeraven-ehr/Patient/1"
+    body = JSON.parse(response.body)
+    assert_includes body.dig("meta", "profile"),
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+  end
+
+  test "response includes name family and given" do
+    get "/lakeraven-ehr/Patient/1"
+    body = JSON.parse(response.body)
+    assert_equal "Anderson", body["name"].first["family"]
+    assert_includes body["name"].first["given"], "Alice"
+  end
+
+  test "response includes gender" do
+    get "/lakeraven-ehr/Patient/1"
+    body = JSON.parse(response.body)
+    assert_equal "female", body["gender"]
+  end
+
+  test "response includes SSN identifier" do
+    get "/lakeraven-ehr/Patient/1"
+    body = JSON.parse(response.body)
+    ssn_id = body["identifier"].find { |id| id["system"]&.include?("ssn") }
+    assert_not_nil ssn_id
+    assert_equal "111-11-1111", ssn_id["value"]
+  end
+
+  test "unknown DFN returns 404 OperationOutcome" do
+    get "/lakeraven-ehr/Patient/99999"
+    assert_response :not_found
+    assert_equal "application/fhir+json", response.media_type
+    body = JSON.parse(response.body)
+    assert_equal "OperationOutcome", body["resourceType"]
+    assert_equal "not-found", body["issue"].first["code"]
+  end
+
+  test "GET /Patient searches by name" do
+    get "/lakeraven-ehr/Patient", params: { name: "Anderson" }
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert_equal "Bundle", body["resourceType"]
+    assert_operator body["total"], :>=, 1
+  end
+
+  test "GET /Patient with no matches returns empty Bundle" do
+    get "/lakeraven-ehr/Patient", params: { name: "ZZZZNONEXISTENT" }
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert_equal "Bundle", body["resourceType"]
+    assert_equal 0, body["total"]
+  end
+end

--- a/test/controllers/lakeraven/ehr/practitioners_controller_test.rb
+++ b/test/controllers/lakeraven/ehr/practitioners_controller_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::PractitionersControllerTest < ActionDispatch::IntegrationTest
+  test "GET /Practitioner/:ien returns 200 with FHIR Practitioner" do
+    get "/lakeraven-ehr/Practitioner/101"
+    assert_response :ok
+    assert_equal "application/fhir+json", response.media_type
+    body = JSON.parse(response.body)
+    assert_equal "Practitioner", body["resourceType"]
+    assert_equal "101", body["id"]
+    assert_equal "MARTINEZ", body["name"].first["family"]
+  end
+
+  test "response includes NPI identifier" do
+    get "/lakeraven-ehr/Practitioner/101"
+    body = JSON.parse(response.body)
+    npi_id = body["identifier"].find { |id| id["system"]&.include?("npi") }
+    assert_equal "1234567890", npi_id["value"]
+  end
+
+  test "unknown IEN returns 404 OperationOutcome" do
+    get "/lakeraven-ehr/Practitioner/99999"
+    assert_response :not_found
+    body = JSON.parse(response.body)
+    assert_equal "OperationOutcome", body["resourceType"]
+    assert_equal "not-found", body["issue"].first["code"]
+  end
+
+  test "GET /Practitioner searches by name" do
+    get "/lakeraven-ehr/Practitioner", params: { name: "MARTINEZ" }
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert_equal "Bundle", body["resourceType"]
+    assert_equal 1, body["total"]
+  end
+
+  test "GET /Practitioner with no matches returns empty Bundle" do
+    get "/lakeraven-ehr/Practitioner", params: { name: "ZZZZNONEXISTENT" }
+    assert_response :ok
+    body = JSON.parse(response.body)
+    assert_equal 0, body["total"]
+  end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  mount Lakeraven::Ehr::Engine => "/lakeraven-ehr"
+  mount Lakeraven::EHR::Engine => "/lakeraven-ehr"
 end

--- a/test/models/lakeraven/ehr/patient_test.rb
+++ b/test/models/lakeraven/ehr/patient_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::PatientTest < ActiveSupport::TestCase
+  # GatewayFactory defaults to mock in test env.
+  # MockGatewayAdapter seeds patients DFN 1-5 on first use.
+
+  # -- find_by_dfn -----------------------------------------------------------
+
+  test "find_by_dfn returns a Patient for a known DFN" do
+    patient = Lakeraven::EHR::Patient.find_by_dfn(1)
+    assert_not_nil patient
+    assert_kind_of Lakeraven::EHR::Patient, patient
+    assert_equal 1, patient.dfn
+    assert_equal "Anderson,Alice", patient.name
+    assert_equal "F", patient.sex
+  end
+
+  test "find_by_dfn returns nil for unknown DFN" do
+    assert_nil Lakeraven::EHR::Patient.find_by_dfn(99999)
+  end
+
+  test "find_by_dfn returns nil for zero" do
+    assert_nil Lakeraven::EHR::Patient.find_by_dfn(0)
+  end
+
+  test "find_by_dfn returns nil for nil" do
+    assert_nil Lakeraven::EHR::Patient.find_by_dfn(nil)
+  end
+
+  test "find_by_dfn merges extended demographics" do
+    patient = Lakeraven::EHR::Patient.find_by_dfn(1)
+    assert_equal "AMERICAN INDIAN", patient.race
+    assert_equal "123 Main St", patient.address_line1
+    assert_equal "AK", patient.state
+    assert_equal "907-555-1234", patient.phone
+    assert_equal "ANLC-12345", patient.tribal_enrollment_number
+  end
+
+  # -- search ----------------------------------------------------------------
+
+  test "search returns patients matching name pattern" do
+    results = Lakeraven::EHR::Patient.search("Anderson")
+    assert_operator results.length, :>=, 1
+    assert results.all? { |p| p.is_a?(Lakeraven::EHR::Patient) }
+  end
+
+  test "search returns empty array for no matches" do
+    assert_equal [], Lakeraven::EHR::Patient.search("ZZZZNONEXISTENT")
+  end
+
+  # -- composite fields ------------------------------------------------------
+
+  test "name syncs to first_name and last_name" do
+    patient = Lakeraven::EHR::Patient.new(name: "DOE,JOHN")
+    assert_equal "Doe", patient.last_name
+    assert_equal "John", patient.first_name
+  end
+
+  test "first_name and last_name sync to name" do
+    patient = Lakeraven::EHR::Patient.new(first_name: "Jane", last_name: "Smith")
+    assert_equal "Smith,Jane", patient.name
+  end
+
+  # -- display_name ----------------------------------------------------------
+
+  test "display_name formats MUMPS name for display" do
+    patient = Lakeraven::EHR::Patient.new(name: "DOE,JOHN")
+    assert_equal "JOHN DOE", patient.display_name
+  end
+
+  # -- to_fhir ---------------------------------------------------------------
+
+  test "to_fhir returns a FHIR Patient hash" do
+    patient = Lakeraven::EHR::Patient.find_by_dfn(1)
+    fhir = patient.to_fhir
+
+    assert_equal "Patient", fhir[:resourceType]
+    assert_equal "1", fhir[:id]
+    assert_includes fhir.dig(:meta, :profile), "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+    assert_equal "Anderson", fhir[:name].first[:family]
+    assert_equal "female", fhir[:gender]
+  end
+end

--- a/test/models/lakeraven/ehr/practitioner_test.rb
+++ b/test/models/lakeraven/ehr/practitioner_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Lakeraven::EHR::PractitionerTest < ActiveSupport::TestCase
+  # MockGatewayAdapter seeds practitioners IEN 101-102.
+
+  # -- find_by_ien -----------------------------------------------------------
+
+  test "find_by_ien returns a Practitioner for a known IEN" do
+    prac = Lakeraven::EHR::Practitioner.find_by_ien(101)
+    assert_not_nil prac
+    assert_kind_of Lakeraven::EHR::Practitioner, prac
+    assert_equal 101, prac.ien
+    assert_equal "MARTINEZ,SARAH", prac.name
+    assert_equal "Cardiology", prac.specialty
+    assert_equal "1234567890", prac.npi
+    assert_equal "Physician", prac.provider_class
+  end
+
+  test "find_by_ien returns nil for unknown IEN" do
+    assert_nil Lakeraven::EHR::Practitioner.find_by_ien(99999)
+  end
+
+  test "find_by_ien returns nil for nil" do
+    assert_nil Lakeraven::EHR::Practitioner.find_by_ien(nil)
+  end
+
+  # -- search ----------------------------------------------------------------
+
+  test "search returns practitioners matching name pattern" do
+    results = Lakeraven::EHR::Practitioner.search("MARTINEZ")
+    assert_equal 1, results.length
+    assert_equal "MARTINEZ,SARAH", results.first.name
+  end
+
+  test "search with empty string returns all practitioners" do
+    results = Lakeraven::EHR::Practitioner.search("")
+    assert_equal 2, results.length
+  end
+
+  test "search returns empty array for no matches" do
+    assert_equal [], Lakeraven::EHR::Practitioner.search("ZZZZNONEXISTENT")
+  end
+
+  # -- composite fields ------------------------------------------------------
+
+  test "name syncs to first_name and last_name" do
+    prac = Lakeraven::EHR::Practitioner.new(name: "CHEN,JAMES")
+    assert_equal "Chen", prac.last_name
+    assert_equal "James", prac.first_name
+  end
+
+  # -- display_name ----------------------------------------------------------
+
+  test "display_name formats MUMPS name for display" do
+    prac = Lakeraven::EHR::Practitioner.new(name: "MARTINEZ,SARAH")
+    assert_equal "SARAH MARTINEZ", prac.display_name
+  end
+
+  # -- to_fhir ---------------------------------------------------------------
+
+  test "to_fhir returns a FHIR Practitioner hash" do
+    prac = Lakeraven::EHR::Practitioner.find_by_ien(101)
+    fhir = prac.to_fhir
+
+    assert_equal "Practitioner", fhir[:resourceType]
+    assert_equal "101", fhir[:id]
+    assert_equal "MARTINEZ", fhir[:name].first[:family]
+    npi_id = fhir[:identifier].find { |id| id[:system]&.include?("npi") }
+    assert_equal "1234567890", npi_id[:value]
+  end
+end

--- a/test/support/mock_gateway_adapter.rb
+++ b/test/support/mock_gateway_adapter.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "singleton"
+require "monitor"
+
+# Mock Gateway Adapter — simulates RPMS RPC responses for tests.
+# Responds to call_rpc with caret-delimited strings matching real RPC formats.
+class MockGatewayAdapter
+  include Singleton
+
+  def initialize
+    super
+    @patients = {}
+    @practitioners = {}
+    @mutex = Monitor.new
+    @seeded = false
+  end
+
+  def call_rpc(rpc_name, *params)
+    ensure_seeded!
+    raw = call_rpc_raw(rpc_name, *params)
+    raw.to_s.split("\n").map { |line| line.delete("\r") }
+  end
+
+  def call_rpc_raw(rpc_name, *params)
+    ensure_seeded!
+
+    case rpc_name
+    when "ORWPT SELECT"
+      dfn = params[0].to_i
+      p = @patients[dfn]
+      return "" unless p
+      age = p[:dob] ? ((Date.current - p[:dob]).to_i / 365) : ""
+      "#{p[:name]}^#{p[:sex]}^#{format_date(p[:dob])}^#{p[:ssn]}^^^^^^^^^^^#{age}"
+
+    when "ORWPT ID INFO"
+      dfn = params[0].to_i
+      p = @patients[dfn]
+      return "" unless p
+      "#{p[:name]}^#{p[:sex]}^#{format_date(p[:dob])}^#{p[:ssn]}^#{p[:race]}^#{p[:address_line1]}^#{p[:city]}^#{p[:state]}^#{p[:zip_code]}^#{p[:phone]}^#{p[:tribal_enrollment_number]}^#{p[:service_area]}^#{p[:coverage_type]}"
+
+    when "ORWPT LIST ALL"
+      pattern = params[0].to_s
+      matching = @patients.select { |_dfn, p| name_matches?(p[:name], pattern) }
+      matching.map { |dfn, p| "#{dfn}^#{p[:name]}" }.join("\r\n")
+
+    when "ORWPT FULLSSN"
+      ssn = params[0].to_s
+      match = @patients.find { |_dfn, p| p[:ssn] == ssn }
+      match ? "#{match[0]}^#{match[1][:name]}^^#{match[1][:ssn]}" : ""
+
+    when "ORWU USERINFO"
+      ien = params[0].to_i
+      pr = @practitioners[ien]
+      return "" unless pr
+      "#{pr[:name]}^#{pr[:title]}^#{pr[:service_section]}^#{pr[:specialty]}^#{pr[:npi]}^#{pr[:dea_number]}^#{pr[:phone]}^#{pr[:provider_class]}"
+
+    when "ORWU NEWPERS"
+      pattern = params[0].to_s
+      matching = @practitioners.select { |_ien, pr| name_matches?(pr[:name], pattern) }
+      matching.map { |ien, pr| "#{ien}^#{pr[:name]}^#{pr[:title]}" }.join("\r\n")
+
+    when "XUS SIGNON SETUP"
+      "OK"
+
+    else
+      Rails.logger.warn("MockGatewayAdapter: Unknown RPC: #{rpc_name}") if defined?(Rails)
+      ""
+    end
+  end
+
+  private
+
+  def ensure_seeded!
+    return if @seeded
+    @mutex.synchronize do
+      return if @seeded
+      seed_patients
+      seed_practitioners
+      @seeded = true
+    end
+  end
+
+  def seed_patients
+    @patients[1] = { name: "Anderson,Alice", sex: "F", dob: Date.parse("1980-05-15"), ssn: "111-11-1111",
+                     race: "AMERICAN INDIAN", address_line1: "123 Main St", city: "Anchorage", state: "AK",
+                     zip_code: "99501", phone: "907-555-1234", tribal_enrollment_number: "ANLC-12345",
+                     service_area: "Anchorage", coverage_type: "IHS" }
+    @patients[2] = { name: "MOUSE,MICKEY M", sex: "M", dob: Date.parse("2010-02-14"), ssn: "000009999",
+                     race: "AMERICAN INDIAN", address_line1: "456 Disney Ave", city: "Orlando", state: "FL",
+                     zip_code: "32801", phone: "555-5678", tribal_enrollment_number: "NN-67890",
+                     service_area: "Arizona", coverage_type: "IHS/Medicaid" }
+    @patients[3] = { name: "DOE,JANE", sex: "F", dob: Date.parse("1990-12-25"), ssn: "555667777",
+                     race: "AMERICAN INDIAN", tribal_enrollment_number: "CNO-24680",
+                     service_area: "Oklahoma", coverage_type: "IHS" }
+  end
+
+  def seed_practitioners
+    @practitioners[101] = { name: "MARTINEZ,SARAH", title: "MD", service_section: "Internal Medicine",
+                            specialty: "Cardiology", npi: "1234567890", phone: "907-555-9999",
+                            provider_class: "Physician" }
+    @practitioners[102] = { name: "CHEN,JAMES", title: "DO", service_section: "Surgery",
+                            specialty: "Orthopedic Surgery", npi: "2345678901", phone: "907-555-8888",
+                            provider_class: "Physician" }
+  end
+
+  def name_matches?(name, pattern)
+    return true if pattern.blank?
+    name.to_s.upcase.start_with?(pattern.upcase)
+  end
+
+  def format_date(date)
+    return "" unless date
+    year_code = ((date.year - 1700) / 100.0).floor + 1
+    century_year = date.year % 100
+    format("%d%02d%02d%02d", year_code, century_year, date.month, date.day)
+  end
+end


### PR DESCRIPTION
## Summary
- Patient model (ActiveModel, no DB) with `find_by_dfn`, `search`, `find_by_ssn`
- PatientGateway — thin orchestrator over rpms-rpc DataMapper DSL
- FHIR::PatientSerializer — US Core conformant Patient resource
- GatewayFactory — env-var-driven mock/RPC switching
- BaseGateway — shared RPC client access
- MockGatewayAdapter — seed data for tests (patients DFN 1-3, practitioners IEN 101-102)

## Architecture
```
Patient.find_by_dfn(1)
  → PatientGateway.find(1)
    → rpc_client.call_rpc("ORWPT SELECT", "1")
    → DataMapper[:patient_select].parse_one(response)
    → Patient.new(**attrs)
```

Two layers (model → gateway → rpms-rpc). No repository middleman, no opaque identifiers.

## Test plan
- [x] find_by_dfn for known/unknown/zero/nil DFN
- [x] Extended demographics merge (race, address, phone, tribal)
- [x] search by name pattern + empty results
- [x] Composite field sync (name ↔ first_name/last_name)
- [x] display_name formatting
- [x] to_fhir returns US Core Patient with correct id, profile, name, gender

🤖 Generated with [Claude Code](https://claude.com/claude-code)