### PR TITLE
SMART EHR launch context model

### DIFF
--- a/app/models/lakeraven/ehr/launch_context.rb
+++ b/app/models/lakeraven/ehr/launch_context.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # SMART EHR launch context — DB-backed token that binds a patient
+    # (and optionally an encounter) to an OAuth authorization flow.
+    #
+    # The host app calls LaunchContext.mint when the EHR user initiates
+    # a SMART app launch. The token endpoint calls LaunchContext.resolve
+    # to look up the patient context and include it in the token response.
+    #
+    # Same pattern as Doorkeeper: engine owns the table + model,
+    # host app wires it to their auth/session.
+    class LaunchContext < ApplicationRecord
+      self.table_name = "lakeraven_ehr_launch_contexts"
+
+      DEFAULT_TTL = 5.minutes
+
+      validates :launch_token, presence: true, uniqueness: true
+      validates :oauth_application_uid, presence: true
+      validates :expires_at, presence: true
+
+      # Mint a new launch context with a unique token.
+      def self.mint(oauth_application_uid:, patient_dfn: nil, encounter_id: nil, facility_identifier: nil, ttl: DEFAULT_TTL)
+        create!(
+          launch_token: generate_token,
+          oauth_application_uid: oauth_application_uid,
+          patient_dfn: patient_dfn,
+          encounter_id: encounter_id,
+          facility_identifier: facility_identifier,
+          expires_at: Time.current + ttl
+        )
+      end
+
+      # Resolve a launch token to its context. Returns nil if expired or not found.
+      def self.resolve(token)
+        find_by("launch_token = ? AND expires_at > ?", token, Time.current)
+      end
+
+      # SMART context fields for the token response.
+      def to_smart_context
+        context = {}
+        context[:patient] = patient_dfn if patient_dfn.present?
+        context[:encounter] = encounter_id if encounter_id.present?
+        context
+      end
+
+      def self.generate_token
+        "lc_#{SecureRandom.urlsafe_base64(24)}"
+      end
+      private_class_method :generate_token
+    end
+  end
+end

--- a/db/migrate/20260421080000_create_launch_contexts.rb
+++ b/db/migrate/20260421080000_create_launch_contexts.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateLaunchContexts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :lakeraven_ehr_launch_contexts do |t|
+      t.string :launch_token, null: false, index: { unique: true }
+      t.string :oauth_application_uid, null: false
+      t.string :patient_dfn
+      t.string :encounter_id
+      t.string :facility_identifier
+      t.datetime :expires_at, null: false
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 20_260_421_072_524) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_080000) do
+  create_table "lakeraven_ehr_launch_contexts", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "encounter_id"
+    t.datetime "expires_at", null: false
+    t.string "facility_identifier"
+    t.string "launch_token", null: false
+    t.string "oauth_application_uid", null: false
+    t.string "patient_dfn"
+    t.datetime "updated_at", null: false
+    t.index ["launch_token"], name: "index_lakeraven_ehr_launch_contexts_on_launch_token", unique: true
+  end
+
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer "application_id", null: false
     t.datetime "created_at", null: false
@@ -22,9 +32,9 @@ ActiveRecord::Schema[8.1].define(version: 20_260_421_072_524) do
     t.datetime "revoked_at"
     t.string "scopes", default: "", null: false
     t.string "token", null: false
-    t.index [ "application_id" ], name: "index_oauth_access_grants_on_application_id"
-    t.index [ "resource_owner_id" ], name: "index_oauth_access_grants_on_resource_owner_id"
-    t.index [ "token" ], name: "index_oauth_access_grants_on_token", unique: true
+    t.index ["application_id"], name: "index_oauth_access_grants_on_application_id"
+    t.index ["resource_owner_id"], name: "index_oauth_access_grants_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 
   create_table "oauth_access_tokens", force: :cascade do |t|
@@ -37,10 +47,10 @@ ActiveRecord::Schema[8.1].define(version: 20_260_421_072_524) do
     t.datetime "revoked_at"
     t.string "scopes"
     t.string "token", null: false
-    t.index [ "application_id" ], name: "index_oauth_access_tokens_on_application_id"
-    t.index [ "refresh_token" ], name: "index_oauth_access_tokens_on_refresh_token", unique: true
-    t.index [ "resource_owner_id" ], name: "index_oauth_access_tokens_on_resource_owner_id"
-    t.index [ "token" ], name: "index_oauth_access_tokens_on_token", unique: true
+    t.index ["application_id"], name: "index_oauth_access_tokens_on_application_id"
+    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
+    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
   end
 
   create_table "oauth_applications", force: :cascade do |t|
@@ -52,7 +62,7 @@ ActiveRecord::Schema[8.1].define(version: 20_260_421_072_524) do
     t.string "secret", null: false
     t.string "uid", null: false
     t.datetime "updated_at", null: false
-    t.index [ "uid" ], name: "index_oauth_applications_on_uid", unique: true
+    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -20,7 +20,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_080000) do
     t.string "oauth_application_uid", null: false
     t.string "patient_dfn"
     t.datetime "updated_at", null: false
-    t.index ["launch_token"], name: "index_lakeraven_ehr_launch_contexts_on_launch_token", unique: true
+    t.index [ "launch_token" ], name: "index_lakeraven_ehr_launch_contexts_on_launch_token", unique: true
   end
 
   create_table "oauth_access_grants", force: :cascade do |t|
@@ -32,9 +32,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_080000) do
     t.datetime "revoked_at"
     t.string "scopes", default: "", null: false
     t.string "token", null: false
-    t.index ["application_id"], name: "index_oauth_access_grants_on_application_id"
-    t.index ["resource_owner_id"], name: "index_oauth_access_grants_on_resource_owner_id"
-    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
+    t.index [ "application_id" ], name: "index_oauth_access_grants_on_application_id"
+    t.index [ "resource_owner_id" ], name: "index_oauth_access_grants_on_resource_owner_id"
+    t.index [ "token" ], name: "index_oauth_access_grants_on_token", unique: true
   end
 
   create_table "oauth_access_tokens", force: :cascade do |t|
@@ -47,10 +47,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_080000) do
     t.datetime "revoked_at"
     t.string "scopes"
     t.string "token", null: false
-    t.index ["application_id"], name: "index_oauth_access_tokens_on_application_id"
-    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
-    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
-    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
+    t.index [ "application_id" ], name: "index_oauth_access_tokens_on_application_id"
+    t.index [ "refresh_token" ], name: "index_oauth_access_tokens_on_refresh_token", unique: true
+    t.index [ "resource_owner_id" ], name: "index_oauth_access_tokens_on_resource_owner_id"
+    t.index [ "token" ], name: "index_oauth_access_tokens_on_token", unique: true
   end
 
   create_table "oauth_applications", force: :cascade do |t|
@@ -62,7 +62,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_080000) do
     t.string "secret", null: false
     t.string "uid", null: false
     t.datetime "updated_at", null: false
-    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
+    t.index [ "uid" ], name: "index_oauth_applications_on_uid", unique: true
   end
 
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"

--- a/test/models/lakeraven/ehr/launch_context_test.rb
+++ b/test/models/lakeraven/ehr/launch_context_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class LaunchContextTest < ActiveSupport::TestCase
+      setup do
+        @app = Doorkeeper::Application.create!(
+          name: "test", redirect_uri: "https://example.test/callback",
+          scopes: "launch patient/Patient.read", confidential: true
+        )
+      end
+
+      teardown do
+        LaunchContext.delete_all
+        Doorkeeper::Application.delete_all
+      end
+
+      test "mint creates a launch context with a token" do
+        ctx = LaunchContext.mint(
+          oauth_application_uid: @app.uid,
+          patient_dfn: "1",
+          facility_identifier: "fac_main"
+        )
+
+        assert ctx.persisted?
+        assert ctx.launch_token.present?
+        assert_equal @app.uid, ctx.oauth_application_uid
+        assert_equal "1", ctx.patient_dfn
+        assert_equal "fac_main", ctx.facility_identifier
+      end
+
+      test "launch_token starts with lc_ prefix" do
+        ctx = LaunchContext.mint(
+          oauth_application_uid: @app.uid,
+          patient_dfn: "1"
+        )
+
+        assert ctx.launch_token.start_with?("lc_")
+      end
+
+      test "resolve finds a valid launch context by token" do
+        ctx = LaunchContext.mint(
+          oauth_application_uid: @app.uid,
+          patient_dfn: "1"
+        )
+
+        found = LaunchContext.resolve(ctx.launch_token)
+        assert_equal ctx.id, found.id
+        assert_equal "1", found.patient_dfn
+      end
+
+      test "resolve returns nil for unknown token" do
+        assert_nil LaunchContext.resolve("lc_nonexistent")
+      end
+
+      test "resolve returns nil for expired token" do
+        ctx = LaunchContext.mint(
+          oauth_application_uid: @app.uid,
+          patient_dfn: "1",
+          ttl: 1.minute
+        )
+
+        travel 2.minutes
+        assert_nil LaunchContext.resolve(ctx.launch_token)
+      ensure
+        travel_back
+      end
+
+      test "patient_dfn is optional" do
+        ctx = LaunchContext.mint(oauth_application_uid: @app.uid)
+
+        assert ctx.persisted?
+        assert_nil ctx.patient_dfn
+      end
+
+      test "token response includes patient when launch resolves" do
+        ctx = LaunchContext.mint(
+          oauth_application_uid: @app.uid,
+          patient_dfn: "42"
+        )
+
+        smart_context = ctx.to_smart_context
+        assert_equal "42", smart_context[:patient]
+      end
+
+      test "token response omits patient when no patient_dfn" do
+        ctx = LaunchContext.mint(oauth_application_uid: @app.uid)
+
+        smart_context = ctx.to_smart_context
+        refute smart_context.key?(:patient)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- LaunchContext model (ActiveRecord) for SMART EHR launch flow
- Token minting with `lc_` prefix and configurable TTL (default 5 min)
- `resolve` finds valid (non-expired) context by token
- `to_smart_context` returns patient/encounter fields for token response
- DB migration ships with the engine (like Doorkeeper)

## Test plan
- [x] mint creates persisted context with token
- [x] Token starts with lc_ prefix
- [x] resolve finds valid context
- [x] resolve returns nil for unknown token
- [x] resolve returns nil for expired token
- [x] patient_dfn is optional
- [x] to_smart_context includes patient when set
- [x] to_smart_context omits patient when unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)