### PR TITLE
PHI audit logging with automatic capture on FHIR requests

### DIFF
--- a/app/controllers/concerns/lakeraven/ehr/auditable_clinical_access.rb
+++ b/app/controllers/concerns/lakeraven/ehr/auditable_clinical_access.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # After-action concern that logs every authenticated FHIR request
+    # as an AuditEvent. Skips when no token is present (401 responses).
+    module AuditableClinicalAccess
+      extend ActiveSupport::Concern
+
+      included do
+        after_action :record_audit_event
+      end
+
+      private
+
+      def record_audit_event
+        return unless current_token
+
+        AuditEvent.create!(
+          event_type: "rest",
+          action: "R",
+          outcome: audit_outcome,
+          entity_type: fhir_resource_type,
+          entity_identifier: audit_entity_identifier,
+          agent_who_type: "Application",
+          agent_who_identifier: current_token.application&.uid,
+          tenant_identifier: request.headers["X-Tenant-Identifier"],
+          facility_identifier: request.headers["X-Facility-Identifier"]
+        )
+      rescue => e
+        Rails.logger.error("AuditEvent write failed: #{e.message}")
+      end
+
+      def audit_outcome
+        case response.status
+        when 200..299 then "0"   # success
+        when 400..499 then "4"   # minor failure
+        else "8"                 # serious failure
+        end
+      end
+
+      def audit_entity_identifier
+        params[:dfn] || params[:ien] || params[:id]
+      end
+    end
+  end
+end

--- a/app/controllers/lakeraven/ehr/application_controller.rb
+++ b/app/controllers/lakeraven/ehr/application_controller.rb
@@ -4,6 +4,7 @@ module Lakeraven
   module EHR
     class ApplicationController < ActionController::API
       include SmartAuthentication
+      include AuditableClinicalAccess
 
       FHIR_CONTENT_TYPE = "application/fhir+json"
 

--- a/app/models/lakeraven/ehr/audit_event.rb
+++ b/app/models/lakeraven/ehr/audit_event.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # PHI audit log — every authenticated FHIR read produces a row.
+    # Immutable once written (ReadOnlyRecord on update).
+    # No PHI in the row itself — only identifiers per ADR 0002.
+    class AuditEvent < ApplicationRecord
+      self.table_name = "lakeraven_ehr_audit_events"
+
+      validates :event_type, presence: true
+      validates :action, presence: true
+      validates :outcome, presence: true
+      validates :entity_type, presence: true
+
+      scope :recent, -> { order(created_at: :desc) }
+
+      def readonly?
+        persisted?
+      end
+    end
+  end
+end

--- a/db/migrate/20260421090000_create_audit_events.rb
+++ b/db/migrate/20260421090000_create_audit_events.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateAuditEvents < ActiveRecord::Migration[8.1]
+  def change
+    create_table :lakeraven_ehr_audit_events do |t|
+      t.string :event_type, null: false
+      t.string :action, null: false
+      t.string :outcome, null: false
+      t.string :entity_type
+      t.string :entity_identifier
+      t.string :agent_who_type
+      t.string :agent_who_identifier
+      t.string :tenant_identifier
+      t.string :facility_identifier
+      t.timestamps
+    end
+
+    add_index :lakeraven_ehr_audit_events, :created_at
+    add_index :lakeraven_ehr_audit_events, :entity_type
+    add_index :lakeraven_ehr_audit_events, :tenant_identifier
+  end
+end

--- a/test/controllers/lakeraven/ehr/audit_logging_test.rb
+++ b/test/controllers/lakeraven/ehr/audit_logging_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class AuditLoggingTest < ActionDispatch::IntegrationTest
+      setup do
+        AuditEvent.delete_all
+        @oauth_app = Doorkeeper::Application.create!(
+          name: "test", redirect_uri: "https://example.test/callback",
+          scopes: "system/Patient.read", confidential: true
+        )
+        token = Doorkeeper::AccessToken.create!(
+          application: @oauth_app, scopes: "system/Patient.read", expires_in: 3600
+        )
+        @headers = { "Authorization" => "Bearer #{token.plaintext_token || token.token}" }
+      end
+
+      teardown do
+        AuditEvent.delete_all
+        Doorkeeper::AccessToken.delete_all
+        Doorkeeper::Application.delete_all
+      end
+
+      test "successful GET produces an AuditEvent" do
+        assert_difference -> { AuditEvent.count }, 1 do
+          get "/lakeraven-ehr/Patient/1", headers: @headers
+        end
+
+        event = AuditEvent.recent.first
+        assert_equal "rest", event.event_type
+        assert_equal "R", event.action
+        assert_equal "0", event.outcome
+        assert_equal "Patient", event.entity_type
+        assert_equal "1", event.entity_identifier
+        assert_equal "Application", event.agent_who_type
+        assert_equal @oauth_app.uid, event.agent_who_identifier
+      end
+
+      test "404 response produces an AuditEvent with minor-failure outcome" do
+        assert_difference -> { AuditEvent.count }, 1 do
+          get "/lakeraven-ehr/Patient/99999", headers: @headers
+        end
+
+        event = AuditEvent.recent.first
+        assert_equal "4", event.outcome
+      end
+
+      test "401 auth failure does NOT produce an AuditEvent" do
+        assert_no_difference -> { AuditEvent.count } do
+          get "/lakeraven-ehr/Patient/1"
+        end
+      end
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_21_080000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_090000) do
+  create_table "lakeraven_ehr_audit_events", force: :cascade do |t|
+    t.string "action", null: false
+    t.string "agent_who_identifier"
+    t.string "agent_who_type"
+    t.datetime "created_at", null: false
+    t.string "entity_identifier"
+    t.string "entity_type"
+    t.string "event_type", null: false
+    t.string "facility_identifier"
+    t.string "outcome", null: false
+    t.string "tenant_identifier"
+    t.datetime "updated_at", null: false
+    t.index [ "created_at" ], name: "index_lakeraven_ehr_audit_events_on_created_at"
+    t.index [ "entity_type" ], name: "index_lakeraven_ehr_audit_events_on_entity_type"
+    t.index [ "tenant_identifier" ], name: "index_lakeraven_ehr_audit_events_on_tenant_identifier"
+  end
+
   create_table "lakeraven_ehr_launch_contexts", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "encounter_id"

--- a/test/models/lakeraven/ehr/audit_event_test.rb
+++ b/test/models/lakeraven/ehr/audit_event_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class AuditEventTest < ActiveSupport::TestCase
+      teardown do
+        AuditEvent.delete_all
+      end
+
+      test "creates an audit event with required fields" do
+        event = AuditEvent.create!(
+          event_type: "rest",
+          action: "R",
+          outcome: "0",
+          entity_type: "Patient",
+          entity_identifier: "1",
+          agent_who_type: "Application",
+          agent_who_identifier: "test-app"
+        )
+
+        assert event.persisted?
+        assert_equal "rest", event.event_type
+        assert_equal "R", event.action
+        assert_equal "0", event.outcome
+      end
+
+      test "audit rows are immutable" do
+        event = AuditEvent.create!(
+          event_type: "rest", action: "R", outcome: "0",
+          entity_type: "Patient", entity_identifier: "1",
+          agent_who_type: "Application", agent_who_identifier: "test-app"
+        )
+
+        assert_raises(ActiveRecord::ReadOnlyRecord) { event.update!(outcome: "4") }
+      end
+
+      test "recent scope returns newest first" do
+        old = AuditEvent.create!(
+          event_type: "rest", action: "R", outcome: "0",
+          entity_type: "Patient", entity_identifier: "1",
+          agent_who_type: "Application", agent_who_identifier: "app1"
+        )
+
+        new_event = AuditEvent.create!(
+          event_type: "rest", action: "R", outcome: "0",
+          entity_type: "Patient", entity_identifier: "2",
+          agent_who_type: "Application", agent_who_identifier: "app2"
+        )
+
+        assert_equal new_event.id, AuditEvent.recent.first.id
+      end
+
+      test "validates required fields" do
+        event = AuditEvent.new
+        assert_not event.valid?
+        assert_includes event.errors[:event_type], "can't be blank"
+        assert_includes event.errors[:action], "can't be blank"
+        assert_includes event.errors[:outcome], "can't be blank"
+        assert_includes event.errors[:entity_type], "can't be blank"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- AuditEvent model (ActiveRecord, immutable once persisted)
- AuditableClinicalAccess concern: after_action on all FHIR controllers
- Logs event_type, action, outcome, entity_type/identifier, agent, tenant/facility
- Skips when no token present (401s don't audit — no authenticated actor)
- Outcome mapping: 2xx→"0" (success), 4xx→"4" (minor failure), 5xx→"8" (serious)

## Test plan
- [x] AuditEvent creates with required fields
- [x] Audit rows are immutable (ReadOnlyRecord)
- [x] recent scope returns newest first
- [x] Validates required fields
- [x] Successful GET produces AuditEvent with outcome "0"
- [x] 404 produces AuditEvent with outcome "4"
- [x] 401 does NOT produce AuditEvent
- [x] 61 tests, 139 assertions, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)