### PR TITLE
FHIR clinical resources: AllergyIntolerance, Condition, MedicationRequest, Observation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/lakeraven/rpms-rpc.git
-  revision: 3ac2c769fc34df296484e4ff2947311ac0e1a5bc
+  revision: 31360faecf155190f75c1658b92bf9408f7d602a
   branch: main
   specs:
     rpms-rpc (0.1.0)

--- a/app/controllers/lakeraven/ehr/allergy_intolerances_controller.rb
+++ b/app/controllers/lakeraven/ehr/allergy_intolerances_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class AllergyIntolerancesController < ApplicationController
+      before_action :require_patient_param, only: :index
+
+      def index
+        dfn = extract_patient_dfn(params[:patient])
+        results = AllergyIntolerance.for_patient(dfn)
+        render_bundle(results.map { |r| { resourceType: "AllergyIntolerance" }.merge(r) })
+      end
+
+      private
+
+      def require_patient_param
+        return if params[:patient].present?
+
+        render_operation_outcome(
+          status: :bad_request,
+          severity: "error",
+          code: "required",
+          diagnostics: "Search parameter 'patient' is required"
+        )
+      end
+
+      def extract_patient_dfn(param)
+        param.to_s.delete_prefix("Patient/")
+      end
+    end
+  end
+end

--- a/app/controllers/lakeraven/ehr/conditions_controller.rb
+++ b/app/controllers/lakeraven/ehr/conditions_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class ConditionsController < ApplicationController
+      before_action :require_patient_param, only: :index
+
+      def index
+        dfn = extract_patient_dfn(params[:patient])
+        results = Condition.for_patient(dfn)
+        render_bundle(results.map { |r| { resourceType: "Condition" }.merge(r) })
+      end
+
+      private
+
+      def require_patient_param
+        return if params[:patient].present?
+
+        render_operation_outcome(
+          status: :bad_request,
+          severity: "error",
+          code: "required",
+          diagnostics: "Search parameter 'patient' is required"
+        )
+      end
+
+      def extract_patient_dfn(param)
+        param.to_s.delete_prefix("Patient/")
+      end
+    end
+  end
+end

--- a/app/controllers/lakeraven/ehr/medication_requests_controller.rb
+++ b/app/controllers/lakeraven/ehr/medication_requests_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class MedicationRequestsController < ApplicationController
+      before_action :require_patient_param, only: :index
+
+      def index
+        dfn = extract_patient_dfn(params[:patient])
+        results = MedicationRequest.for_patient(dfn)
+        render_bundle(results.map { |r| { resourceType: "MedicationRequest" }.merge(r) })
+      end
+
+      private
+
+      def require_patient_param
+        return if params[:patient].present?
+
+        render_operation_outcome(
+          status: :bad_request,
+          severity: "error",
+          code: "required",
+          diagnostics: "Search parameter 'patient' is required"
+        )
+      end
+
+      def extract_patient_dfn(param)
+        param.to_s.delete_prefix("Patient/")
+      end
+    end
+  end
+end

--- a/app/controllers/lakeraven/ehr/observations_controller.rb
+++ b/app/controllers/lakeraven/ehr/observations_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class ObservationsController < ApplicationController
+      before_action :require_patient_param, only: :index
+
+      def index
+        dfn = extract_patient_dfn(params[:patient])
+        results = Observation.for_patient(dfn)
+        render_bundle(results.map { |r| { resourceType: "Observation" }.merge(r) })
+      end
+
+      private
+
+      def require_patient_param
+        return if params[:patient].present?
+
+        render_operation_outcome(
+          status: :bad_request,
+          severity: "error",
+          code: "required",
+          diagnostics: "Search parameter 'patient' is required"
+        )
+      end
+
+      def extract_patient_dfn(param)
+        param.to_s.delete_prefix("Patient/")
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/allergy_intolerance_gateway.rb
+++ b/app/gateways/lakeraven/ehr/allergy_intolerance_gateway.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+
+require "rpms_rpc/mappings"
+module Lakeraven
+  module EHR
+    class AllergyIntoleranceGateway < BaseGateway
+      def self.for_patient(dfn)
+        RpmsRpc::DataMapper.allergy_list.fetch_many(rpc_client, dfn.to_s)
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/condition_gateway.rb
+++ b/app/gateways/lakeraven/ehr/condition_gateway.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+
+require "rpms_rpc/mappings"
+module Lakeraven
+  module EHR
+    class ConditionGateway < BaseGateway
+      def self.for_patient(dfn)
+        RpmsRpc::DataMapper.problem_list.fetch_many(rpc_client, dfn.to_s)
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/medication_request_gateway.rb
+++ b/app/gateways/lakeraven/ehr/medication_request_gateway.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+
+require "rpms_rpc/mappings"
+module Lakeraven
+  module EHR
+    class MedicationRequestGateway < BaseGateway
+      def self.for_patient(dfn)
+        RpmsRpc::DataMapper.medication_list.fetch_many(rpc_client, dfn.to_s)
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/observation_gateway.rb
+++ b/app/gateways/lakeraven/ehr/observation_gateway.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+
+require "rpms_rpc/mappings"
+module Lakeraven
+  module EHR
+    class ObservationGateway < BaseGateway
+      def self.for_patient(dfn)
+        RpmsRpc::DataMapper.vitals.fetch_many(rpc_client, dfn.to_s)
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/allergy_intolerance.rb
+++ b/app/models/lakeraven/ehr/allergy_intolerance.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class AllergyIntolerance
+      def self.for_patient(dfn)
+        AllergyIntoleranceGateway.for_patient(dfn)
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/condition.rb
+++ b/app/models/lakeraven/ehr/condition.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class Condition
+      def self.for_patient(dfn)
+        ConditionGateway.for_patient(dfn)
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/medication_request.rb
+++ b/app/models/lakeraven/ehr/medication_request.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class MedicationRequest
+      def self.for_patient(dfn)
+        MedicationRequestGateway.for_patient(dfn)
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/observation.rb
+++ b/app/models/lakeraven/ehr/observation.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class Observation
+      def self.for_patient(dfn)
+        ObservationGateway.for_patient(dfn)
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,8 @@ Lakeraven::EHR::Engine.routes.draw do
   use_doorkeeper
   resources :patients, path: "Patient", only: %i[index show], param: :dfn
   resources :practitioners, path: "Practitioner", only: %i[index show], param: :ien
+  resources :allergy_intolerances, path: "AllergyIntolerance", only: %i[index]
+  resources :conditions, path: "Condition", only: %i[index]
+  resources :medication_requests, path: "MedicationRequest", only: %i[index]
+  resources :observations, path: "Observation", only: %i[index]
 end

--- a/test/controllers/lakeraven/ehr/allergy_intolerances_controller_test.rb
+++ b/test/controllers/lakeraven/ehr/allergy_intolerances_controller_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class AllergyIntolerancesControllerTest < ActionDispatch::IntegrationTest
+      setup do
+        @oauth_app = Doorkeeper::Application.create!(
+          name: "test", redirect_uri: "https://example.test/callback",
+          scopes: "system/AllergyIntolerance.read", confidential: true
+        )
+        token = Doorkeeper::AccessToken.create!(
+          application: @oauth_app, scopes: "system/AllergyIntolerance.read", expires_in: 3600
+        )
+        @headers = { "Authorization" => "Bearer #{token.plaintext_token || token.token}" }
+      end
+
+      teardown do
+        Doorkeeper::AccessToken.delete_all
+        Doorkeeper::Application.delete_all
+      end
+
+      test "GET /AllergyIntolerance?patient=1 returns FHIR Bundle" do
+        get "/lakeraven-ehr/AllergyIntolerance", params: { patient: "1" }, headers: @headers
+        assert_response :ok
+        body = JSON.parse(response.body)
+        assert_equal "Bundle", body["resourceType"]
+        assert_equal "searchset", body["type"]
+      end
+
+      test "search without patient param returns 400" do
+        get "/lakeraven-ehr/AllergyIntolerance", headers: @headers
+        assert_response :bad_request
+        body = JSON.parse(response.body)
+        assert_equal "OperationOutcome", body["resourceType"]
+      end
+    end
+  end
+end

--- a/test/controllers/lakeraven/ehr/fhir_clinical_resources_test.rb
+++ b/test/controllers/lakeraven/ehr/fhir_clinical_resources_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class FhirClinicalResourcesTest < ActionDispatch::IntegrationTest
+      setup do
+        @oauth_app = Doorkeeper::Application.create!(
+          name: "test", redirect_uri: "https://example.test/callback",
+          scopes: "system/*.read", confidential: true
+        )
+        token = Doorkeeper::AccessToken.create!(
+          application: @oauth_app, scopes: "system/*.read", expires_in: 3600
+        )
+        @headers = { "Authorization" => "Bearer #{token.plaintext_token || token.token}" }
+      end
+
+      teardown do
+        Doorkeeper::AccessToken.delete_all
+        Doorkeeper::Application.delete_all
+      end
+
+      # -- AllergyIntolerance --------------------------------------------------
+
+      test "GET /AllergyIntolerance?patient=1 returns FHIR Bundle" do
+        get "/lakeraven-ehr/AllergyIntolerance", params: { patient: "1" }, headers: @headers
+        assert_response :ok
+        body = JSON.parse(response.body)
+        assert_equal "Bundle", body["resourceType"]
+        assert_equal "searchset", body["type"]
+      end
+
+      test "AllergyIntolerance search without patient returns 400" do
+        get "/lakeraven-ehr/AllergyIntolerance", headers: @headers
+        assert_response :bad_request
+        body = JSON.parse(response.body)
+        assert_equal "OperationOutcome", body["resourceType"]
+      end
+
+      test "AllergyIntolerance entries have correct resourceType" do
+        get "/lakeraven-ehr/AllergyIntolerance", params: { patient: "1" }, headers: @headers
+        body = JSON.parse(response.body)
+        body["entry"]&.each do |entry|
+          assert_equal "AllergyIntolerance", entry.dig("resource", "resourceType")
+        end
+      end
+
+      # -- Condition -----------------------------------------------------------
+
+      test "GET /Condition?patient=1 returns FHIR Bundle" do
+        get "/lakeraven-ehr/Condition", params: { patient: "1" }, headers: @headers
+        assert_response :ok
+        body = JSON.parse(response.body)
+        assert_equal "Bundle", body["resourceType"]
+      end
+
+      test "Condition search without patient returns 400" do
+        get "/lakeraven-ehr/Condition", headers: @headers
+        assert_response :bad_request
+      end
+
+      # -- MedicationRequest ---------------------------------------------------
+
+      test "GET /MedicationRequest?patient=1 returns FHIR Bundle" do
+        get "/lakeraven-ehr/MedicationRequest", params: { patient: "1" }, headers: @headers
+        assert_response :ok
+        body = JSON.parse(response.body)
+        assert_equal "Bundle", body["resourceType"]
+      end
+
+      test "MedicationRequest search without patient returns 400" do
+        get "/lakeraven-ehr/MedicationRequest", headers: @headers
+        assert_response :bad_request
+      end
+
+      # -- Observation ---------------------------------------------------------
+
+      test "GET /Observation?patient=1 returns FHIR Bundle" do
+        get "/lakeraven-ehr/Observation", params: { patient: "1" }, headers: @headers
+        assert_response :ok
+        body = JSON.parse(response.body)
+        assert_equal "Bundle", body["resourceType"]
+      end
+
+      test "Observation search without patient returns 400" do
+        get "/lakeraven-ehr/Observation", headers: @headers
+        assert_response :bad_request
+      end
+
+      # -- Content type --------------------------------------------------------
+
+      test "clinical resource endpoints return FHIR JSON content type" do
+        get "/lakeraven-ehr/AllergyIntolerance", params: { patient: "1" }, headers: @headers
+        assert_equal "application/fhir+json", response.media_type
+      end
+
+      # -- Patient/ prefix support ---------------------------------------------
+
+      test "accepts Patient/ prefix in patient param" do
+        get "/lakeraven-ehr/Condition", params: { patient: "Patient/1" }, headers: @headers
+        assert_response :ok
+      end
+
+      # -- Auth required -------------------------------------------------------
+
+      test "clinical endpoints require auth" do
+        get "/lakeraven-ehr/AllergyIntolerance", params: { patient: "1" }
+        assert_response :unauthorized
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Four patient-scoped FHIR clinical resource endpoints, each with Model → Gateway → DataMapper layering:
- `GET /AllergyIntolerance?patient={dfn}` (ORQQAL LIST)
- `GET /Condition?patient={dfn}` (ORQQPL LIST)
- `GET /MedicationRequest?patient={dfn}` (ORQQPS LIST)
- `GET /Observation?patient={dfn}` (ORQQVI VITALS)

All require SMART Bearer token. Missing `patient` param returns 400 OperationOutcome. Supports `Patient/` prefix in patient param.

Closes #14, closes #15, closes #16, closes #17

## Test plan
- [x] Each resource returns FHIR Bundle with correct resourceType
- [x] Missing patient param returns 400
- [x] Correct FHIR JSON content type
- [x] Patient/ prefix support
- [x] Auth required
- [x] 75 tests, 161 assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)