### PR TITLE
Organization and Location models with FHIR read endpoints

### DIFF
--- a/app/controllers/lakeraven/ehr/locations_controller.rb
+++ b/app/controllers/lakeraven/ehr/locations_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class LocationsController < ApplicationController
+      def show
+        location = Location.find_by_ien(params[:ien])
+
+        if location.nil?
+          render_operation_outcome(status: :not_found, severity: "error", code: "not-found", diagnostics: "Location not found")
+          return
+        end
+
+        render_fhir(location.to_fhir)
+      end
+    end
+  end
+end

--- a/app/controllers/lakeraven/ehr/organizations_controller.rb
+++ b/app/controllers/lakeraven/ehr/organizations_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class OrganizationsController < ApplicationController
+      def show
+        org = Organization.find_by_ien(params[:ien])
+
+        if org.nil?
+          render_operation_outcome(status: :not_found, severity: "error", code: "not-found", diagnostics: "Organization not found")
+          return
+        end
+
+        render_fhir(org.to_fhir)
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/location_gateway.rb
+++ b/app/gateways/lakeraven/ehr/location_gateway.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rpms_rpc/mappings"
+
+module Lakeraven
+  module EHR
+    class LocationGateway
+      def self.find(ien)
+        RpmsRpc::DataMapper.hospital_location.fetch_one(ien.to_s)
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/organization_gateway.rb
+++ b/app/gateways/lakeraven/ehr/organization_gateway.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rpms_rpc/mappings"
+
+module Lakeraven
+  module EHR
+    class OrganizationGateway
+      def self.find(ien)
+        RpmsRpc::DataMapper.institution.fetch_one(ien.to_s)
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/location.rb
+++ b/app/models/lakeraven/ehr/location.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class Location
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :ien, :integer
+      attribute :name, :string
+      attribute :abbreviation, :string
+      attribute :type, :string
+      attribute :division, :string
+
+      def self.find_by_ien(ien)
+        return nil unless ien.present? && ien.to_i > 0
+
+        attrs = LocationGateway.find(ien.to_i)
+        attrs ? new(**attrs) : nil
+      end
+
+      def to_fhir
+        {
+          resourceType: "Location",
+          id: ien.to_s,
+          name: name,
+          alias: abbreviation.present? ? [ abbreviation ] : [],
+          mode: "instance"
+        }
+      end
+
+      def to_param = ien.to_s
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/organization.rb
+++ b/app/models/lakeraven/ehr/organization.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class Organization
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :ien, :integer
+      attribute :name, :string
+      attribute :station_number, :string
+      attribute :address, :string
+      attribute :city, :string
+      attribute :state, :string
+      attribute :zip_code, :string
+      attribute :phone, :string
+
+      def self.find_by_ien(ien)
+        return nil unless ien.present? && ien.to_i > 0
+
+        attrs = OrganizationGateway.find(ien.to_i)
+        attrs ? new(**attrs) : nil
+      end
+
+      def to_fhir
+        {
+          resourceType: "Organization",
+          id: ien.to_s,
+          name: name,
+          identifier: station_number ? [ { system: "http://hl7.org/fhir/sid/us-npi", value: station_number } ] : [],
+          address: build_address,
+          telecom: phone.present? ? [ { system: "phone", value: phone } ] : []
+        }
+      end
+
+      def to_param = ien.to_s
+
+      private
+
+      def build_address
+        return [] if address.blank?
+
+        [ { line: [ address ], city: city, state: state, postalCode: zip_code, country: "US" }.compact ]
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,6 @@ Lakeraven::EHR::Engine.routes.draw do
   resources :medication_requests, path: "MedicationRequest", only: %i[index]
   resources :observations, path: "Observation", only: %i[index]
   resources :encounters, path: "Encounter", only: %i[index]
+  resources :organizations, path: "Organization", only: %i[show], param: :ien
+  resources :locations, path: "Location", only: %i[show], param: :ien
 end

--- a/test/controllers/lakeraven/ehr/locations_controller_test.rb
+++ b/test/controllers/lakeraven/ehr/locations_controller_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class LocationsControllerTest < ActionDispatch::IntegrationTest
+      setup do
+        @oauth_app = Doorkeeper::Application.create!(
+          name: "test", redirect_uri: "https://example.test/callback",
+          scopes: "system/*.read", confidential: true
+        )
+        token = Doorkeeper::AccessToken.create!(
+          application: @oauth_app, scopes: "system/*.read", expires_in: 3600
+        )
+        @headers = { "Authorization" => "Bearer #{token.plaintext_token || token.token}" }
+      end
+
+      teardown do
+        Doorkeeper::AccessToken.delete_all
+        Doorkeeper::Application.delete_all
+      end
+
+      test "GET /Location/:ien returns FHIR Location" do
+        get "/lakeraven-ehr/Location/1", headers: @headers
+        assert_response :ok
+        body = JSON.parse(response.body)
+        assert_equal "Location", body["resourceType"]
+        assert_equal "1", body["id"]
+        assert_equal "Primary Care Clinic", body["name"]
+      end
+
+      test "unknown Location returns 404" do
+        get "/lakeraven-ehr/Location/99999", headers: @headers
+        assert_response :not_found
+        body = JSON.parse(response.body)
+        assert_equal "OperationOutcome", body["resourceType"]
+      end
+    end
+  end
+end

--- a/test/controllers/lakeraven/ehr/organizations_controller_test.rb
+++ b/test/controllers/lakeraven/ehr/organizations_controller_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class OrganizationsControllerTest < ActionDispatch::IntegrationTest
+      setup do
+        @oauth_app = Doorkeeper::Application.create!(
+          name: "test", redirect_uri: "https://example.test/callback",
+          scopes: "system/*.read", confidential: true
+        )
+        token = Doorkeeper::AccessToken.create!(
+          application: @oauth_app, scopes: "system/*.read", expires_in: 3600
+        )
+        @headers = { "Authorization" => "Bearer #{token.plaintext_token || token.token}" }
+      end
+
+      teardown do
+        Doorkeeper::AccessToken.delete_all
+        Doorkeeper::Application.delete_all
+      end
+
+      test "GET /Organization/:ien returns FHIR Organization" do
+        get "/lakeraven-ehr/Organization/1", headers: @headers
+        assert_response :ok
+        body = JSON.parse(response.body)
+        assert_equal "Organization", body["resourceType"]
+        assert_equal "1", body["id"]
+        assert_equal "Alaska Native Medical Center", body["name"]
+      end
+
+      test "unknown Organization returns 404" do
+        get "/lakeraven-ehr/Organization/99999", headers: @headers
+        assert_response :not_found
+        body = JSON.parse(response.body)
+        assert_equal "OperationOutcome", body["resourceType"]
+      end
+
+      test "Organization includes address" do
+        get "/lakeraven-ehr/Organization/1", headers: @headers
+        body = JSON.parse(response.body)
+        addr = body["address"]&.first
+        assert_equal "Anchorage", addr["city"]
+        assert_equal "AK", addr["state"]
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,6 +39,15 @@ RpmsRpc.mock! do |m|
   m.seed_collection(:practitioner_list,
     [ { ien: 101, name: "MARTINEZ,SARAH", title: "MD" }, { ien: 102, name: "CHEN,JAMES", title: "DO" } ],
     filter_field: :name)
+
+  # Institutions (IEN 1)
+  m.seed(:institution, "1", { ien: 1, name: "Alaska Native Medical Center", station_number: "463",
+                               address: "4315 Diplomacy Dr", city: "Anchorage", state: "AK",
+                               zip_code: "99508", phone: "907-729-1900" })
+
+  # Locations (IEN 1)
+  m.seed(:hospital_location, "1", { ien: 1, name: "Primary Care Clinic", abbreviation: "PCC",
+                                     type: "C", division: "463" })
 end
 
 # Load fixtures from the engine


### PR DESCRIPTION
## Summary
- Organization model + gateway (BHDO INST DATA via DataMapper)
- Location model + gateway (BHDO HOSP LOC DATA via DataMapper)
- `GET /Organization/:ien` and `GET /Location/:ien` FHIR endpoints
- FHIR serialization with address, identifier, telecom

Closes #12

## Test plan
- [x] Organization read returns FHIR Organization with name, address, id
- [x] Location read returns FHIR Location with name, id
- [x] Unknown IEN returns 404 OperationOutcome
- [x] 82 tests, 178 assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)