### PR TITLE
Coverage model with FHIR R4 serialization and eligibility helpers

### DIFF
--- a/app/models/lakeraven/ehr/coverage.rb
+++ b/app/models/lakeraven/ehr/coverage.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # FHIR R4 Coverage — patient insurance record.
+    # Used for eligibility checks and coordination of benefits.
+    class Coverage
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Validations
+
+      COVERAGE_TYPES = %w[
+        medicare_a medicare_b medicare_d medicaid private_insurance
+        va_benefits workers_comp auto_insurance state_program tribal_program
+      ].freeze
+
+      FHIR_STATUSES = %w[active cancelled draft entered-in-error].freeze
+      PRC_STATUSES = %w[exhausted not_enrolled denied pending].freeze
+      VALID_STATUSES = (FHIR_STATUSES + PRC_STATUSES).freeze
+
+      attribute :patient_dfn, :string
+      attribute :coverage_type, :string
+      attribute :status, :string, default: "active"
+      attribute :payor_name, :string
+      attribute :payor_id, :string
+      attribute :subscriber_id, :string
+      attribute :member_id, :string
+      attribute :group_id, :string
+      attribute :dependent_number, :string
+      attribute :relationship, :string, default: "self"
+      attribute :start_date, :date
+      attribute :end_date, :date
+      attribute :order, :integer
+
+      validates :patient_dfn, presence: true
+      validates :coverage_type, presence: true, inclusion: { in: COVERAGE_TYPES }
+      validates :status, inclusion: { in: VALID_STATUSES }
+
+      # -- Status helpers ----------------------------------------------------
+
+      def active?
+        status == "active" && within_coverage_period?
+      end
+
+      def expired?
+        end_date.present? && end_date < Date.current
+      end
+
+      def cancelled?
+        status == "cancelled"
+      end
+
+      def within_coverage_period?
+        return true unless start_date || end_date
+
+        today = Date.current
+        (start_date.nil? || today >= start_date) && (end_date.nil? || today <= end_date)
+      end
+
+      # -- Payor helpers -----------------------------------------------------
+
+      def medicare?
+        coverage_type&.start_with?("medicare")
+      end
+
+      def medicaid?
+        coverage_type == "medicaid"
+      end
+
+      def private_insurance?
+        coverage_type == "private_insurance"
+      end
+
+      def va_benefits?
+        coverage_type == "va_benefits"
+      end
+
+      def government_payer?
+        medicare? || medicaid? || va_benefits?
+      end
+
+      # -- COB ---------------------------------------------------------------
+
+      def primary?
+        order == 1
+      end
+
+      def secondary?
+        order == 2
+      end
+
+      # -- FHIR serialization ------------------------------------------------
+
+      def to_fhir
+        {
+          resourceType: "Coverage",
+          status: status,
+          beneficiary: { reference: "Patient/#{patient_dfn}" },
+          payor: payor_name ? [ { display: payor_name } ] : [],
+          period: build_period,
+          class: build_class_array,
+          order: order
+        }.compact
+      end
+
+      private
+
+      def build_period
+        return nil unless start_date || end_date
+
+        p = {}
+        p[:start] = start_date.iso8601 if start_date
+        p[:end] = end_date.iso8601 if end_date
+        p
+      end
+
+      def build_class_array
+        classes = []
+        classes << { type: { coding: [ { code: "group" } ] }, value: group_id } if group_id
+        classes << { type: { coding: [ { code: "plan" } ] }, value: subscriber_id } if subscriber_id
+        classes.empty? ? nil : classes
+      end
+    end
+  end
+end

--- a/test/models/lakeraven/ehr/coverage_test.rb
+++ b/test/models/lakeraven/ehr/coverage_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class CoverageTest < ActiveSupport::TestCase
+      test "creates with required attributes" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid", subscriber_id: "MCD123")
+        assert cov.valid?
+        assert_equal "active", cov.status
+      end
+
+      test "validates patient_dfn presence" do
+        cov = Coverage.new(coverage_type: "medicaid")
+        assert_not cov.valid?
+        assert_includes cov.errors[:patient_dfn], "can't be blank"
+      end
+
+      test "validates coverage_type inclusion" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "bogus")
+        assert_not cov.valid?
+      end
+
+      test "validates status inclusion" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid", status: "bogus")
+        assert_not cov.valid?
+      end
+
+      # -- Status helpers ------------------------------------------------------
+
+      test "active? checks status and period" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid",
+                           start_date: 1.year.ago, end_date: 1.year.from_now)
+        assert cov.active?
+      end
+
+      test "active? returns false when expired" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid",
+                           start_date: 2.years.ago, end_date: 1.year.ago)
+        assert_not cov.active?
+      end
+
+      test "expired? checks end_date" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid", end_date: 1.day.ago)
+        assert cov.expired?
+      end
+
+      # -- Payor helpers -------------------------------------------------------
+
+      test "medicare? checks coverage_type prefix" do
+        assert Coverage.new(coverage_type: "medicare_a").medicare?
+        assert Coverage.new(coverage_type: "medicare_b").medicare?
+        assert_not Coverage.new(coverage_type: "medicaid").medicare?
+      end
+
+      test "government_payer? includes medicare, medicaid, va" do
+        assert Coverage.new(coverage_type: "medicare_a").government_payer?
+        assert Coverage.new(coverage_type: "medicaid").government_payer?
+        assert Coverage.new(coverage_type: "va_benefits").government_payer?
+        assert_not Coverage.new(coverage_type: "private_insurance").government_payer?
+      end
+
+      # -- COB -----------------------------------------------------------------
+
+      test "primary? and secondary?" do
+        assert Coverage.new(order: 1).primary?
+        assert Coverage.new(order: 2).secondary?
+      end
+
+      # -- FHIR serialization --------------------------------------------------
+
+      test "to_fhir returns Coverage resource" do
+        cov = Coverage.new(
+          patient_dfn: "1", coverage_type: "medicaid", status: "active",
+          payor_name: "State Medicaid", subscriber_id: "MCD123",
+          start_date: Date.new(2025, 1, 1), end_date: Date.new(2025, 12, 31)
+        )
+        fhir = cov.to_fhir
+
+        assert_equal "Coverage", fhir[:resourceType]
+        assert_equal "active", fhir[:status]
+        assert_equal "Patient/1", fhir.dig(:beneficiary, :reference)
+        assert_equal "2025-01-01", fhir.dig(:period, :start)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Coverage model (ActiveModel) representing patient insurance records
- 9 coverage types: medicare_a/b/d, medicaid, private_insurance, va_benefits, workers_comp, auto_insurance, state_program, tribal_program
- Status helpers: active?, expired?, within_coverage_period?
- Payor helpers: medicare?, medicaid?, government_payer?
- COB: primary?, secondary?, order
- FHIR R4 Coverage serialization with beneficiary, payor, period, class

Closes #25

## Test plan
- [x] Creates with required attributes, default status
- [x] Validates patient_dfn, coverage_type, status
- [x] active? checks status + period
- [x] expired? checks end_date
- [x] Payor type predicates
- [x] COB ordering
- [x] to_fhir serialization
- [x] 99 tests, 210 assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)