### PR TITLE
CoverageEligibilityRequest model with FHIR R4 serialization

### DIFF
--- a/app/models/lakeraven/ehr/coverage_eligibility_request.rb
+++ b/app/models/lakeraven/ehr/coverage_eligibility_request.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # FHIR R4 CoverageEligibilityRequest — the inquiry DTO for asking
+    # "does this patient have active coverage for this service?"
+    #
+    # The engine defines the request shape. The actual 270 transaction is
+    # performed by an adapter (Stedi in lakeraven-private, mock in tests).
+    class CoverageEligibilityRequest
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Validations
+
+      VALID_PURPOSES = %w[auth-requirements benefits discovery validation].freeze
+
+      attribute :patient_dfn, :string
+      attribute :coverage_type, :string
+      attribute :purpose, :string, default: "benefits"
+      attribute :service_date, :date
+      attribute :provider_npi, :string
+      attribute :provider_ien, :integer
+      attribute :service_type_codes # Array of STC strings
+
+      validates :patient_dfn, presence: true
+      validates :coverage_type, presence: true, inclusion: { in: Coverage::COVERAGE_TYPES }
+      validates :purpose, inclusion: { in: VALID_PURPOSES }
+
+      def initialize(attributes = {})
+        super
+        self.service_date ||= Date.current
+      end
+
+      def to_fhir
+        {
+          resourceType: "CoverageEligibilityRequest",
+          status: "active",
+          purpose: purpose,
+          patient: { reference: "Patient/#{patient_dfn}" },
+          servicedDate: service_date&.iso8601,
+          provider: provider_npi ? { identifier: { system: "http://hl7.org/fhir/sid/us-npi", value: provider_npi } } : nil,
+          insurance: [ { coverage: { display: coverage_type } } ]
+        }.compact
+      end
+    end
+  end
+end

--- a/test/models/lakeraven/ehr/coverage_eligibility_request_test.rb
+++ b/test/models/lakeraven/ehr/coverage_eligibility_request_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class CoverageEligibilityRequestTest < ActiveSupport::TestCase
+      test "creates with required attributes" do
+        req = CoverageEligibilityRequest.new(
+          patient_dfn: "1",
+          coverage_type: "medicaid",
+          purpose: "benefits"
+        )
+        assert req.valid?
+      end
+
+      test "validates patient_dfn presence" do
+        req = CoverageEligibilityRequest.new(coverage_type: "medicaid", purpose: "benefits")
+        assert_not req.valid?
+        assert_includes req.errors[:patient_dfn], "can't be blank"
+      end
+
+      test "validates coverage_type inclusion" do
+        req = CoverageEligibilityRequest.new(patient_dfn: "1", coverage_type: "bogus", purpose: "benefits")
+        assert_not req.valid?
+      end
+
+      test "validates purpose inclusion" do
+        req = CoverageEligibilityRequest.new(patient_dfn: "1", coverage_type: "medicaid", purpose: "bogus")
+        assert_not req.valid?
+      end
+
+      test "defaults purpose to benefits" do
+        req = CoverageEligibilityRequest.new(patient_dfn: "1", coverage_type: "medicaid")
+        assert_equal "benefits", req.purpose
+      end
+
+      test "defaults service_date to today" do
+        req = CoverageEligibilityRequest.new(patient_dfn: "1", coverage_type: "medicaid")
+        assert_equal Date.current, req.service_date
+      end
+
+      test "accepts service_type_codes" do
+        req = CoverageEligibilityRequest.new(
+          patient_dfn: "1", coverage_type: "medicaid",
+          service_type_codes: %w[30 MH]
+        )
+        assert_equal %w[30 MH], req.service_type_codes
+      end
+
+      # -- FHIR serialization --------------------------------------------------
+
+      test "to_fhir returns CoverageEligibilityRequest resource" do
+        req = CoverageEligibilityRequest.new(
+          patient_dfn: "1", coverage_type: "medicaid",
+          provider_npi: "1234567890", service_date: Date.new(2025, 6, 1)
+        )
+        fhir = req.to_fhir
+
+        assert_equal "CoverageEligibilityRequest", fhir[:resourceType]
+        assert_equal "active", fhir[:status]
+        assert_equal "benefits", fhir[:purpose]
+        assert_equal "Patient/1", fhir.dig(:patient, :reference)
+        assert_equal "2025-06-01", fhir[:servicedDate]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- CoverageEligibilityRequest model (ActiveModel) — the inquiry DTO for eligibility checks
- Validates patient_dfn, coverage_type, purpose
- Defaults: purpose="benefits", service_date=today
- Supports service_type_codes (STC array) and provider_npi
- FHIR R4 serialization

Closes #26

## Test plan
- [x] Creates with required attributes
- [x] Validates patient_dfn, coverage_type, purpose
- [x] Defaults purpose and service_date
- [x] Accepts service_type_codes
- [x] to_fhir serialization
- [x] 107 tests, 224 assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)