### PR TITLE
CoverageEligibilityResponse model with AAA error handling

### DIFF
--- a/app/models/lakeraven/ehr/coverage_eligibility_response.rb
+++ b/app/models/lakeraven/ehr/coverage_eligibility_response.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # FHIR R4 CoverageEligibilityResponse — result of a 271 eligibility check.
+    # Holds coverage status, plan details, and error information.
+    #
+    # Created by the eligibility adapter (Stedi in lakeraven-private, mock in tests).
+    class CoverageEligibilityResponse
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Validations
+
+      VALID_STATUSES = %w[enrolled not_enrolled pending denied exhausted error].freeze
+      TERMINAL_STATUSES = %w[enrolled not_enrolled denied exhausted].freeze
+      TRANSIENT_ERROR_CODES = %w[42 80].freeze
+
+      attribute :patient_dfn, :string
+      attribute :coverage_type, :string
+      attribute :status, :string
+      attribute :plan_name, :string
+      attribute :policy_id, :string
+      attribute :group_id, :string
+      attribute :subscriber_id, :string
+      attribute :insurer_name, :string
+      attribute :insurer_id, :string
+      attribute :start_date, :date
+      attribute :end_date, :date
+      attribute :error_code, :string
+      attribute :error_message, :string
+
+      validates :status, inclusion: { in: VALID_STATUSES }
+
+      # -- Status helpers ----------------------------------------------------
+
+      def enrolled?
+        status == "enrolled"
+      end
+
+      def not_enrolled?
+        status == "not_enrolled"
+      end
+
+      def error?
+        status == "error"
+      end
+
+      def pending?
+        status == "pending"
+      end
+
+      def active_coverage?
+        enrolled? && within_coverage_period?
+      end
+
+      def within_coverage_period?
+        return true unless start_date || end_date
+
+        today = Date.current
+        (start_date.nil? || today >= start_date) && (end_date.nil? || today <= end_date)
+      end
+
+      def final?
+        TERMINAL_STATUSES.include?(status)
+      end
+
+      # -- Error helpers (AAA codes from Stedi article) ----------------------
+
+      def transient_error?
+        error? && TRANSIENT_ERROR_CODES.include?(error_code)
+      end
+
+      # -- FHIR serialization ------------------------------------------------
+
+      def to_fhir
+        {
+          resourceType: "CoverageEligibilityResponse",
+          status: "active",
+          outcome: fhir_outcome,
+          patient: { reference: "Patient/#{patient_dfn}" },
+          insurer: insurer_name ? { display: insurer_name } : nil,
+          insurance: build_insurance
+        }.compact
+      end
+
+      private
+
+      def fhir_outcome
+        case status
+        when "enrolled", "not_enrolled", "denied", "exhausted" then "complete"
+        when "pending" then "queued"
+        when "error" then "error"
+        end
+      end
+
+      def build_insurance
+        return nil unless enrolled?
+
+        [ {
+          coverage: { display: coverage_type },
+          benefitPeriod: build_period
+        }.compact ]
+      end
+
+      def build_period
+        return nil unless start_date || end_date
+
+        p = {}
+        p[:start] = start_date.iso8601 if start_date
+        p[:end] = end_date.iso8601 if end_date
+        p
+      end
+    end
+  end
+end

--- a/test/models/lakeraven/ehr/coverage_eligibility_response_test.rb
+++ b/test/models/lakeraven/ehr/coverage_eligibility_response_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class CoverageEligibilityResponseTest < ActiveSupport::TestCase
+      test "creates with enrolled status" do
+        resp = CoverageEligibilityResponse.new(
+          patient_dfn: "1", coverage_type: "medicaid", status: "enrolled",
+          plan_name: "State Medicaid", insurer_name: "State of Alaska"
+        )
+        assert resp.enrolled?
+        assert resp.active_coverage?
+      end
+
+      test "not_enrolled status" do
+        resp = CoverageEligibilityResponse.new(
+          patient_dfn: "1", coverage_type: "medicaid", status: "not_enrolled"
+        )
+        assert resp.not_enrolled?
+        assert_not resp.active_coverage?
+      end
+
+      test "error status" do
+        resp = CoverageEligibilityResponse.new(
+          patient_dfn: "1", coverage_type: "medicaid", status: "error",
+          error_code: "75", error_message: "Member details don't match"
+        )
+        assert resp.error?
+        assert_not resp.active_coverage?
+      end
+
+      test "validates status inclusion" do
+        resp = CoverageEligibilityResponse.new(
+          patient_dfn: "1", coverage_type: "medicaid", status: "bogus"
+        )
+        assert_not resp.valid?
+      end
+
+      test "within_coverage_period? checks dates" do
+        resp = CoverageEligibilityResponse.new(
+          patient_dfn: "1", coverage_type: "medicaid", status: "enrolled",
+          start_date: 1.year.ago, end_date: 1.year.from_now
+        )
+        assert resp.within_coverage_period?
+      end
+
+      test "within_coverage_period? false when expired" do
+        resp = CoverageEligibilityResponse.new(
+          patient_dfn: "1", coverage_type: "medicaid", status: "enrolled",
+          start_date: 2.years.ago, end_date: 1.year.ago
+        )
+        assert_not resp.within_coverage_period?
+      end
+
+      test "final? for terminal statuses" do
+        assert CoverageEligibilityResponse.new(status: "enrolled").final?
+        assert CoverageEligibilityResponse.new(status: "not_enrolled").final?
+        assert CoverageEligibilityResponse.new(status: "denied").final?
+        assert_not CoverageEligibilityResponse.new(status: "pending").final?
+      end
+
+      # -- AAA error codes (from Stedi article) --------------------------------
+
+      test "transient_error? for retryable codes" do
+        resp = CoverageEligibilityResponse.new(status: "error", error_code: "42")
+        assert resp.transient_error?
+
+        resp2 = CoverageEligibilityResponse.new(status: "error", error_code: "80")
+        assert resp2.transient_error?
+      end
+
+      test "transient_error? false for non-retryable codes" do
+        resp = CoverageEligibilityResponse.new(status: "error", error_code: "75")
+        assert_not resp.transient_error?
+      end
+
+      # -- FHIR serialization --------------------------------------------------
+
+      test "to_fhir returns CoverageEligibilityResponse resource" do
+        resp = CoverageEligibilityResponse.new(
+          patient_dfn: "1", coverage_type: "medicaid", status: "enrolled",
+          plan_name: "State Medicaid", insurer_name: "State of Alaska",
+          start_date: Date.new(2025, 1, 1), end_date: Date.new(2025, 12, 31)
+        )
+        fhir = resp.to_fhir
+
+        assert_equal "CoverageEligibilityResponse", fhir[:resourceType]
+        assert_equal "active", fhir[:status]
+        assert_equal "complete", fhir[:outcome]
+        assert_equal "Patient/1", fhir.dig(:patient, :reference)
+      end
+
+      test "to_fhir maps error status to error outcome" do
+        resp = CoverageEligibilityResponse.new(
+          patient_dfn: "1", coverage_type: "medicaid", status: "error",
+          error_code: "75", error_message: "Member mismatch"
+        )
+        fhir = resp.to_fhir
+
+        assert_equal "error", fhir[:outcome]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- CoverageEligibilityResponse model — result of 271 eligibility check
- Statuses: enrolled, not_enrolled, pending, denied, exhausted, error
- AAA error codes are standard X12 270/271 (not Clearinghouse-specific)
- transient_error? for auto-retry (42=payer unavailable, 80=timeout)
- FHIR R4 serialization with outcome mapping

Closes #27

## Test plan
- [x] Status predicates, active_coverage?, final?
- [x] AAA transient error detection
- [x] FHIR serialization with outcome mapping
- [x] 118 tests, 245 assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)