### PR TITLE
Eligibility adapter interface with pluggable backends

### DIFF
--- a/app/services/lakeraven/ehr/eligibility_check.rb
+++ b/app/services/lakeraven/ehr/eligibility_check.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # Orchestrates an eligibility check via the configured adapter.
+    #
+    #   result = EligibilityCheck.call(request)
+    #   result.enrolled?  # => true/false
+    #
+    # The adapter is pluggable — configure it in the host app:
+    #
+    #   Lakeraven::EHR.configure do |c|
+    #     c.eligibility_adapter = StediEligibilityAdapter.new
+    #   end
+    #
+    # The adapter must respond to #call(CoverageEligibilityRequest)
+    # and return a CoverageEligibilityResponse.
+    class EligibilityCheck
+      class InvalidRequestError < StandardError; end
+
+      def self.call(request)
+        raise InvalidRequestError, request.errors.full_messages.join(", ") unless request.valid?
+
+        adapter = Lakeraven::EHR.configuration.eligibility_adapter
+        adapter.call(request)
+      end
+    end
+  end
+end

--- a/app/services/lakeraven/ehr/mock_eligibility_adapter.rb
+++ b/app/services/lakeraven/ehr/mock_eligibility_adapter.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # Default mock adapter for eligibility checks.
+    # Returns "enrolled" with a 1-year coverage period.
+    # Used in tests and development when no clearinghouse is configured.
+    class MockEligibilityAdapter
+      def call(request)
+        CoverageEligibilityResponse.new(
+          patient_dfn: request.patient_dfn,
+          coverage_type: request.coverage_type,
+          status: "enrolled",
+          plan_name: "Mock Plan",
+          insurer_name: "Mock Insurer",
+          start_date: 1.year.ago.to_date,
+          end_date: 1.year.from_now.to_date
+        )
+      end
+    end
+  end
+end

--- a/lib/lakeraven/ehr.rb
+++ b/lib/lakeraven/ehr.rb
@@ -6,5 +6,34 @@ require "lakeraven/ehr/engine"
 
 module Lakeraven
   module EHR
+    class Configuration
+      attr_accessor :tenant_resolver, :facility_resolver, :eligibility_adapter
+
+      def initialize
+        @tenant_resolver = ->(request) {
+          value = request.headers["X-Tenant-Identifier"].to_s.strip
+          value.empty? ? nil : value
+        }
+        @facility_resolver = ->(request) {
+          value = request.headers["X-Facility-Identifier"].to_s.strip
+          value.empty? ? nil : value
+        }
+        @eligibility_adapter = MockEligibilityAdapter.new
+      end
+    end
+
+    class << self
+      def configuration
+        @configuration ||= Configuration.new
+      end
+
+      def configure
+        yield(configuration)
+      end
+
+      def reset_configuration!
+        @configuration = Configuration.new
+      end
+    end
   end
 end

--- a/test/models/lakeraven/ehr/eligibility_check_test.rb
+++ b/test/models/lakeraven/ehr/eligibility_check_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class EligibilityCheckTest < ActiveSupport::TestCase
+      setup do
+        @request = CoverageEligibilityRequest.new(
+          patient_dfn: "1", coverage_type: "medicaid",
+          provider_npi: "1234567890"
+        )
+      end
+
+      # -- Mock adapter returns enrolled by default --------------------------
+
+      test "check returns CoverageEligibilityResponse" do
+        result = EligibilityCheck.call(@request)
+        assert_kind_of CoverageEligibilityResponse, result
+      end
+
+      test "mock adapter returns enrolled status" do
+        result = EligibilityCheck.call(@request)
+        assert result.enrolled?
+        assert_equal "medicaid", result.coverage_type
+        assert_equal "1", result.patient_dfn
+      end
+
+      # -- Adapter configuration ---------------------------------------------
+
+      test "uses configured adapter" do
+        custom_adapter = ->(_req) {
+          CoverageEligibilityResponse.new(
+            patient_dfn: "1", coverage_type: "medicaid", status: "not_enrolled"
+          )
+        }
+
+        original = Lakeraven::EHR.configuration.eligibility_adapter
+        Lakeraven::EHR.configuration.eligibility_adapter = custom_adapter
+
+        result = EligibilityCheck.call(@request)
+        assert result.not_enrolled?
+      ensure
+        Lakeraven::EHR.configuration.eligibility_adapter = original
+      end
+
+      # -- Validation ---------------------------------------------------------
+
+      test "raises on invalid request" do
+        bad_request = CoverageEligibilityRequest.new(patient_dfn: nil)
+        assert_raises(EligibilityCheck::InvalidRequestError) do
+          EligibilityCheck.call(bad_request)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `EligibilityCheck.call(request)` — orchestrates eligibility check via configured adapter
- `MockEligibilityAdapter` — default, returns enrolled with 1-year period
- `Configuration#eligibility_adapter` — pluggable (host app sets Clearinghouse, Change HC, etc.)
- Validates request before calling adapter
- Configuration class restored with tenant/facility resolvers + eligibility adapter

Closes #28

## Usage
```ruby
# Host app configures adapter
Lakeraven::EHR.configure do |c|
  c.eligibility_adapter = ClearinghouseEligibilityAdapter.new(api_key: ENV["CLEARINGHOUSE_API_KEY"])
end

# Engine code just calls
result = EligibilityCheck.call(request)
result.enrolled?  # => true/false
```

## Test plan
- [x] Returns CoverageEligibilityResponse
- [x] Mock adapter returns enrolled
- [x] Custom adapter pluggable via configuration
- [x] Invalid request raises InvalidRequestError
- [x] 122 tests, 251 assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)