### PR TITLE
VFC eligibility should check codes via RPMS RPC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/lakeraven/rpms-rpc.git
-  revision: bcc2516cd1248dc1aad62ae20aaf8496767aa2cc
+  revision: e5c284404f61ea0e1a2d1e4a08f84273591fdc8e
   branch: main
   specs:
     rpms-rpc (0.1.0)

--- a/app/gateways/lakeraven/ehr/eligibility_gateway.rb
+++ b/app/gateways/lakeraven/ehr/eligibility_gateway.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rpms_rpc/mappings"
+
+module Lakeraven
+  module EHR
+    class EligibilityGateway
+      def self.patient_eligibility(dfn)
+        RpmsRpc::DataMapper.vfc_eligibility.fetch_one(dfn.to_s) || { code: nil, label: nil }
+      end
+
+      def self.list_codes
+        RpmsRpc::DataMapper.vfc_eligibility_list.fetch_many
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/vfc_eligibility.rb
+++ b/app/models/lakeraven/ehr/vfc_eligibility.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # VFC (Vaccines for Children) eligibility via RPMS RPCs.
+    # Used for vaccine lot enforcement — fail-closed check before
+    # administering VFC-funded vaccines.
+    class VfcEligibility
+      VFC_ELIGIBLE_CODES = %w[V02 V03 V04 V05 V06 V07].freeze
+
+      def self.patient_eligibility(dfn)
+        EligibilityGateway.patient_eligibility(dfn)
+      end
+
+      def self.list_codes
+        EligibilityGateway.list_codes
+      end
+
+      def self.eligible?(code)
+        VFC_ELIGIBLE_CODES.include?(code.to_s)
+      end
+    end
+  end
+end

--- a/test/models/lakeraven/ehr/vfc_eligibility_test.rb
+++ b/test/models/lakeraven/ehr/vfc_eligibility_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class VfcEligibilityTest < ActiveSupport::TestCase
+      test "patient_eligibility returns code and label" do
+        result = VfcEligibility.patient_eligibility("1")
+        assert_kind_of Hash, result
+        assert result.key?(:code)
+        assert result.key?(:label)
+      end
+
+      test "patient_eligibility returns nil code for unknown patient" do
+        result = VfcEligibility.patient_eligibility("99999")
+        assert_nil result[:code]
+      end
+
+      test "list_codes returns array of code/label hashes" do
+        codes = VfcEligibility.list_codes
+        assert_kind_of Array, codes
+      end
+
+      test "eligible? checks VFC eligible codes" do
+        assert VfcEligibility.eligible?("V02")
+        assert VfcEligibility.eligible?("V04")
+        assert_not VfcEligibility.eligible?("V01")
+        assert_not VfcEligibility.eligible?(nil)
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,6 +48,18 @@ RpmsRpc.mock! do |m|
   # Locations (IEN 1)
   m.seed(:hospital_location, "1", { ien: 1, name: "Primary Care Clinic", abbreviation: "PCC",
                                      type: "C", division: "463" })
+
+  # VFC Eligibility
+  m.seed(:vfc_eligibility, "1", { code: "V04", label: "American Indian/Alaska Native" })
+  m.seed_collection(:vfc_eligibility_list, [
+    { code: "V01", label: "Not VFC eligible" },
+    { code: "V02", label: "VFC eligible - Medicaid" },
+    { code: "V03", label: "VFC eligible - Uninsured" },
+    { code: "V04", label: "VFC eligible - AI/AN" },
+    { code: "V05", label: "VFC eligible - FQHC" },
+    { code: "V06", label: "VFC eligible - State specific" },
+    { code: "V07", label: "VFC eligible - Local specific" }
+  ])
 end
 
 # Load fixtures from the engine


### PR DESCRIPTION
## Summary
- VfcEligibility model with eligible? predicate (V02-V07)
- EligibilityGateway: patient_eligibility + list_codes via DataMapper
- BIPC ELIGGET/ELIGLIST mappings added to rpms-rpc (#8)

Closes #29

## Test plan
- [x] patient_eligibility returns code/label
- [x] Returns nil code for unknown patient
- [x] list_codes returns array
- [x] eligible? for VFC codes V02-V07, not V01
- [x] 126 tests, 260 assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)