### PR TITLE
FHIR Coverage API should expose eligibility check endpoint

### DIFF
--- a/app/controllers/lakeraven/ehr/coverage_eligibility_requests_controller.rb
+++ b/app/controllers/lakeraven/ehr/coverage_eligibility_requests_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class CoverageEligibilityRequestsController < ApplicationController
+      def create
+        request = CoverageEligibilityRequest.new(eligibility_params)
+
+        unless request.valid?
+          render_operation_outcome(
+            status: :unprocessable_content,
+            severity: "error",
+            code: "invalid",
+            diagnostics: request.errors.full_messages.join(", ")
+          )
+          return
+        end
+
+        result = EligibilityCheck.call(request)
+        render_fhir(result.to_fhir)
+      end
+
+      private
+
+      def eligibility_params
+        params.permit(:patient_dfn, :coverage_type, :provider_npi, :service_date, :purpose)
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,5 @@ Lakeraven::EHR::Engine.routes.draw do
   resources :service_requests, path: "ServiceRequest", only: %i[index]
   resources :immunizations, path: "Immunization", only: %i[index]
   resources :procedures, path: "Procedure", only: %i[index]
+  resources :coverage_eligibility_requests, path: "CoverageEligibilityRequest", only: %i[create]
 end

--- a/test/controllers/lakeraven/ehr/coverages_controller_test.rb
+++ b/test/controllers/lakeraven/ehr/coverages_controller_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class CoveragesControllerTest < ActionDispatch::IntegrationTest
+      setup do
+        @oauth_app = Doorkeeper::Application.create!(
+          name: "test", redirect_uri: "https://example.test/callback",
+          scopes: "system/*.read", confidential: true
+        )
+        token = Doorkeeper::AccessToken.create!(
+          application: @oauth_app, scopes: "system/*.read", expires_in: 3600
+        )
+        @headers = { "Authorization" => "Bearer #{token.plaintext_token || token.token}" }
+      end
+
+      teardown do
+        Doorkeeper::AccessToken.delete_all
+        Doorkeeper::Application.delete_all
+      end
+
+      # -- POST /CoverageEligibilityRequest (trigger check) -------------------
+
+      test "POST triggers eligibility check and returns response" do
+        post "/lakeraven-ehr/CoverageEligibilityRequest",
+             params: { patient_dfn: "1", coverage_type: "medicaid" },
+             headers: @headers
+        assert_response :ok
+        body = JSON.parse(response.body)
+        assert_equal "CoverageEligibilityResponse", body["resourceType"]
+      end
+
+      test "POST with invalid request returns 422" do
+        post "/lakeraven-ehr/CoverageEligibilityRequest",
+             params: { coverage_type: "medicaid" },
+             headers: @headers
+        assert_response :unprocessable_content
+        body = JSON.parse(response.body)
+        assert_equal "OperationOutcome", body["resourceType"]
+      end
+
+      test "POST requires auth" do
+        post "/lakeraven-ehr/CoverageEligibilityRequest",
+             params: { patient_dfn: "1", coverage_type: "medicaid" }
+        assert_response :unauthorized
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `POST /CoverageEligibilityRequest` triggers eligibility check via configured adapter
- Returns FHIR CoverageEligibilityResponse
- Invalid request returns 422 OperationOutcome
- Auth required

Closes #30

## Test plan
- [x] POST triggers check and returns CoverageEligibilityResponse
- [x] Invalid request returns 422
- [x] Auth required
- [x] 129 tests, 265 assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)