### PR TITLE
Clinical decision support alerts: reminders, allergies, severity

### DIFF
--- a/app/services/lakeraven/ehr/clinical_alert_service.rb
+++ b/app/services/lakeraven/ehr/clinical_alert_service.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # Aggregates clinical alerts for a patient from multiple sources:
+    # - Clinical reminders (DUE status only)
+    # - Allergy alerts with severity
+    #
+    # Does NOT call DrugInteractionService — drug checks happen at prescribing time,
+    # not on background page load.
+    class ClinicalAlertService
+      Alert = Struct.new(:type, :description, :severity, keyword_init: true)
+
+      def initialize(reminders: [], allergies: [])
+        @reminders = reminders
+        @allergies = allergies
+      end
+
+      def background_alerts
+        alerts = []
+        alerts.concat(reminder_alerts)
+        alerts.concat(allergy_alerts)
+        alerts
+      end
+
+      def severity_summary
+        all = background_alerts
+        {
+          high: all.count { |a| a.severity == :high },
+          moderate: all.count { |a| a.severity == :moderate },
+          low: all.count { |a| a.severity == :low }
+        }
+      end
+
+      def drug_interactions
+        [] # Intentionally empty — drug checks at prescribing time only
+      end
+
+      private
+
+      def reminder_alerts
+        @reminders
+          .select { |r| r[:status]&.upcase == "DUE" }
+          .map do |r|
+            Alert.new(
+              type: :reminder,
+              description: r[:name] || r[:description],
+              severity: map_reminder_severity(r)
+            )
+          end
+      end
+
+      def allergy_alerts
+        @allergies.map do |a|
+          Alert.new(
+            type: :allergy,
+            description: a[:allergen] || a[:description],
+            severity: map_allergy_severity(a[:severity])
+          )
+        end
+      end
+
+      def map_reminder_severity(reminder)
+        case reminder[:priority]&.downcase
+        when "high", "urgent" then :high
+        when "moderate", "normal" then :moderate
+        else :low
+        end
+      end
+
+      def map_allergy_severity(severity)
+        case severity&.downcase
+        when "severe", "high" then :high
+        when "moderate" then :moderate
+        else :low
+        end
+      end
+    end
+  end
+end

--- a/features/clinical_decision_support.feature
+++ b/features/clinical_decision_support.feature
@@ -1,0 +1,31 @@
+@cds
+Feature: Clinical Decision Support Alerts
+  As a healthcare provider
+  I need to see clinical alerts on a patient's profile
+  So that I can make informed clinical decisions
+
+  Background:
+    Given I am logged in as a provider
+
+  Scenario: Display clinical reminders filtered to DUE status
+    Given a patient with due clinical reminders
+    When I check the patient's background alerts
+    Then I should see only DUE reminders
+    And each reminder should have a severity level
+
+  Scenario: Display active allergy alerts with severity
+    Given a patient with known allergies
+    When I check the patient's background alerts
+    Then I should see allergy alerts with severity badges
+    And allergy severity should be mapped from the severity field
+
+  Scenario: Background alerts do not call DrugInteractionService
+    Given a patient with known allergies
+    When I check the patient's background alerts
+    Then the drug interactions list should be empty
+
+  Scenario: Severity summary aggregates all alert severities
+    Given a patient with due clinical reminders
+    And a patient with known allergies
+    When I check the patient's background alerts
+    Then I should see a severity summary with high, moderate, and low counts

--- a/features/step_definitions/clinical_decision_support_steps.rb
+++ b/features/step_definitions/clinical_decision_support_steps.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+Given("I am logged in as a provider") do
+  # Provider context established
+end
+
+Given("a patient with due clinical reminders") do
+  @reminders ||= []
+  @reminders.concat([
+    { name: "Diabetes A1C screening", status: "DUE", priority: "high" },
+    { name: "Flu vaccine", status: "DUE", priority: "moderate" },
+    { name: "Blood pressure check", status: "DUE", priority: "low" }
+  ])
+end
+
+Given("a patient with known allergies") do
+  @allergies ||= []
+  @allergies.concat([
+    { allergen: "Penicillin", severity: "severe" },
+    { allergen: "Aspirin", severity: "moderate" }
+  ])
+end
+
+When("I check the patient's background alerts") do
+  @service = Lakeraven::EHR::ClinicalAlertService.new(
+    reminders: @reminders || [],
+    allergies: @allergies || []
+  )
+  @alerts = @service.background_alerts
+end
+
+Then("I should see only DUE reminders") do
+  reminder_alerts = @alerts.select { |a| a.type == :reminder }
+  assert reminder_alerts.any?, "Expected DUE reminder alerts"
+end
+
+Then("each reminder should have a severity level") do
+  reminder_alerts = @alerts.select { |a| a.type == :reminder }
+  reminder_alerts.each do |a|
+    assert %i[high moderate low].include?(a.severity), "Expected severity, got #{a.severity}"
+  end
+end
+
+Then("I should see allergy alerts with severity badges") do
+  allergy_alerts = @alerts.select { |a| a.type == :allergy }
+  assert allergy_alerts.any?, "Expected allergy alerts"
+  allergy_alerts.each { |a| assert a.severity.present? }
+end
+
+Then("allergy severity should be mapped from the severity field") do
+  allergy_alerts = @alerts.select { |a| a.type == :allergy }
+  severe = allergy_alerts.find { |a| a.description == "Penicillin" }
+  assert_equal :high, severe.severity
+end
+
+Then("the drug interactions list should be empty") do
+  assert_equal [], @service.drug_interactions
+end
+
+Then("I should see a severity summary with high, moderate, and low counts") do
+  summary = @service.severity_summary
+  assert summary[:high].positive?, "Expected high count > 0"
+  assert summary[:moderate].positive?, "Expected moderate count > 0"
+  assert summary[:low].positive?, "Expected low count > 0"
+end


### PR DESCRIPTION
## Summary
- ClinicalAlertService: aggregates DUE reminders + allergy alerts with severity mapping
- Drug interactions intentionally empty on background load (prescribing-time only)
- Severity summary with high/moderate/low counts

## Test plan
- [x] 4 BDD scenarios
- [x] 164 minitest + 92 cucumber total, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)