### PR TITLE
Phase 1 model enrichment: Patient, Practitioner, Coverage, Organization, Location

### DIFF
--- a/app/models/lakeraven/ehr/location.rb
+++ b/app/models/lakeraven/ehr/location.rb
@@ -30,6 +30,14 @@ module Lakeraven
       end
 
       def to_param = ien.to_s
+
+      def persisted?
+        ien.present? && ien.to_i.positive?
+      end
+
+      def active?
+        true # Default; RPMS locations are active if returned
+      end
     end
   end
 end

--- a/app/models/lakeraven/ehr/organization.rb
+++ b/app/models/lakeraven/ehr/organization.rb
@@ -35,6 +35,14 @@ module Lakeraven
 
       def to_param = ien.to_s
 
+      def persisted?
+        ien.present? && ien.to_i.positive?
+      end
+
+      def full_address
+        [ address, city, state, zip_code ].compact.reject(&:empty?).join(", ")
+      end
+
       private
 
       def build_address

--- a/app/models/lakeraven/ehr/patient.rb
+++ b/app/models/lakeraven/ehr/patient.rb
@@ -24,6 +24,10 @@ module Lakeraven
       attribute :zip_code, :string
       attribute :phone, :string
 
+      # Date aliases
+      attribute :born_on, :date
+      attribute :birth_date, :date
+
       # Derived name parts
       attribute :first_name, :string
       attribute :last_name, :string
@@ -34,7 +38,16 @@ module Lakeraven
       attribute :service_area, :string
       attribute :coverage_type, :string
 
+      class RecordNotFound < StandardError; end
+
       # -- Class methods (AR-like) -------------------------------------------
+
+      def self.find(dfn)
+        patient = find_by_dfn(dfn)
+        raise RecordNotFound, "Couldn't find Patient with 'dfn'=#{dfn}" unless patient
+
+        patient
+      end
 
       def self.find_by_dfn(dfn)
         return nil unless dfn.present? && dfn.to_i.positive?
@@ -44,6 +57,11 @@ module Lakeraven
 
       def self.search(name_pattern)
         PatientGateway.search(name_pattern.to_s)
+      end
+
+      def self.search_by_ssn(ssn)
+        patient = find_by_ssn(ssn)
+        patient ? [ patient ] : []
       end
 
       def self.find_by_ssn(ssn)
@@ -85,6 +103,10 @@ module Lakeraven
 
       def to_param
         dfn.to_s
+      end
+
+      def persisted?
+        dfn.present? && dfn.to_i.positive?
       end
 
       # -- Tribal enrollment -------------------------------------------------
@@ -135,6 +157,11 @@ module Lakeraven
       private
 
       def sync_composite_fields
+        # Sync born_on ↔ dob
+        self.born_on ||= dob
+        self.dob ||= born_on
+
+        # Sync name ↔ first_name/last_name
         self.name = "#{last_name},#{first_name}" if first_name.present? && last_name.present? && name.blank?
 
         return unless name.present? && first_name.blank? && last_name.blank?

--- a/app/models/lakeraven/ehr/practitioner.rb
+++ b/app/models/lakeraven/ehr/practitioner.rb
@@ -55,6 +55,18 @@ module Lakeraven
         ien.to_s
       end
 
+      def persisted?
+        ien.present? && ien.to_i.positive?
+      end
+
+      def can_prescribe_controlled?
+        dea_number.present? && !dea_number.empty?
+      end
+
+      def credentials_summary
+        [ title, specialty ].compact.reject(&:empty?).join(", ")
+      end
+
       # -- FHIR serialization -----------------------------------------------
 
       def to_fhir

--- a/test/models/lakeraven/ehr/coverage_test.rb
+++ b/test/models/lakeraven/ehr/coverage_test.rb
@@ -5,16 +5,34 @@ require "test_helper"
 module Lakeraven
   module EHR
     class CoverageTest < ActiveSupport::TestCase
+      # -- Creation + defaults ---------------------------------------------------
+
       test "creates with required attributes" do
-        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid", subscriber_id: "MCD123")
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid")
         assert cov.valid?
+      end
+
+      test "defaults status to active" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid")
         assert_equal "active", cov.status
       end
 
-      test "validates patient_dfn presence" do
+      test "defaults relationship to self" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid")
+        assert_equal "self", cov.relationship
+      end
+
+      # -- Validation ------------------------------------------------------------
+
+      test "requires patient_dfn" do
         cov = Coverage.new(coverage_type: "medicaid")
         assert_not cov.valid?
         assert_includes cov.errors[:patient_dfn], "can't be blank"
+      end
+
+      test "requires coverage_type" do
+        cov = Coverage.new(patient_dfn: "1")
+        assert_not cov.valid?
       end
 
       test "validates coverage_type inclusion" do
@@ -27,31 +45,74 @@ module Lakeraven
         assert_not cov.valid?
       end
 
-      # -- Status helpers ------------------------------------------------------
+      test "accepts all valid coverage types" do
+        Coverage::COVERAGE_TYPES.each do |type|
+          cov = Coverage.new(patient_dfn: "1", coverage_type: type)
+          assert cov.valid?, "Expected #{type} to be valid"
+        end
+      end
 
-      test "active? checks status and period" do
+      test "accepts all valid statuses" do
+        Coverage::VALID_STATUSES.each do |status|
+          cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid", status: status)
+          assert cov.valid?, "Expected status #{status} to be valid"
+        end
+      end
+
+      # -- Status helpers --------------------------------------------------------
+
+      test "active? true when active and within period" do
         cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid",
                            start_date: 1.year.ago, end_date: 1.year.from_now)
         assert cov.active?
       end
 
-      test "active? returns false when expired" do
+      test "active? false when cancelled" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid", status: "cancelled")
+        assert_not cov.active?
+      end
+
+      test "active? false when expired" do
         cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid",
                            start_date: 2.years.ago, end_date: 1.year.ago)
         assert_not cov.active?
       end
 
-      test "expired? checks end_date" do
-        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid", end_date: 1.day.ago)
-        assert cov.expired?
+      test "expired? true when end_date past" do
+        assert Coverage.new(end_date: 1.day.ago).expired?
       end
 
-      # -- Payor helpers -------------------------------------------------------
+      test "expired? false when no end_date" do
+        assert_not Coverage.new.expired?
+      end
 
-      test "medicare? checks coverage_type prefix" do
+      test "within_coverage_period? true when no dates set" do
+        assert Coverage.new.within_coverage_period?
+      end
+
+      test "cancelled? checks status" do
+        assert Coverage.new(status: "cancelled").cancelled?
+      end
+
+      # -- Payor helpers ---------------------------------------------------------
+
+      test "medicare? checks prefix" do
         assert Coverage.new(coverage_type: "medicare_a").medicare?
         assert Coverage.new(coverage_type: "medicare_b").medicare?
+        assert Coverage.new(coverage_type: "medicare_d").medicare?
         assert_not Coverage.new(coverage_type: "medicaid").medicare?
+      end
+
+      test "medicaid?" do
+        assert Coverage.new(coverage_type: "medicaid").medicaid?
+      end
+
+      test "private_insurance?" do
+        assert Coverage.new(coverage_type: "private_insurance").private_insurance?
+      end
+
+      test "va_benefits?" do
+        assert Coverage.new(coverage_type: "va_benefits").va_benefits?
       end
 
       test "government_payer? includes medicare, medicaid, va" do
@@ -59,16 +120,18 @@ module Lakeraven
         assert Coverage.new(coverage_type: "medicaid").government_payer?
         assert Coverage.new(coverage_type: "va_benefits").government_payer?
         assert_not Coverage.new(coverage_type: "private_insurance").government_payer?
+        assert_not Coverage.new(coverage_type: "workers_comp").government_payer?
       end
 
-      # -- COB -----------------------------------------------------------------
+      # -- COB -------------------------------------------------------------------
 
       test "primary? and secondary?" do
         assert Coverage.new(order: 1).primary?
         assert Coverage.new(order: 2).secondary?
+        assert_not Coverage.new(order: 1).secondary?
       end
 
-      # -- FHIR serialization --------------------------------------------------
+      # -- FHIR serialization ----------------------------------------------------
 
       test "to_fhir returns Coverage resource" do
         cov = Coverage.new(
@@ -81,7 +144,32 @@ module Lakeraven
         assert_equal "Coverage", fhir[:resourceType]
         assert_equal "active", fhir[:status]
         assert_equal "Patient/1", fhir.dig(:beneficiary, :reference)
+      end
+
+      test "to_fhir includes period when dates set" do
+        cov = Coverage.new(
+          patient_dfn: "1", coverage_type: "medicaid",
+          start_date: Date.new(2025, 1, 1), end_date: Date.new(2025, 12, 31)
+        )
+        fhir = cov.to_fhir
+
         assert_equal "2025-01-01", fhir.dig(:period, :start)
+        assert_equal "2025-12-31", fhir.dig(:period, :end)
+      end
+
+      test "to_fhir includes payor" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid", payor_name: "State Medicaid")
+        fhir = cov.to_fhir
+
+        assert_equal "State Medicaid", fhir[:payor].first[:display]
+      end
+
+      test "to_fhir includes class with subscriber_id" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid", subscriber_id: "MCD123")
+        fhir = cov.to_fhir
+
+        plan_class = fhir[:class]&.find { |c| c.dig(:type, :coding, 0, :code) == "plan" }
+        assert_equal "MCD123", plan_class[:value]
       end
     end
   end

--- a/test/models/lakeraven/ehr/location_test.rb
+++ b/test/models/lakeraven/ehr/location_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class LocationTest < ActiveSupport::TestCase
+      test "find_by_ien returns Location for known IEN" do
+        loc = Location.find_by_ien(1)
+        assert_not_nil loc
+        assert_equal "Primary Care Clinic", loc.name
+        assert_equal "PCC", loc.abbreviation
+      end
+
+      test "find_by_ien returns nil for unknown IEN" do
+        assert_nil Location.find_by_ien(99_999)
+      end
+
+      test "persisted? with valid IEN" do
+        assert Location.new(ien: 1, name: "Test").persisted?
+      end
+
+      test "persisted? false without IEN" do
+        refute Location.new(name: "Test").persisted?
+      end
+
+      test "active? defaults to true" do
+        assert Location.new(ien: 1, name: "Test").active?
+      end
+
+      test "to_fhir returns Location resource" do
+        loc = Location.find_by_ien(1)
+        fhir = loc.to_fhir
+
+        assert_equal "Location", fhir[:resourceType]
+        assert_equal "1", fhir[:id]
+        assert_equal "Primary Care Clinic", fhir[:name]
+      end
+
+      test "to_fhir includes alias for abbreviation" do
+        loc = Location.find_by_ien(1)
+        fhir = loc.to_fhir
+
+        assert_includes fhir[:alias], "PCC"
+      end
+
+      test "to_fhir mode is instance" do
+        loc = Location.new(ien: 1, name: "Test")
+        assert_equal "instance", loc.to_fhir[:mode]
+      end
+    end
+  end
+end

--- a/test/models/lakeraven/ehr/organization_test.rb
+++ b/test/models/lakeraven/ehr/organization_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class OrganizationTest < ActiveSupport::TestCase
+      test "find_by_ien returns Organization for known IEN" do
+        org = Organization.find_by_ien(1)
+        assert_not_nil org
+        assert_equal "Alaska Native Medical Center", org.name
+        assert_equal "463", org.station_number
+      end
+
+      test "find_by_ien returns nil for unknown IEN" do
+        assert_nil Organization.find_by_ien(99_999)
+      end
+
+      test "persisted? with valid IEN" do
+        assert Organization.new(ien: 1, name: "Test").persisted?
+      end
+
+      test "persisted? false without IEN" do
+        refute Organization.new(name: "Test").persisted?
+      end
+
+      test "full_address combines parts" do
+        org = Organization.new(address: "123 Main St", city: "Anchorage", state: "AK", zip_code: "99508")
+        assert_equal "123 Main St, Anchorage, AK, 99508", org.full_address
+      end
+
+      test "full_address handles missing parts" do
+        org = Organization.new(city: "Anchorage", state: "AK")
+        assert_equal "Anchorage, AK", org.full_address
+      end
+
+      test "to_fhir returns Organization resource" do
+        org = Organization.find_by_ien(1)
+        fhir = org.to_fhir
+
+        assert_equal "Organization", fhir[:resourceType]
+        assert_equal "1", fhir[:id]
+        assert_equal "Alaska Native Medical Center", fhir[:name]
+      end
+
+      test "to_fhir includes address" do
+        org = Organization.find_by_ien(1)
+        fhir = org.to_fhir
+
+        addr = fhir[:address]&.first
+        assert_equal "AK", addr[:state]
+      end
+
+      test "to_fhir includes telecom" do
+        org = Organization.find_by_ien(1)
+        fhir = org.to_fhir
+
+        assert fhir[:telecom]&.any?
+      end
+
+      test "to_fhir includes station number as identifier" do
+        org = Organization.find_by_ien(1)
+        fhir = org.to_fhir
+
+        assert fhir[:identifier]&.any?
+      end
+    end
+  end
+end

--- a/test/models/lakeraven/ehr/patient_test.rb
+++ b/test/models/lakeraven/ehr/patient_test.rb
@@ -5,34 +5,31 @@ require "test_helper"
 module Lakeraven
   module EHR
     class PatientTest < ActiveSupport::TestCase
-      # GatewayFactory defaults to mock in test env.
-      # MockGatewayAdapter seeds patients DFN 1-5 on first use.
-
       # -- find_by_dfn -----------------------------------------------------------
 
       test "find_by_dfn returns a Patient for a known DFN" do
-        patient = Lakeraven::EHR::Patient.find_by_dfn(1)
+        patient = Patient.find_by_dfn(1)
         assert_not_nil patient
-        assert_kind_of Lakeraven::EHR::Patient, patient
+        assert_kind_of Patient, patient
         assert_equal 1, patient.dfn
         assert_equal "Anderson,Alice", patient.name
         assert_equal "F", patient.sex
       end
 
       test "find_by_dfn returns nil for unknown DFN" do
-        assert_nil Lakeraven::EHR::Patient.find_by_dfn(99_999)
+        assert_nil Patient.find_by_dfn(99_999)
       end
 
       test "find_by_dfn returns nil for zero" do
-        assert_nil Lakeraven::EHR::Patient.find_by_dfn(0)
+        assert_nil Patient.find_by_dfn(0)
       end
 
       test "find_by_dfn returns nil for nil" do
-        assert_nil Lakeraven::EHR::Patient.find_by_dfn(nil)
+        assert_nil Patient.find_by_dfn(nil)
       end
 
       test "find_by_dfn merges extended demographics" do
-        patient = Lakeraven::EHR::Patient.find_by_dfn(1)
+        patient = Patient.find_by_dfn(1)
         assert_equal "AMERICAN INDIAN", patient.race
         assert_equal "123 Main St", patient.address_line1
         assert_equal "AK", patient.state
@@ -40,42 +37,107 @@ module Lakeraven
         assert_equal "ANLC-12345", patient.tribal_enrollment_number
       end
 
+      # -- find (raises) --------------------------------------------------------
+
+      test "find returns patient for known DFN" do
+        patient = Patient.find(1)
+        assert_equal 1, patient.dfn
+      end
+
+      test "find raises RecordNotFound for unknown DFN" do
+        assert_raises(Patient::RecordNotFound) { Patient.find(99_999) }
+      end
+
       # -- search ----------------------------------------------------------------
 
       test "search returns patients matching name pattern" do
-        results = Lakeraven::EHR::Patient.search("Anderson")
+        results = Patient.search("Anderson")
         assert_operator results.length, :>=, 1
-        assert(results.all? { |p| p.is_a?(Lakeraven::EHR::Patient) })
+        assert(results.all? { |p| p.is_a?(Patient) })
       end
 
       test "search returns empty array for no matches" do
-        assert_equal [], Lakeraven::EHR::Patient.search("ZZZZNONEXISTENT")
+        assert_equal [], Patient.search("ZZZZNONEXISTENT")
       end
 
-      # -- composite fields ------------------------------------------------------
+      # -- search_by_ssn --------------------------------------------------------
+
+      test "search_by_ssn returns array with matching patient" do
+        results = Patient.search_by_ssn("111-11-1111")
+        assert_equal 1, results.length
+      end
+
+      test "search_by_ssn returns empty array for no match" do
+        assert_equal [], Patient.search_by_ssn("000-00-0000")
+      end
+
+      # -- composite fields: name ------------------------------------------------
 
       test "name syncs to first_name and last_name" do
-        patient = Lakeraven::EHR::Patient.new(name: "DOE,JOHN")
+        patient = Patient.new(name: "DOE,JOHN")
         assert_equal "Doe", patient.last_name
         assert_equal "John", patient.first_name
       end
 
       test "first_name and last_name sync to name" do
-        patient = Lakeraven::EHR::Patient.new(first_name: "Jane", last_name: "Smith")
+        patient = Patient.new(first_name: "Jane", last_name: "Smith")
         assert_equal "Smith,Jane", patient.name
+      end
+
+      # -- composite fields: born_on / dob ---------------------------------------
+
+      test "born_on syncs to dob" do
+        patient = Patient.new(born_on: Date.new(1980, 1, 15), sex: "M")
+        assert_equal Date.new(1980, 1, 15), patient.dob
+      end
+
+      test "dob syncs to born_on" do
+        patient = Patient.new(dob: Date.new(1990, 6, 1), sex: "F")
+        assert_equal Date.new(1990, 6, 1), patient.born_on
       end
 
       # -- display_name ----------------------------------------------------------
 
       test "display_name formats MUMPS name for display" do
-        patient = Lakeraven::EHR::Patient.new(name: "DOE,JOHN")
+        patient = Patient.new(name: "DOE,JOHN")
         assert_equal "JOHN DOE", patient.display_name
+      end
+
+      test "formal_name capitalizes properly" do
+        patient = Patient.new(name: "DOE,JOHN MICHAEL")
+        assert_equal "Doe, John Michael", patient.formal_name
+      end
+
+      # -- persisted? ------------------------------------------------------------
+
+      test "persisted? true with valid DFN" do
+        patient = Patient.new(dfn: 1, name: "DOE,JOHN", sex: "M")
+        assert patient.persisted?
+      end
+
+      test "persisted? false without DFN" do
+        patient = Patient.new(name: "DOE,JOHN", sex: "M")
+        refute patient.persisted?
+      end
+
+      # -- PRC attributes -------------------------------------------------------
+
+      test "patient has PRC-specific attributes" do
+        patient = Patient.new(
+          first_name: "John", last_name: "Doe",
+          born_on: Date.new(1980, 1, 15),
+          tribal_enrollment_number: "ANLC-12345",
+          service_area: "Anchorage", coverage_type: "IHS"
+        )
+        assert_equal "ANLC-12345", patient.tribal_enrollment_number
+        assert_equal "Anchorage", patient.service_area
+        assert_equal "IHS", patient.coverage_type
       end
 
       # -- to_fhir ---------------------------------------------------------------
 
       test "to_fhir returns a FHIR Patient hash" do
-        patient = Lakeraven::EHR::Patient.find_by_dfn(1)
+        patient = Patient.find_by_dfn(1)
         fhir = patient.to_fhir
 
         assert_equal "Patient", fhir[:resourceType]
@@ -83,6 +145,47 @@ module Lakeraven
         assert_includes fhir.dig(:meta, :profile), "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
         assert_equal "Anderson", fhir[:name].first[:family]
         assert_equal "female", fhir[:gender]
+      end
+
+      test "to_fhir includes RPMS identifiers" do
+        patient = Patient.find_by_dfn(1)
+        fhir = patient.to_fhir
+
+        dfn_id = fhir[:identifier].find { |id| id[:system] == "urn:oid:2.16.840.1.113883.4.349" }
+        assert_not_nil dfn_id
+        assert_equal "1", dfn_id[:value]
+      end
+
+      test "to_fhir includes SSN identifier" do
+        patient = Patient.find_by_dfn(1)
+        fhir = patient.to_fhir
+
+        ssn_id = fhir[:identifier].find { |id| id[:system]&.include?("ssn") }
+        assert_equal "111-11-1111", ssn_id[:value]
+      end
+
+      test "to_fhir includes birthDate" do
+        patient = Patient.find_by_dfn(1)
+        fhir = patient.to_fhir
+
+        assert_equal "1980-05-15", fhir[:birthDate]
+      end
+
+      test "to_fhir includes address" do
+        patient = Patient.find_by_dfn(1)
+        fhir = patient.to_fhir
+
+        addr = fhir[:address]&.first
+        assert_equal "AK", addr[:state]
+        assert_equal "Anchorage", addr[:city]
+      end
+
+      test "to_fhir includes telecom" do
+        patient = Patient.find_by_dfn(1)
+        fhir = patient.to_fhir
+
+        telecom = fhir[:telecom]&.first
+        assert_equal "907-555-1234", telecom[:value]
       end
     end
   end

--- a/test/models/lakeraven/ehr/practitioner_test.rb
+++ b/test/models/lakeraven/ehr/practitioner_test.rb
@@ -5,14 +5,12 @@ require "test_helper"
 module Lakeraven
   module EHR
     class PractitionerTest < ActiveSupport::TestCase
-      # MockGatewayAdapter seeds practitioners IEN 101-102.
-
       # -- find_by_ien -----------------------------------------------------------
 
       test "find_by_ien returns a Practitioner for a known IEN" do
-        prac = Lakeraven::EHR::Practitioner.find_by_ien(101)
+        prac = Practitioner.find_by_ien(101)
         assert_not_nil prac
-        assert_kind_of Lakeraven::EHR::Practitioner, prac
+        assert_kind_of Practitioner, prac
         assert_equal 101, prac.ien
         assert_equal "MARTINEZ,SARAH", prac.name
         assert_equal "Cardiology", prac.specialty
@@ -21,56 +19,116 @@ module Lakeraven
       end
 
       test "find_by_ien returns nil for unknown IEN" do
-        assert_nil Lakeraven::EHR::Practitioner.find_by_ien(99_999)
+        assert_nil Practitioner.find_by_ien(99_999)
       end
 
       test "find_by_ien returns nil for nil" do
-        assert_nil Lakeraven::EHR::Practitioner.find_by_ien(nil)
+        assert_nil Practitioner.find_by_ien(nil)
       end
 
       # -- search ----------------------------------------------------------------
 
       test "search returns practitioners matching name pattern" do
-        results = Lakeraven::EHR::Practitioner.search("MARTINEZ")
+        results = Practitioner.search("MARTINEZ")
         assert_equal 1, results.length
         assert_equal "MARTINEZ,SARAH", results.first.name
       end
 
       test "search with empty string returns all practitioners" do
-        results = Lakeraven::EHR::Practitioner.search("")
+        results = Practitioner.search("")
         assert_equal 2, results.length
       end
 
       test "search returns empty array for no matches" do
-        assert_equal [], Lakeraven::EHR::Practitioner.search("ZZZZNONEXISTENT")
+        assert_equal [], Practitioner.search("ZZZZNONEXISTENT")
       end
 
       # -- composite fields ------------------------------------------------------
 
       test "name syncs to first_name and last_name" do
-        prac = Lakeraven::EHR::Practitioner.new(name: "CHEN,JAMES")
+        prac = Practitioner.new(name: "CHEN,JAMES")
         assert_equal "Chen", prac.last_name
         assert_equal "James", prac.first_name
+      end
+
+      test "first_name and last_name sync to name" do
+        prac = Practitioner.new(first_name: "Sarah", last_name: "Martinez")
+        assert_equal "Martinez,Sarah", prac.name
       end
 
       # -- display_name ----------------------------------------------------------
 
       test "display_name formats MUMPS name for display" do
-        prac = Lakeraven::EHR::Practitioner.new(name: "MARTINEZ,SARAH")
+        prac = Practitioner.new(name: "MARTINEZ,SARAH")
         assert_equal "SARAH MARTINEZ", prac.display_name
+      end
+
+      # -- persisted? ------------------------------------------------------------
+
+      test "persisted? true with valid IEN" do
+        prac = Practitioner.new(ien: 101, name: "TEST,DOC")
+        assert prac.persisted?
+      end
+
+      test "persisted? false without IEN" do
+        prac = Practitioner.new(name: "TEST,DOC")
+        refute prac.persisted?
+      end
+
+      # -- credential helpers ----------------------------------------------------
+
+      test "can_prescribe_controlled? true with DEA number" do
+        prac = Practitioner.new(dea_number: "AB1234567")
+        assert prac.can_prescribe_controlled?
+      end
+
+      test "can_prescribe_controlled? false without DEA" do
+        prac = Practitioner.new(dea_number: nil)
+        refute prac.can_prescribe_controlled?
+      end
+
+      test "credentials_summary combines title and specialty" do
+        prac = Practitioner.new(title: "MD", specialty: "Cardiology")
+        assert_equal "MD, Cardiology", prac.credentials_summary
+      end
+
+      test "credentials_summary handles missing title" do
+        prac = Practitioner.new(specialty: "Cardiology")
+        assert_equal "Cardiology", prac.credentials_summary
       end
 
       # -- to_fhir ---------------------------------------------------------------
 
       test "to_fhir returns a FHIR Practitioner hash" do
-        prac = Lakeraven::EHR::Practitioner.find_by_ien(101)
+        prac = Practitioner.find_by_ien(101)
         fhir = prac.to_fhir
 
         assert_equal "Practitioner", fhir[:resourceType]
         assert_equal "101", fhir[:id]
         assert_equal "MARTINEZ", fhir[:name].first[:family]
+      end
+
+      test "to_fhir includes NPI identifier" do
+        prac = Practitioner.find_by_ien(101)
+        fhir = prac.to_fhir
+
         npi_id = fhir[:identifier].find { |id| id[:system]&.include?("npi") }
         assert_equal "1234567890", npi_id[:value]
+      end
+
+      test "to_fhir includes qualification" do
+        prac = Practitioner.find_by_ien(101)
+        fhir = prac.to_fhir
+
+        assert prac.to_fhir[:qualification]&.any?
+      end
+
+      test "to_fhir includes telecom" do
+        prac = Practitioner.find_by_ien(101)
+        fhir = prac.to_fhir
+
+        telecom = fhir[:telecom]&.first
+        assert_equal "907-555-9999", telecom[:value]
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,6 +26,8 @@ RpmsRpc.mock! do |m|
   m.seed(:patient_id_info, "3", { race: "AMERICAN INDIAN", tribal_enrollment_number: "CNO-24680",
                                    service_area: "Oklahoma", coverage_type: "IHS" })
 
+  m.seed(:patient_ssn, "111-11-1111", { dfn: 1, name: "Anderson,Alice", ssn: "111-11-1111" })
+
   m.seed_collection(:patient_list,
     [ { dfn: 1, name: "Anderson,Alice" }, { dfn: 2, name: "MOUSE,MICKEY M" }, { dfn: 3, name: "DOE,JANE" } ],
     filter_field: :name)


### PR DESCRIPTION
## Summary
Enrich existing models with missing attributes, methods, and test coverage from rpms_redux.

| Model | Before | After | New methods |
|---|---|---|---|
| Patient | 11 tests | 26 tests | find (raises), born_on sync, persisted?, search_by_ssn, FHIR detail |
| Practitioner | 9 tests | 19 tests | persisted?, can_prescribe_controlled?, credentials_summary, FHIR detail |
| Coverage | 11 tests | 26 tests | All valid types/statuses, cancelled?, within_coverage_period?, FHIR detail |
| Organization | 3 tests | 10 tests | persisted?, full_address, FHIR detail (NEW model tests) |
| Location | 2 tests | 8 tests | persisted?, active?, FHIR detail (NEW model tests) |

## Totals
- **89 model tests** (up from 36)
- **222 minitest + 107 cucumber = 329 total**

🤖 Generated with [Claude Code](https://claude.com/claude-code)