### PR TITLE
Add Device, DiagnosticReport, DocumentReference, CarePlan, Goal, KernelUser models

### DIFF
--- a/app/models/lakeraven/ehr/care_plan.rb
+++ b/app/models/lakeraven/ehr/care_plan.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class CarePlan
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :ien, :string
+      attribute :patient_dfn, :string
+      attribute :title, :string
+      attribute :description, :string
+      attribute :status, :string, default: "active"
+      attribute :intent, :string, default: "plan"
+      attribute :category, :string
+      attribute :period_start, :date
+      attribute :period_end, :date
+      attribute :author_name, :string
+
+      def active? = status == "active"
+
+      def to_fhir
+        {
+          resourceType: "CarePlan",
+          id: ien,
+          status: status,
+          intent: intent,
+          title: title,
+          subject: patient_dfn ? { reference: "Patient/#{patient_dfn}" } : nil
+        }.compact
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/device.rb
+++ b/app/models/lakeraven/ehr/device.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class Device
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :ien, :string
+      attribute :patient_dfn, :string
+      attribute :udi_carrier, :string
+      attribute :udi_device_identifier, :string
+      attribute :status, :string, default: "active"
+      attribute :manufacturer, :string
+      attribute :manufacture_date, :date
+      attribute :expiration_date, :date
+      attribute :lot_number, :string
+      attribute :serial_number, :string
+      attribute :device_name, :string
+      attribute :model_number, :string
+      attribute :type_code, :string
+      attribute :type_display, :string
+
+      def active? = status == "active"
+
+      def to_fhir
+        {
+          resourceType: "Device",
+          id: ien,
+          patient: patient_dfn ? { reference: "Patient/#{patient_dfn}" } : nil,
+          udiCarrier: udi_carrier ? [ { carrierHRF: udi_carrier } ] : nil,
+          status: status,
+          manufacturer: manufacturer,
+          deviceName: device_name ? [ { name: device_name, type: "user-friendly-name" } ] : nil
+        }.compact
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/diagnostic_report.rb
+++ b/app/models/lakeraven/ehr/diagnostic_report.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class DiagnosticReport
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :ien, :string
+      attribute :patient_dfn, :string
+      attribute :category, :string
+      attribute :code, :string
+      attribute :code_display, :string
+      attribute :status, :string, default: "final"
+      attribute :effective_datetime, :datetime
+      attribute :issued, :datetime
+      attribute :performer_name, :string
+      attribute :conclusion, :string
+
+      def final? = status == "final"
+
+      def to_fhir
+        {
+          resourceType: "DiagnosticReport",
+          id: ien,
+          status: status,
+          code: { text: code_display },
+          subject: patient_dfn ? { reference: "Patient/#{patient_dfn}" } : nil,
+          conclusion: conclusion
+        }.compact
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/document_reference.rb
+++ b/app/models/lakeraven/ehr/document_reference.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class DocumentReference
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :id, :string
+      attribute :status, :string, default: "current"
+      attribute :type_code, :string
+      attribute :type_display, :string
+      attribute :category, :string
+      attribute :subject_patient_dfn, :string
+      attribute :author_ien, :string
+      attribute :date, :datetime
+      attribute :description, :string
+      attribute :content_url, :string
+      attribute :content_type, :string
+
+      def current? = status == "current"
+
+      def to_fhir
+        {
+          resourceType: "DocumentReference",
+          status: status,
+          type: type_display ? { text: type_display } : nil,
+          subject: subject_patient_dfn ? { reference: "Patient/#{subject_patient_dfn}" } : nil,
+          description: description,
+          content: content_url ? [ { attachment: { url: content_url, contentType: content_type } } ] : []
+        }.compact
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/goal.rb
+++ b/app/models/lakeraven/ehr/goal.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class Goal
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :ien, :string
+      attribute :patient_dfn, :string
+      attribute :description, :string
+      attribute :lifecycle_status, :string, default: "active"
+      attribute :achievement_status, :string
+      attribute :category, :string
+      attribute :priority, :string
+      attribute :start_date, :date
+      attribute :target_date, :date
+
+      def active? = lifecycle_status == "active"
+      def achieved? = achievement_status == "achieved"
+
+      def to_fhir
+        {
+          resourceType: "Goal",
+          id: ien,
+          lifecycleStatus: lifecycle_status,
+          description: { text: description },
+          subject: patient_dfn ? { reference: "Patient/#{patient_dfn}" } : nil
+        }.compact
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/kernel_user.rb
+++ b/app/models/lakeraven/ehr/kernel_user.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class KernelUser
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :duz, :integer
+      attribute :name, :string
+      attribute :title, :string
+
+      def display_name
+        return name if name.blank?
+
+        parts = name.split(",")
+        last = parts[0]&.strip
+        first = parts[1]&.strip
+        first.present? ? "#{first} #{last}" : last
+      end
+
+      def to_param = duz.to_s
+    end
+  end
+end

--- a/test/models/lakeraven/ehr/additional_models_test.rb
+++ b/test/models/lakeraven/ehr/additional_models_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class AdditionalModelsTest < ActiveSupport::TestCase
+      # -- Device ----------------------------------------------------------------
+
+      test "Device has UDI and manufacturer attributes" do
+        d = Device.new(ien: "1", patient_dfn: "1", device_name: "Pacemaker",
+                       manufacturer: "Medtronic", udi_carrier: "UDI123")
+        assert_equal "Pacemaker", d.device_name
+        assert_equal "Medtronic", d.manufacturer
+        assert d.active?
+      end
+
+      test "Device to_fhir" do
+        d = Device.new(ien: "1", patient_dfn: "1", device_name: "Pacemaker", status: "active")
+        fhir = d.to_fhir
+        assert_equal "Device", fhir[:resourceType]
+        assert_equal "Patient/1", fhir.dig(:patient, :reference)
+      end
+
+      # -- DiagnosticReport ------------------------------------------------------
+
+      test "DiagnosticReport has code and conclusion" do
+        dr = DiagnosticReport.new(code_display: "CBC", conclusion: "Normal", status: "final")
+        assert_equal "CBC", dr.code_display
+        assert dr.final?
+      end
+
+      test "DiagnosticReport to_fhir" do
+        dr = DiagnosticReport.new(ien: "1", patient_dfn: "1", code_display: "CBC", status: "final")
+        fhir = dr.to_fhir
+        assert_equal "DiagnosticReport", fhir[:resourceType]
+      end
+
+      # -- DocumentReference -----------------------------------------------------
+
+      test "DocumentReference has content URL" do
+        doc = DocumentReference.new(description: "Lab report", content_url: "/docs/123.pdf", content_type: "application/pdf")
+        assert_equal "/docs/123.pdf", doc.content_url
+        assert doc.current?
+      end
+
+      test "DocumentReference to_fhir" do
+        doc = DocumentReference.new(subject_patient_dfn: "1", description: "Report", content_url: "/test.pdf")
+        fhir = doc.to_fhir
+        assert_equal "DocumentReference", fhir[:resourceType]
+        assert_equal "/test.pdf", fhir[:content].first.dig(:attachment, :url)
+      end
+
+      # -- CarePlan --------------------------------------------------------------
+
+      test "CarePlan has title and status" do
+        cp = CarePlan.new(title: "Diabetes Management", status: "active", intent: "plan")
+        assert_equal "Diabetes Management", cp.title
+        assert cp.active?
+      end
+
+      test "CarePlan to_fhir" do
+        cp = CarePlan.new(ien: "1", patient_dfn: "1", title: "Diabetes", status: "active", intent: "plan")
+        fhir = cp.to_fhir
+        assert_equal "CarePlan", fhir[:resourceType]
+        assert_equal "plan", fhir[:intent]
+      end
+
+      # -- Goal ------------------------------------------------------------------
+
+      test "Goal has description and lifecycle status" do
+        g = Goal.new(description: "A1C below 7", lifecycle_status: "active")
+        assert_equal "A1C below 7", g.description
+        assert g.active?
+      end
+
+      test "Goal achieved?" do
+        g = Goal.new(achievement_status: "achieved")
+        assert g.achieved?
+      end
+
+      test "Goal to_fhir" do
+        g = Goal.new(ien: "1", patient_dfn: "1", description: "A1C below 7", lifecycle_status: "active")
+        fhir = g.to_fhir
+        assert_equal "Goal", fhir[:resourceType]
+        assert_equal "A1C below 7", fhir.dig(:description, :text)
+      end
+
+      # -- KernelUser ------------------------------------------------------------
+
+      test "KernelUser has DUZ and name" do
+        u = KernelUser.new(duz: 101, name: "MARTINEZ,SARAH", title: "MD")
+        assert_equal 101, u.duz
+        assert_equal "SARAH MARTINEZ", u.display_name
+      end
+
+      test "KernelUser to_param" do
+        u = KernelUser.new(duz: 101)
+        assert_equal "101", u.to_param
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
6 new ActiveModel classes ported from rpms_redux with attributes, predicates, and to_fhir.

| Model | Attributes | Predicates |
|---|---|---|
| Device | 14 | active? |
| DiagnosticReport | 10 | final? |
| DocumentReference | 11 | current? |
| CarePlan | 10 | active? |
| Goal | 9 | active?, achieved? |
| KernelUser | 3 | display_name |

13 new tests, 251 total minitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)