### PR TITLE
Add PractitionerRole, CpoeOrder, Provenance models

### DIFF
--- a/app/models/lakeraven/ehr/cpoe_order.rb
+++ b/app/models/lakeraven/ehr/cpoe_order.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class CpoeOrder
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :id, :string
+      attribute :patient_dfn, :string
+      attribute :requester_duz, :string
+      attribute :requester_name, :string
+      attribute :status, :string, default: "draft"
+      attribute :intent, :string, default: "order"
+      attribute :category, :string
+      attribute :priority, :string, default: "routine"
+      attribute :code, :string
+      attribute :code_display, :string
+      attribute :body_site, :string
+      attribute :clinical_reason, :string
+      attribute :note, :string
+      attribute :authored_on, :datetime
+      attribute :signed_at, :datetime
+      attribute :signer_duz, :string
+      attribute :signed_content_hash, :string
+
+      def draft? = status == "draft"
+      def active? = status == "active"
+      def completed? = status == "completed"
+      def signed? = signed_at.present?
+
+      def sign!(signer_duz:)
+        self.signer_duz = signer_duz
+        self.signed_at = Time.current
+        self.signed_content_hash = Digest::SHA256.hexdigest(signable_content)
+        self.status = "active"
+      end
+
+      def to_fhir
+        {
+          resourceType: "ServiceRequest",
+          id: id,
+          status: status,
+          intent: intent,
+          priority: priority,
+          code: code_display ? { text: code_display } : nil,
+          subject: patient_dfn ? { reference: "Patient/#{patient_dfn}" } : nil,
+          requester: requester_name ? { display: requester_name } : nil
+        }.compact
+      end
+
+      private
+
+      def signable_content
+        [ patient_dfn, code, code_display, dosage_or_instructions ].compact.join("|")
+      end
+
+      def dosage_or_instructions
+        note || clinical_reason
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/practitioner_role.rb
+++ b/app/models/lakeraven/ehr/practitioner_role.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class PractitionerRole
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      ROLES = {
+        "doctor" => "Doctor",
+        "nurse" => "Nurse",
+        "pharmacist" => "Pharmacist",
+        "surgeon" => "Surgeon",
+        "therapist" => "Therapist"
+      }.freeze
+
+      attribute :practitioner_ien, :integer
+      attribute :organization_ien, :integer
+      attribute :role, :string
+      attribute :specialty, :string
+      attribute :active, :boolean, default: true
+      attribute :period_start, :date
+      attribute :period_end, :date
+      attribute :location_iens # Array
+
+      def active? = active
+      def role_display = ROLES[role] || role
+
+      def within_period?
+        today = Date.current
+        (period_start.nil? || today >= period_start) && (period_end.nil? || today <= period_end)
+      end
+
+      def to_fhir
+        {
+          resourceType: "PractitionerRole",
+          active: active,
+          practitioner: { reference: "Practitioner/#{practitioner_ien}" },
+          organization: organization_ien ? { reference: "Organization/#{organization_ien}" } : nil,
+          code: role ? [ { text: role_display } ] : [],
+          specialty: specialty ? [ { text: specialty } ] : []
+        }.compact
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/provenance.rb
+++ b/app/models/lakeraven/ehr/provenance.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class Provenance
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :target_type, :string
+      attribute :target_id, :string
+      attribute :recorded, :datetime
+      attribute :activity, :string
+      attribute :agent_who_id, :string
+      attribute :agent_who_type, :string
+      attribute :agent_type, :string
+
+      def to_fhir
+        {
+          resourceType: "Provenance",
+          target: [ { reference: "#{target_type}/#{target_id}" } ],
+          recorded: recorded&.iso8601,
+          activity: activity ? { text: activity } : nil,
+          agent: [ {
+            who: { reference: "#{agent_who_type}/#{agent_who_id}" }
+          } ]
+        }.compact
+      end
+    end
+  end
+end

--- a/test/models/lakeraven/ehr/cpoe_order_test.rb
+++ b/test/models/lakeraven/ehr/cpoe_order_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class CpoeOrderTest < ActiveSupport::TestCase
+      test "defaults to draft status" do
+        order = CpoeOrder.new(code_display: "CBC", patient_dfn: "1")
+        assert order.draft?
+        refute order.signed?
+      end
+
+      test "sign! sets signed_at and status to active" do
+        order = CpoeOrder.new(code_display: "CBC", patient_dfn: "1")
+        order.sign!(signer_duz: "101")
+
+        assert order.signed?
+        assert order.active?
+        assert_equal "101", order.signer_duz
+        assert order.signed_content_hash.present?
+      end
+
+      test "to_fhir returns ServiceRequest resource" do
+        order = CpoeOrder.new(id: "ord-1", patient_dfn: "1", code_display: "CBC", status: "active", intent: "order")
+        fhir = order.to_fhir
+        assert_equal "ServiceRequest", fhir[:resourceType]
+        assert_equal "active", fhir[:status]
+      end
+    end
+  end
+end

--- a/test/models/lakeraven/ehr/practitioner_role_test.rb
+++ b/test/models/lakeraven/ehr/practitioner_role_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class PractitionerRoleTest < ActiveSupport::TestCase
+      test "has practitioner and organization references" do
+        pr = PractitionerRole.new(practitioner_ien: 101, organization_ien: 1, role: "doctor", specialty: "Cardiology")
+        assert_equal 101, pr.practitioner_ien
+        assert_equal "Doctor", pr.role_display
+      end
+
+      test "defaults to active" do
+        assert PractitionerRole.new.active?
+      end
+
+      test "within_period? true when no dates" do
+        assert PractitionerRole.new.within_period?
+      end
+
+      test "within_period? true when current" do
+        pr = PractitionerRole.new(period_start: 1.year.ago, period_end: 1.year.from_now)
+        assert pr.within_period?
+      end
+
+      test "within_period? false when expired" do
+        pr = PractitionerRole.new(period_start: 2.years.ago, period_end: 1.year.ago)
+        refute pr.within_period?
+      end
+
+      test "to_fhir returns PractitionerRole resource" do
+        pr = PractitionerRole.new(practitioner_ien: 101, organization_ien: 1, role: "doctor", active: true)
+        fhir = pr.to_fhir
+        assert_equal "PractitionerRole", fhir[:resourceType]
+        assert_equal "Practitioner/101", fhir.dig(:practitioner, :reference)
+      end
+    end
+  end
+end

--- a/test/models/lakeraven/ehr/provenance_test.rb
+++ b/test/models/lakeraven/ehr/provenance_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class ProvenanceTest < ActiveSupport::TestCase
+      test "tracks target and agent" do
+        p = Provenance.new(target_type: "Patient", target_id: "1",
+                           agent_who_type: "Practitioner", agent_who_id: "101",
+                           activity: "create", recorded: Time.current)
+        assert_equal "Patient", p.target_type
+        assert_equal "101", p.agent_who_id
+      end
+
+      test "to_fhir returns Provenance resource" do
+        p = Provenance.new(target_type: "Patient", target_id: "1",
+                           agent_who_type: "Practitioner", agent_who_id: "101",
+                           recorded: Time.current)
+        fhir = p.to_fhir
+        assert_equal "Provenance", fhir[:resourceType]
+        assert_equal "Patient/1", fhir[:target].first[:reference]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
3 remaining models ported from rpms_redux:

| Model | Attributes | Key features |
|---|---|---|
| PractitionerRole | 8 | Role display, period checking, FHIR PractitionerRole |
| CpoeOrder | 18 | Draft → signed workflow, content hash, FHIR ServiceRequest |
| Provenance | 7 | FHIR Provenance audit trail (simplified; OCAP fields come with #62) |

11 new tests, 262 total minitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)