### PR TITLE
Test database should use PostgreSQL instead of SQLite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,26 @@ jobs:
   test:
     name: Test (Ruby 3.4)
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/lakeraven_ehr_test
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.4"
           bundler-cache: true
-      - run: bundle exec rails db:migrate
-        env:
-          RAILS_ENV: test
+      - run: bundle exec rails db:create db:migrate
       - run: bundle exec rails test
-        env:
-          RAILS_ENV: test

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 gem "rpms-rpc", github: "lakeraven/rpms-rpc", branch: "main"
 
 gem "puma"
-gem "sqlite3"
+gem "pg"
 
 gem "cucumber-rails", require: false
 gem "minitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,13 @@ GEM
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
+    pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-aarch64-linux-musl)
+    pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-darwin)
+    pg (1.6.3-x86_64-linux)
+    pg (1.6.3-x86_64-linux-musl)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -305,14 +312,6 @@ GEM
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
-    sqlite3 (2.9.3-aarch64-linux-gnu)
-    sqlite3 (2.9.3-aarch64-linux-musl)
-    sqlite3 (2.9.3-arm-linux-gnu)
-    sqlite3 (2.9.3-arm-linux-musl)
-    sqlite3 (2.9.3-arm64-darwin)
-    sqlite3 (2.9.3-x86_64-darwin)
-    sqlite3 (2.9.3-x86_64-linux-gnu)
-    sqlite3 (2.9.3-x86_64-linux-musl)
     stringio (3.2.0)
     sys-uname (1.5.1)
       ffi (~> 1.1)
@@ -351,10 +350,10 @@ DEPENDENCIES
   cucumber-rails
   lakeraven-ehr!
   minitest
+  pg
   puma
   rpms-rpc!
   rubocop-rails-omakase
-  sqlite3
 
 BUNDLED WITH
    2.7.2

--- a/features/step_definitions/sdoh_sogi_steps.rb
+++ b/features/step_definitions/sdoh_sogi_steps.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+Given("patient {string} has an observation with code {string} and value {string} recorded on {string}") do |_dfn, code, value, date|
+  @observations ||= []
+  @observations << ::OpenStruct.new(code: code, value: value, effective_date: Date.parse(date))
+end
+
 Given("the observation has category {string}") do |category|
   @observation_category = category
 end

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -1,31 +1,12 @@
-# SQLite. Versions 3.8.0 and up are supported.
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem "sqlite3"
-#
 default: &default
-  adapter: sqlite3
-  max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
+  adapter: postgresql
+  encoding: unicode
+  pool: 5
 
 development:
   <<: *default
-  database: storage/development.sqlite3
+  database: lakeraven_ehr_dev
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: storage/test.sqlite3
-
-# SQLite3 write its data on the local filesystem, as such it requires
-# persistent disks. If you are deploying to a managed service, you should
-# make sure it provides disk persistence, as many don't.
-#
-# Similarly, if you deploy your application as a Docker container, you must
-# ensure the database is located in a persisted volume.
-production:
-  <<: *default
-  # database: path/to/persistent/storage/production.sqlite3
+  database: lakeraven_ehr_test

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,6 +11,9 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[8.1].define(version: 2026_04_22_120000) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
   create_table "lakeraven_ehr_audit_events", force: :cascade do |t|
     t.string "action", null: false
     t.string "agent_who_identifier"


### PR DESCRIPTION
## Summary
- Switch dummy app from SQLite to PostgreSQL
- CI workflow adds PostgreSQL 16 service container
- Unblocks sdoh_sogi cucumber (needs PatientSupplement AR table)
- All 113 cucumber scenarios now pass (up from 107 — sdoh_sogi unblocked)

Closes #76

## Test plan
- [x] 272 minitest, all green on PG
- [x] 113 cucumber scenarios, all green on PG
- [x] **385 total tests**

🤖 Generated with [Claude Code](https://claude.com/claude-code)