### PR TITLE
Add FHIR read gateway with from_fhir on all clinical models

### DIFF
--- a/app/controllers/lakeraven/ehr/allergy_intolerances_controller.rb
+++ b/app/controllers/lakeraven/ehr/allergy_intolerances_controller.rb
@@ -8,7 +8,7 @@ module Lakeraven
       def index
         dfn = extract_patient_dfn(params[:patient])
         results = AllergyIntolerance.for_patient(dfn)
-        render_bundle(results.map { |r| { resourceType: "AllergyIntolerance" }.merge(r) })
+        render_bundle(results.map(&:to_fhir))
       end
 
       private

--- a/app/controllers/lakeraven/ehr/conditions_controller.rb
+++ b/app/controllers/lakeraven/ehr/conditions_controller.rb
@@ -8,7 +8,7 @@ module Lakeraven
       def index
         dfn = extract_patient_dfn(params[:patient])
         results = Condition.for_patient(dfn)
-        render_bundle(results.map { |r| { resourceType: "Condition" }.merge(r) })
+        render_bundle(results.map(&:to_fhir))
       end
 
       private

--- a/app/controllers/lakeraven/ehr/encounters_controller.rb
+++ b/app/controllers/lakeraven/ehr/encounters_controller.rb
@@ -8,7 +8,7 @@ module Lakeraven
       def index
         dfn = params[:patient].to_s.delete_prefix("Patient/")
         results = EncounterGateway.for_patient(dfn)
-        render_bundle(results.map { |r| { resourceType: "Encounter" }.merge(r) })
+        render_bundle(results.map(&:to_fhir))
       end
 
       private

--- a/app/controllers/lakeraven/ehr/immunizations_controller.rb
+++ b/app/controllers/lakeraven/ehr/immunizations_controller.rb
@@ -8,7 +8,7 @@ module Lakeraven
       def index
         dfn = params[:patient].to_s.delete_prefix("Patient/")
         results = Immunization.for_patient(dfn)
-        render_bundle(results.map { |r| { resourceType: "Immunization" }.merge(r) })
+        render_bundle(results.map(&:to_fhir))
       end
 
       private

--- a/app/controllers/lakeraven/ehr/medication_requests_controller.rb
+++ b/app/controllers/lakeraven/ehr/medication_requests_controller.rb
@@ -8,7 +8,7 @@ module Lakeraven
       def index
         dfn = extract_patient_dfn(params[:patient])
         results = MedicationRequest.for_patient(dfn)
-        render_bundle(results.map { |r| { resourceType: "MedicationRequest" }.merge(r) })
+        render_bundle(results.map(&:to_fhir))
       end
 
       private

--- a/app/controllers/lakeraven/ehr/observations_controller.rb
+++ b/app/controllers/lakeraven/ehr/observations_controller.rb
@@ -8,7 +8,7 @@ module Lakeraven
       def index
         dfn = extract_patient_dfn(params[:patient])
         results = Observation.for_patient(dfn)
-        render_bundle(results.map { |r| { resourceType: "Observation" }.merge(r) })
+        render_bundle(results.map(&:to_fhir))
       end
 
       private

--- a/app/controllers/lakeraven/ehr/procedures_controller.rb
+++ b/app/controllers/lakeraven/ehr/procedures_controller.rb
@@ -8,7 +8,7 @@ module Lakeraven
       def index
         dfn = params[:patient].to_s.delete_prefix("Patient/")
         results = Procedure.for_patient(dfn)
-        render_bundle(results.map { |r| { resourceType: "Procedure" }.merge(r) })
+        render_bundle(results.map(&:to_fhir))
       end
 
       private

--- a/app/controllers/lakeraven/ehr/service_requests_controller.rb
+++ b/app/controllers/lakeraven/ehr/service_requests_controller.rb
@@ -8,7 +8,7 @@ module Lakeraven
       def index
         dfn = params[:patient].to_s.delete_prefix("Patient/")
         results = ServiceRequest.for_patient(dfn)
-        render_bundle(results.map { |r| { resourceType: "ServiceRequest" }.merge(r) })
+        render_bundle(results.map(&:to_fhir))
       end
 
       private

--- a/app/gateways/lakeraven/ehr/allergy_intolerance_gateway.rb
+++ b/app/gateways/lakeraven/ehr/allergy_intolerance_gateway.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
-
 module Lakeraven
   module EHR
     class AllergyIntoleranceGateway
-      MAPPING = :allergy_list
-
       def self.for_patient(dfn)
-        RpmsRpc::DataMapper.public_send(MAPPING).fetch_many(dfn.to_s)
+        if RpmsRpc.configuration.fhir_client.present?
+          FHIRReadGateway.search("AllergyIntolerance", patient: dfn.to_s)
+        else
+          require "rpms_rpc/mappings"
+          RpmsRpc::DataMapper.allergy_list.fetch_many(dfn.to_s).map { |attrs| AllergyIntolerance.new(**attrs) }
+        end
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/condition_gateway.rb
+++ b/app/gateways/lakeraven/ehr/condition_gateway.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
-
 module Lakeraven
   module EHR
     class ConditionGateway
-      MAPPING = :problem_list
-
       def self.for_patient(dfn)
-        RpmsRpc::DataMapper.public_send(MAPPING).fetch_many(dfn.to_s)
+        if RpmsRpc.configuration.fhir_client.present?
+          FHIRReadGateway.search("Condition", patient: dfn.to_s)
+        else
+          require "rpms_rpc/mappings"
+          RpmsRpc::DataMapper.problem_list.fetch_many(dfn.to_s).map { |attrs| Condition.new(**attrs) }
+        end
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/fhir_read_gateway.rb
+++ b/app/gateways/lakeraven/ehr/fhir_read_gateway.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # Single FHIR read gateway for all resource types.
+    # Routes reads to RpmsRpc.fhir_client (IRIS for Health or mock).
+    # Each model provides from_fhir(hash) for deserialization.
+    class FHIRReadGateway
+      class << self
+        def read(resource_type, id)
+          result = RpmsRpc.fhir_client.read(resource_type, id.to_s)
+          return nil if result["resourceType"] == "OperationOutcome"
+
+          model_class(resource_type).from_fhir(result)
+        end
+
+        def search(resource_type, params = {})
+          bundle = RpmsRpc.fhir_client.search(resource_type, params)
+          entries = bundle["entry"] || []
+          entries.map { |e| model_class(resource_type).from_fhir(e["resource"]) }
+        end
+
+        private
+
+        def model_class(resource_type)
+          Lakeraven::EHR.const_get(resource_type)
+        end
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/immunization_gateway.rb
+++ b/app/gateways/lakeraven/ehr/immunization_gateway.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
-
 module Lakeraven
   module EHR
     class ImmunizationGateway
       def self.for_patient(dfn)
-        RpmsRpc::DataMapper.allergy_list.fetch_many(dfn.to_s)
+        if RpmsRpc.configuration.fhir_client.present?
+          FHIRReadGateway.search("Immunization", patient: dfn.to_s)
+        else
+          require "rpms_rpc/mappings"
+          RpmsRpc::DataMapper.immunization_list.fetch_many(dfn.to_s).map { |attrs| Immunization.new(**attrs) }
+        end
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/medication_request_gateway.rb
+++ b/app/gateways/lakeraven/ehr/medication_request_gateway.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
-
 module Lakeraven
   module EHR
     class MedicationRequestGateway
-      MAPPING = :medication_list
-
       def self.for_patient(dfn)
-        RpmsRpc::DataMapper.public_send(MAPPING).fetch_many(dfn.to_s)
+        if RpmsRpc.configuration.fhir_client.present?
+          FHIRReadGateway.search("MedicationRequest", patient: dfn.to_s)
+        else
+          require "rpms_rpc/mappings"
+          RpmsRpc::DataMapper.medication_list.fetch_many(dfn.to_s).map { |attrs| MedicationRequest.new(**attrs) }
+        end
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/observation_gateway.rb
+++ b/app/gateways/lakeraven/ehr/observation_gateway.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
-
 module Lakeraven
   module EHR
     class ObservationGateway
-      MAPPING = :vitals
-
       def self.for_patient(dfn)
-        RpmsRpc::DataMapper.public_send(MAPPING).fetch_many(dfn.to_s)
+        if RpmsRpc.configuration.fhir_client.present?
+          FHIRReadGateway.search("Observation", patient: dfn.to_s)
+        else
+          require "rpms_rpc/mappings"
+          RpmsRpc::DataMapper.vitals.fetch_many(dfn.to_s).map { |attrs| Observation.new(**attrs) }
+        end
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/patient_gateway.rb
+++ b/app/gateways/lakeraven/ehr/patient_gateway.rb
@@ -1,12 +1,41 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
-
 module Lakeraven
   module EHR
     class PatientGateway
       class << self
         def find(dfn)
+          if fhir_mode?
+            FHIRReadGateway.read("Patient", dfn)
+          else
+            find_via_rpc(dfn)
+          end
+        end
+
+        def search(name_pattern)
+          if fhir_mode?
+            FHIRReadGateway.search("Patient", name: name_pattern)
+          else
+            search_via_rpc(name_pattern)
+          end
+        end
+
+        def find_by_ssn(ssn)
+          if fhir_mode?
+            FHIRReadGateway.search("Patient", identifier: ssn).first
+          else
+            find_by_ssn_via_rpc(ssn)
+          end
+        end
+
+        private
+
+        def fhir_mode?
+          RpmsRpc.configuration.fhir_client.present?
+        end
+
+        def find_via_rpc(dfn)
+          require "rpms_rpc/mappings"
           attrs = RpmsRpc::DataMapper.patient_select.fetch_one(dfn.to_s, extras: { dfn: dfn.to_i })
           return nil unless attrs
 
@@ -16,12 +45,14 @@ module Lakeraven
           Patient.new(**attrs)
         end
 
-        def search(name_pattern)
+        def search_via_rpc(name_pattern)
+          require "rpms_rpc/mappings"
           results = RpmsRpc::DataMapper.patient_list.fetch_many(name_pattern, "1")
           results.map { |attrs| Patient.new(**attrs) }
         end
 
-        def find_by_ssn(ssn)
+        def find_by_ssn_via_rpc(ssn)
+          require "rpms_rpc/mappings"
           attrs = RpmsRpc::DataMapper.patient_ssn.fetch_one(ssn)
           attrs ? Patient.new(**attrs) : nil
         end

--- a/app/gateways/lakeraven/ehr/procedure_gateway.rb
+++ b/app/gateways/lakeraven/ehr/procedure_gateway.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
-
 module Lakeraven
   module EHR
     class ProcedureGateway
       def self.for_patient(dfn)
-        RpmsRpc::DataMapper.procedure_list.fetch_many(dfn.to_s)
+        if RpmsRpc.configuration.fhir_client.present?
+          FHIRReadGateway.search("Procedure", patient: dfn.to_s)
+        else
+          require "rpms_rpc/mappings"
+          RpmsRpc::DataMapper.procedure_list.fetch_many(dfn.to_s).map { |attrs| Procedure.new(**attrs) }
+        end
       end
     end
   end

--- a/app/models/lakeraven/ehr/allergy_intolerance.rb
+++ b/app/models/lakeraven/ehr/allergy_intolerance.rb
@@ -20,6 +20,22 @@ module Lakeraven
         AllergyIntoleranceGateway.for_patient(dfn)
       end
 
+      def self.from_fhir(hash)
+        h = hash.transform_keys(&:to_s)
+        patient_ref = h.dig("patient", "reference") || h.dig("subject", "reference")
+        new(
+          ien: h["id"],
+          patient_dfn: patient_ref&.delete_prefix("Patient/"),
+          allergen: h.dig("code", "text"),
+          allergen_code: h.dig("code", "coding", 0, "code"),
+          clinical_status: h.dig("clinicalStatus", "coding", 0, "code"),
+          category: Array(h["category"]).first,
+          criticality: h["criticality"],
+          reaction: h.dig("reaction", 0, "manifestation", 0, "text"),
+          severity: h.dig("reaction", 0, "severity")
+        )
+      end
+
       def active? = clinical_status == "active"
       def medication? = category == "medication"
       def food? = category == "food"

--- a/app/models/lakeraven/ehr/condition.rb
+++ b/app/models/lakeraven/ehr/condition.rb
@@ -21,6 +21,22 @@ module Lakeraven
         ConditionGateway.for_patient(dfn)
       end
 
+      def self.from_fhir(hash)
+        h = hash.transform_keys(&:to_s)
+        new(
+          ien: h["id"],
+          patient_dfn: h.dig("subject", "reference")&.delete_prefix("Patient/"),
+          code: h.dig("code", "coding", 0, "code"),
+          display: h.dig("code", "text"),
+          clinical_status: h.dig("clinicalStatus", "coding", 0, "code"),
+          verification_status: h.dig("verificationStatus", "coding", 0, "code"),
+          category: h.dig("category", 0, "coding", 0, "code"),
+          severity: h.dig("severity", "coding", 0, "code"),
+          onset_datetime: h["onsetDateTime"],
+          recorded_date: h["recordedDate"]
+        )
+      end
+
       def active? = clinical_status == "active"
       def resolved? = clinical_status == "resolved"
       def problem_list_item? = category == "problem-list-item"

--- a/app/models/lakeraven/ehr/immunization.rb
+++ b/app/models/lakeraven/ehr/immunization.rb
@@ -25,6 +25,23 @@ module Lakeraven
         ImmunizationGateway.for_patient(dfn)
       end
 
+      def self.from_fhir(hash)
+        h = hash.transform_keys(&:to_s)
+        new(
+          ien: h["id"],
+          patient_dfn: (h.dig("patient", "reference") || h.dig("subject", "reference"))&.delete_prefix("Patient/"),
+          vaccine_code: h.dig("vaccineCode", "coding", 0, "code"),
+          vaccine_display: h.dig("vaccineCode", "text"),
+          status: h["status"],
+          lot_number: h["lotNumber"],
+          occurrence_datetime: h["occurrenceDateTime"],
+          site: h.dig("site", "text"),
+          route: h.dig("route", "text"),
+          performer_name: h.dig("performer", 0, "actor", "display"),
+          manufacturer: h.dig("manufacturer", "display")
+        )
+      end
+
       def completed? = status == "completed"
       def not_done? = status == "not-done"
       def entered_in_error? = status == "entered-in-error"

--- a/app/models/lakeraven/ehr/medication_request.rb
+++ b/app/models/lakeraven/ehr/medication_request.rb
@@ -22,6 +22,20 @@ module Lakeraven
         MedicationRequestGateway.for_patient(dfn)
       end
 
+      def self.from_fhir(hash)
+        h = hash.transform_keys(&:to_s)
+        new(
+          ien: h["id"],
+          patient_dfn: h.dig("subject", "reference")&.delete_prefix("Patient/"),
+          medication_code: h.dig("medicationCodeableConcept", "coding", 0, "code"),
+          medication_display: h.dig("medicationCodeableConcept", "text"),
+          status: h["status"],
+          dosage_instruction: h.dig("dosageInstruction", 0, "text"),
+          authored_on: h["authoredOn"],
+          requester_name: h.dig("requester", "display")
+        )
+      end
+
       def active? = status == "active"
 
       def to_fhir

--- a/app/models/lakeraven/ehr/observation.rb
+++ b/app/models/lakeraven/ehr/observation.rb
@@ -21,6 +21,22 @@ module Lakeraven
         ObservationGateway.for_patient(dfn)
       end
 
+      def self.from_fhir(hash)
+        h = hash.transform_keys(&:to_s)
+        new(
+          ien: h["id"],
+          patient_dfn: h.dig("subject", "reference")&.delete_prefix("Patient/"),
+          code: h.dig("code", "coding", 0, "code"),
+          display: h.dig("code", "text"),
+          value: h.dig("valueString"),
+          value_quantity: h.dig("valueQuantity", "value")&.to_s,
+          unit: h.dig("valueQuantity", "unit"),
+          category: h.dig("category", 0, "coding", 0, "code"),
+          status: h["status"],
+          effective_datetime: h["effectiveDateTime"]
+        )
+      end
+
       def vital_sign? = category == "vital-signs"
       def laboratory? = category == "laboratory"
 

--- a/app/models/lakeraven/ehr/patient.rb
+++ b/app/models/lakeraven/ehr/patient.rb
@@ -40,6 +40,51 @@ module Lakeraven
 
       class RecordNotFound < StandardError; end
 
+      def self.from_fhir(hash)
+        hash = hash.transform_keys(&:to_s)
+        name_entry = Array(hash["name"]).first || {}
+        family = name_entry["family"].to_s
+        given = Array(name_entry["given"]).join(" ")
+        name = given.present? ? "#{family},#{given}" : family
+
+        ssn = Array(hash["identifier"]).find { |i| i["system"].to_s.include?("us-ssn") }&.dig("value")
+        dfn_id = hash["id"]
+
+        attrs = {
+          dfn: dfn_id.to_i,
+          name: name,
+          dob: hash["birthDate"] ? Date.parse(hash["birthDate"]) : nil,
+          sex: case hash["gender"]
+               when "male" then "M"
+               when "female" then "F"
+               else "U"
+               end,
+          ssn: ssn
+        }
+
+        addr = Array(hash["address"]).first
+        if addr
+          attrs[:address_line1] = Array(addr["line"]).first
+          attrs[:city] = addr["city"]
+          attrs[:state] = addr["state"]
+          attrs[:zip_code] = addr["postalCode"]
+        end
+
+        phone = Array(hash["telecom"]).find { |t| t["system"] == "phone" }
+        attrs[:phone] = phone["value"] if phone
+
+        race_ext = Array(hash["extension"]).find { |e| e["url"].to_s.include?("us-core-race") }
+        if race_ext
+          text_ext = Array(race_ext["extension"]).find { |e| e["url"] == "text" }
+          attrs[:race] = text_ext["valueString"] if text_ext
+        end
+
+        tribal_ext = Array(hash["extension"]).find { |e| e["url"].to_s.include?("tribal-affiliation") }
+        attrs[:tribal_enrollment_number] = tribal_ext["valueString"] if tribal_ext
+
+        new(**attrs)
+      end
+
       # -- Class methods (AR-like) -------------------------------------------
 
       def self.find(dfn)

--- a/app/models/lakeraven/ehr/procedure.rb
+++ b/app/models/lakeraven/ehr/procedure.rb
@@ -19,6 +19,20 @@ module Lakeraven
         ProcedureGateway.for_patient(dfn)
       end
 
+      def self.from_fhir(hash)
+        h = hash.transform_keys(&:to_s)
+        new(
+          ien: h["id"],
+          patient_dfn: h.dig("subject", "reference")&.delete_prefix("Patient/"),
+          code: h.dig("code", "coding", 0, "code"),
+          display: h.dig("code", "text"),
+          status: h["status"],
+          performed_datetime: h["performedDateTime"],
+          performer_name: h.dig("performer", 0, "actor", "display"),
+          location_name: h.dig("location", "display")
+        )
+      end
+
       def completed? = status == "completed"
 
       def to_fhir

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ ActiveRecord::Migrator.migrations_paths << File.expand_path("../db/migrate", __d
 require "rails/test_help"
 require "rpms_rpc/version"
 require "rpms_rpc/mock_client"
+require "rpms_rpc/mock_fhir_client"
 
 # Configure RpmsRpc with mock client and seed data for all tests.
 RpmsRpc.mock! do |m|
@@ -92,6 +93,68 @@ RpmsRpc.mock! do |m|
   m.seed_user("303", credentials: "testclerk;test123", name: "CLERK,TEST", role: :clerk)
   m.seed_user("304", credentials: "lindarodriguez;test123", name: "RODRIGUEZ,LINDA", role: :case_manager,
                      security_keys: [:prc_supervisor, :cprs_gui_chart])
+end
+
+# Configure mock FHIR client with the same patient data as FHIR resources.
+RpmsRpc.mock_fhir! do |f|
+  f.seed_resource("Patient", "1", {
+    resourceType: "Patient", id: "1",
+    name: [{ use: "official", family: "Anderson", given: ["Alice"] }],
+    gender: "female", birthDate: "1980-05-15",
+    identifier: [
+      { use: "usual", system: "urn:oid:2.16.840.1.113883.4.349", value: "1" },
+      { use: "secondary", system: "http://hl7.org/fhir/sid/us-ssn", value: "111-11-1111" }
+    ],
+    address: [{ use: "home", line: ["123 Main St"], city: "Anchorage", state: "AK", postalCode: "99501" }],
+    telecom: [{ system: "phone", value: "907-555-1234", use: "home" }],
+    extension: [
+      { url: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+        extension: [{ url: "text", valueString: "AMERICAN INDIAN" }] },
+      { url: "http://hl7.org/fhir/us/core/StructureDefinition/tribal-affiliation",
+        valueString: "ANLC-12345" }
+    ]
+  })
+
+  f.seed_resource("Patient", "2", {
+    resourceType: "Patient", id: "2",
+    name: [{ use: "official", family: "Mouse", given: ["Mickey", "M"] }],
+    gender: "male", birthDate: "2010-02-14",
+    identifier: [{ use: "usual", system: "urn:oid:2.16.840.1.113883.4.349", value: "2" }]
+  })
+
+  f.seed_resource("Patient", "3", {
+    resourceType: "Patient", id: "3",
+    name: [{ use: "official", family: "Doe", given: ["Jane"] }],
+    gender: "female", birthDate: "1990-12-25",
+    identifier: [{ use: "usual", system: "urn:oid:2.16.840.1.113883.4.349", value: "3" }]
+  })
+
+  f.seed_resource("Practitioner", "101", {
+    resourceType: "Practitioner", id: "101",
+    name: [{ family: "Martinez", given: ["Sarah"] }],
+    identifier: [{ system: "http://hl7.org/fhir/sid/us-npi", value: "1234567890" }]
+  })
+
+  f.seed_resource("Practitioner", "102", {
+    resourceType: "Practitioner", id: "102",
+    name: [{ family: "Chen", given: ["James"] }],
+    identifier: [{ system: "http://hl7.org/fhir/sid/us-npi", value: "2345678901" }]
+  })
+
+  f.seed_resource("Organization", "1", {
+    resourceType: "Organization", id: "1",
+    name: "Alaska Native Medical Center",
+    identifier: [{ system: "http://hl7.org/fhir/sid/us-npi", value: "463" }],
+    address: [{ line: ["4315 Diplomacy Dr"], city: "Anchorage", state: "AK", postalCode: "99508" }],
+    telecom: [{ system: "phone", value: "907-729-1900" }]
+  })
+
+  f.seed_resource("Location", "1", {
+    resourceType: "Location", id: "1",
+    name: "Primary Care Clinic",
+    alias: ["PCC"],
+    type: [{ coding: [{ code: "C" }] }]
+  })
 end
 
 # Shared auth helper for integration tests.


### PR DESCRIPTION
## Summary

- `FHIRReadGateway`: single read gateway for all FHIR resource types via `RpmsRpc.fhir_client`
- `from_fhir` added to Patient, AllergyIntolerance, Condition, Observation, MedicationRequest, Immunization, Procedure
- All read gateways route to FHIR (default) or RPC (legacy fallback) — both return model instances
- Controllers call `to_fhir` on models instead of merging raw hashes
- Mock FHIR client seeded in test_helper with Patient, Practitioner, Organization, Location data
- Fixed ImmunizationGateway bug (was using `allergy_list` mapping)

Depends on lakeraven/rpms-rpc#36 (merged).

## Test plan

- [x] 531 minitest pass, 0 failures
- [x] 129 cucumber scenarios pass
- [x] FHIR read path active by default (mock FHIR client configured in test_helper)
- [x] RPC fallback still works when no FHIR client configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)