### PR TITLE
Port job_orchestration BDD + Auditable concern + AuditEvent columns

### DIFF
--- a/app/controllers/concerns/lakeraven/ehr/auditable_clinical_access.rb
+++ b/app/controllers/concerns/lakeraven/ehr/auditable_clinical_access.rb
@@ -24,6 +24,7 @@ module Lakeraven
           entity_identifier: audit_entity_identifier,
           agent_who_type: "Application",
           agent_who_identifier: current_token.application&.uid,
+          agent_network_address: request.remote_ip,
           tenant_identifier: request.headers["X-Tenant-Identifier"],
           facility_identifier: request.headers["X-Facility-Identifier"]
         )

--- a/app/models/concerns/lakeraven/ehr/auditable.rb
+++ b/app/models/concerns/lakeraven/ehr/auditable.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # Auditable concern for ActiveJob classes.
+    # Creates an AuditEvent after job execution (success or failure).
+    # PHI is scrubbed from error messages before logging.
+    module Auditable
+      extend ActiveSupport::Concern
+
+      PHI_PATTERNS = [
+        /\b\d{3}-\d{2}-\d{4}\b/,           # SSN
+        /\b[A-Z]+,[A-Z]+(?:\s[A-Z])?\b/i,  # LAST,FIRST format
+        /\bDFN[:\s]*\d+\b/i,               # DFN references
+        /\bPatient\s+DFN[:\s]*\d+\b/i      # Patient DFN references
+      ].freeze
+
+      included do
+        after_perform :record_success_audit
+        rescue_from(StandardError) do |exception|
+          record_failure_audit(exception)
+          raise
+        end
+      end
+
+      private
+
+      def record_success_audit
+        AuditEvent.create!(
+          event_type: "application",
+          action: "E",
+          outcome: "0",
+          entity_type: "Job",
+          entity_identifier: self.class.name
+        )
+      end
+
+      def record_failure_audit(exception)
+        AuditEvent.create!(
+          event_type: "application",
+          action: "E",
+          outcome: "8",
+          entity_type: "Job",
+          entity_identifier: self.class.name,
+          outcome_desc: sanitize_phi(exception.message)
+        )
+      end
+
+      def sanitize_phi(message)
+        result = message.dup
+        PHI_PATTERNS.each { |pattern| result.gsub!(pattern, "[REDACTED]") }
+        result
+      end
+    end
+  end
+end

--- a/db/migrate/20260425010000_add_audit_event_details.rb
+++ b/db/migrate/20260425010000_add_audit_event_details.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddAuditEventDetails < ActiveRecord::Migration[8.1]
+  def change
+    add_column :lakeraven_ehr_audit_events, :outcome_desc, :text
+    add_column :lakeraven_ehr_audit_events, :agent_name, :string
+    add_column :lakeraven_ehr_audit_events, :agent_network_address, :string
+    add_column :lakeraven_ehr_audit_events, :entity_id, :string
+  end
+end

--- a/features/job_orchestration.feature
+++ b/features/job_orchestration.feature
@@ -1,0 +1,38 @@
+Feature: Background job orchestration with audit logging
+  As a compliance officer
+  I need background jobs to create audit trails
+  So that I can track system operations for HIPAA compliance
+
+  Scenario: Successful job creates audit event
+    Given an auditable job that succeeds
+    When the job is performed
+    Then an audit event should exist with outcome "0" and entity type "Job"
+    And the audit event action should be "E"
+    And the audit event type should be "application"
+
+  Scenario: Failed job creates failure audit event with sanitized error
+    Given an auditable job that raises "Patient DFN: 12345 not found"
+    When the job is performed and fails
+    Then an audit event should exist with outcome "8" and entity type "Job"
+    And the failure audit event should have a sanitized outcome description
+
+  Scenario: Job failure audit event does not contain PHI
+    Given an auditable job that raises "SSN 123-45-6789 lookup failed for SMITH,JOHN"
+    When the job is performed and fails
+    Then the failure outcome description should not contain "123-45-6789"
+    And the failure outcome description should not contain "SMITH,JOHN"
+
+  Scenario: Clinical FHIR access creates read audit event
+    Given I am authenticated with SMART-on-FHIR
+    And no audit events exist
+    When I request GET "/lakeraven-ehr/Patient" with params:
+      | patient | 1 |
+    Then the most recent audit event should have action "R"
+    And the most recent audit event should have event_type "rest"
+
+  Scenario: Clinical FHIR access records network address
+    Given I am authenticated with SMART-on-FHIR
+    And no audit events exist
+    When I request GET "/lakeraven-ehr/Patient" with params:
+      | patient | 1 |
+    Then the most recent audit event should have a network address

--- a/features/step_definitions/job_orchestration_steps.rb
+++ b/features/step_definitions/job_orchestration_steps.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "active_job"
+
+# Job Orchestration Steps — lakeraven-ehr
+
+Given("an auditable job that succeeds") do
+  unless Object.const_defined?(:EhrSuccessTestJob)
+    Object.const_set(:EhrSuccessTestJob, Class.new(ActiveJob::Base) {
+      include Lakeraven::EHR::Auditable
+      self.queue_adapter = :inline
+
+      def perform
+        "success"
+      end
+    })
+  end
+  @job_class = EhrSuccessTestJob
+end
+
+Given("an auditable job that raises {string}") do |error_message|
+  @expected_error_message = error_message
+  const_name = "EhrFailJob#{error_message.hash.abs}"
+  unless Object.const_defined?(const_name)
+    klass = Class.new(ActiveJob::Base) {
+      include Lakeraven::EHR::Auditable
+      self.queue_adapter = :inline
+
+      define_method(:perform) do
+        raise StandardError, error_message
+      end
+    }
+    Object.const_set(const_name, klass)
+  end
+  @job_class = Object.const_get(const_name)
+end
+
+When("the job is performed") do
+  Lakeraven::EHR::AuditEvent.delete_all
+  @job_class.perform_now
+end
+
+When("the job is performed and fails") do
+  Lakeraven::EHR::AuditEvent.delete_all
+  @job_class.perform_now rescue nil
+end
+
+Then("an audit event should exist with outcome {string} and entity type {string}") do |outcome, entity_type|
+  @audit_event = Lakeraven::EHR::AuditEvent.find_by(outcome: outcome, entity_type: entity_type)
+  assert @audit_event, "Expected AuditEvent with outcome=#{outcome}, entity_type=#{entity_type}"
+end
+
+Then("the audit event action should be {string}") do |action|
+  assert_equal action, @audit_event.action
+end
+
+Then("the audit event type should be {string}") do |event_type|
+  assert_equal event_type, @audit_event.event_type
+end
+
+Then("the failure audit event should have a sanitized outcome description") do
+  event = Lakeraven::EHR::AuditEvent.find_by(outcome: "8", entity_type: "Job")
+  assert event, "Expected failure AuditEvent"
+  assert event.outcome_desc.present?, "Expected outcome_desc to be present"
+  refute_includes event.outcome_desc, "12345"
+end
+
+Then("the failure outcome description should not contain {string}") do |phi_text|
+  event = Lakeraven::EHR::AuditEvent.find_by(outcome: "8", entity_type: "Job")
+  assert event, "Expected failure AuditEvent"
+  refute_includes event.outcome_desc, phi_text
+end
+
+Then("the most recent audit event should have action {string}") do |action|
+  event = Lakeraven::EHR::AuditEvent.order(created_at: :desc).first
+  assert event, "Expected at least one AuditEvent"
+  assert_equal action, event.action
+end
+
+Then("the most recent audit event should have a network address") do
+  event = Lakeraven::EHR::AuditEvent.order(created_at: :desc).first
+  assert event, "Expected at least one AuditEvent"
+  assert event.agent_network_address.present?, "Expected network address"
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,25 +10,29 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_22_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_25_010000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "lakeraven_ehr_audit_events", force: :cascade do |t|
     t.string "action", null: false
+    t.string "agent_name"
+    t.string "agent_network_address"
     t.string "agent_who_identifier"
     t.string "agent_who_type"
     t.datetime "created_at", null: false
+    t.string "entity_id"
     t.string "entity_identifier"
     t.string "entity_type"
     t.string "event_type", null: false
     t.string "facility_identifier"
     t.string "outcome", null: false
+    t.text "outcome_desc"
     t.string "tenant_identifier"
     t.datetime "updated_at", null: false
-    t.index [ "created_at" ], name: "index_lakeraven_ehr_audit_events_on_created_at"
-    t.index [ "entity_type" ], name: "index_lakeraven_ehr_audit_events_on_entity_type"
-    t.index [ "tenant_identifier" ], name: "index_lakeraven_ehr_audit_events_on_tenant_identifier"
+    t.index ["created_at"], name: "index_lakeraven_ehr_audit_events_on_created_at"
+    t.index ["entity_type"], name: "index_lakeraven_ehr_audit_events_on_entity_type"
+    t.index ["tenant_identifier"], name: "index_lakeraven_ehr_audit_events_on_tenant_identifier"
   end
 
   create_table "lakeraven_ehr_launch_contexts", force: :cascade do |t|
@@ -40,7 +44,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_120000) do
     t.string "oauth_application_uid", null: false
     t.string "patient_dfn"
     t.datetime "updated_at", null: false
-    t.index [ "launch_token" ], name: "index_lakeraven_ehr_launch_contexts_on_launch_token", unique: true
+    t.index ["launch_token"], name: "index_lakeraven_ehr_launch_contexts_on_launch_token", unique: true
   end
 
   create_table "lakeraven_ehr_patient_supplements", force: :cascade do |t|
@@ -49,7 +53,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_120000) do
     t.integer "patient_dfn", null: false
     t.string "sexual_orientation"
     t.datetime "updated_at", null: false
-    t.index [ "patient_dfn" ], name: "index_lakeraven_ehr_patient_supplements_on_patient_dfn", unique: true
+    t.index ["patient_dfn"], name: "index_lakeraven_ehr_patient_supplements_on_patient_dfn", unique: true
   end
 
   create_table "oauth_access_grants", force: :cascade do |t|
@@ -61,9 +65,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_120000) do
     t.datetime "revoked_at"
     t.string "scopes", default: "", null: false
     t.string "token", null: false
-    t.index [ "application_id" ], name: "index_oauth_access_grants_on_application_id"
-    t.index [ "resource_owner_id" ], name: "index_oauth_access_grants_on_resource_owner_id"
-    t.index [ "token" ], name: "index_oauth_access_grants_on_token", unique: true
+    t.index ["application_id"], name: "index_oauth_access_grants_on_application_id"
+    t.index ["resource_owner_id"], name: "index_oauth_access_grants_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 
   create_table "oauth_access_tokens", force: :cascade do |t|
@@ -76,10 +80,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_120000) do
     t.datetime "revoked_at"
     t.string "scopes"
     t.string "token", null: false
-    t.index [ "application_id" ], name: "index_oauth_access_tokens_on_application_id"
-    t.index [ "refresh_token" ], name: "index_oauth_access_tokens_on_refresh_token", unique: true
-    t.index [ "resource_owner_id" ], name: "index_oauth_access_tokens_on_resource_owner_id"
-    t.index [ "token" ], name: "index_oauth_access_tokens_on_token", unique: true
+    t.index ["application_id"], name: "index_oauth_access_tokens_on_application_id"
+    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
+    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
   end
 
   create_table "oauth_applications", force: :cascade do |t|
@@ -91,7 +95,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_120000) do
     t.string "secret", null: false
     t.string "uid", null: false
     t.datetime "updated_at", null: false
-    t.index [ "uid" ], name: "index_oauth_applications_on_uid", unique: true
+    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"


### PR DESCRIPTION
## Summary

- Adds `Lakeraven::EHR::Auditable` concern for ActiveJob classes (PHI-scrubbed audit logging)
- Adds AuditEvent columns: outcome_desc, agent_name, agent_network_address, entity_id
- Updates AuditableClinicalAccess to record request IP
- 5 BDD scenarios for job audit: success, failure+sanitize, PHI scrub, clinical access, network addr

Closes #107

## Test plan

- [x] 180 cucumber scenarios, 180 passed (up from 175)
- [x] 531 minitest, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)