### PR TITLE
TDD model port: 13 models, +275 tests

### DIFF
--- a/app/models/lakeraven/ehr/audit_event.rb
+++ b/app/models/lakeraven/ehr/audit_event.rb
@@ -131,18 +131,18 @@ module Lakeraven
           network: agent_network_address.present? ? { address: agent_network_address } : nil
         }.compact
 
-        [agent]
+        [ agent ]
       end
 
       def build_fhir_entities
         return [] unless has_entity?
 
-        [{
+        [ {
           what: {
             reference: "#{entity_type}/#{entity_identifier}"
           },
           type: entity_type.present? ? { code: entity_type } : nil
-        }.compact]
+        }.compact ]
       end
     end
   end

--- a/app/models/lakeraven/ehr/audit_event.rb
+++ b/app/models/lakeraven/ehr/audit_event.rb
@@ -8,15 +8,141 @@ module Lakeraven
     class AuditEvent < ApplicationRecord
       self.table_name = "lakeraven_ehr_audit_events"
 
+      EVENT_TYPES = {
+        "rest" => "RESTful Operation",
+        "security" => "Security",
+        "application" => "Application",
+        "user" => "User Authentication",
+        "query" => "Query",
+        "import" => "Import",
+        "export" => "Export"
+      }.freeze
+
+      ACTIONS = {
+        "C" => "Create",
+        "R" => "Read",
+        "U" => "Update",
+        "D" => "Delete",
+        "E" => "Execute"
+      }.freeze
+
+      OUTCOMES = {
+        "0" => "Success",
+        "4" => "Minor Failure",
+        "8" => "Serious Failure",
+        "12" => "Major Failure"
+      }.freeze
+
       validates :event_type, presence: true
-      validates :action, presence: true
-      validates :outcome, presence: true
+      validates :action, presence: true, inclusion: { in: ACTIONS.keys }
+      validates :outcome, presence: true, inclusion: { in: OUTCOMES.keys }
       validates :entity_type, presence: true
 
       scope :recent, -> { order(created_at: :desc) }
 
       def readonly?
         persisted?
+      end
+
+      # -- Event type helpers --------------------------------------------------
+
+      def event_type_display
+        EVENT_TYPES[event_type] || "Unknown"
+      end
+
+      # -- Action helpers ------------------------------------------------------
+
+      def create_action? = action == "C"
+      def read_action? = action == "R"
+      def update_action? = action == "U"
+      def delete_action? = action == "D"
+      def execute_action? = action == "E"
+
+      def action_display
+        ACTIONS[action] || "Unknown"
+      end
+
+      # -- Outcome helpers -----------------------------------------------------
+
+      def success? = outcome == "0"
+      def minor_failure? = outcome == "4"
+      def serious_failure? = outcome == "8"
+      def major_failure? = outcome == "12"
+
+      def outcome_display
+        OUTCOMES[outcome] || "Unknown"
+      end
+
+      # -- Entity helpers ------------------------------------------------------
+
+      def has_entity?
+        entity_type.present? && entity_identifier.present?
+      end
+
+      # -- FHIR serialization --------------------------------------------------
+
+      def to_fhir
+        {
+          resourceType: "AuditEvent",
+          id: id&.to_s,
+          type: build_fhir_type,
+          action: action,
+          recorded: created_at&.iso8601,
+          outcome: outcome,
+          outcomeDesc: outcome_desc,
+          agent: build_fhir_agents,
+          entity: build_fhir_entities
+        }.compact
+      end
+
+      def self.resource_class
+        "AuditEvent"
+      end
+
+      def self.from_fhir_attributes(fhir_resource)
+        attrs = {}
+        attrs[:event_type] = fhir_resource.type&.code if fhir_resource.respond_to?(:type) && fhir_resource.type&.respond_to?(:code)
+        attrs[:action] = fhir_resource.action if fhir_resource.respond_to?(:action)
+        attrs[:outcome] = fhir_resource.outcome if fhir_resource.respond_to?(:outcome)
+        attrs
+      end
+
+      private
+
+      def build_fhir_type
+        return nil if event_type.blank?
+
+        {
+          system: "http://terminology.hl7.org/CodeSystem/audit-event-type",
+          code: event_type,
+          display: event_type_display
+        }
+      end
+
+      def build_fhir_agents
+        return [] if agent_who_identifier.blank?
+
+        agent = {
+          who: {
+            reference: "#{agent_who_type || 'Practitioner'}/#{agent_who_identifier}",
+            display: agent_name
+          }.compact,
+          name: agent_name,
+          network: agent_network_address.present? ? { address: agent_network_address } : nil
+        }.compact
+
+        [agent]
+      end
+
+      def build_fhir_entities
+        return [] unless has_entity?
+
+        [{
+          what: {
+            reference: "#{entity_type}/#{entity_identifier}"
+          },
+          type: entity_type.present? ? { code: entity_type } : nil
+        }.compact]
       end
     end
   end

--- a/app/models/lakeraven/ehr/condition.rb
+++ b/app/models/lakeraven/ehr/condition.rb
@@ -72,7 +72,7 @@ module Lakeraven
           subject: patient_dfn ? { reference: "Patient/#{patient_dfn}" } : nil,
           clinicalStatus: build_clinical_status,
           code: build_code,
-          category: category ? [{ coding: [{ code: category }] }] : nil,
+          category: category ? [ { coding: [ { code: category } ] } ] : nil,
           severity: build_severity
         }.compact
       end
@@ -83,10 +83,10 @@ module Lakeraven
         return nil unless clinical_status
 
         {
-          coding: [{
+          coding: [ {
             system: "http://terminology.hl7.org/CodeSystem/condition-clinical",
             code: clinical_status
-          }]
+          } ]
         }
       end
 
@@ -96,7 +96,7 @@ module Lakeraven
         result = {}
         if code
           system_url = CODE_SYSTEM_URLS[code_system] || CODE_SYSTEM_URLS["icd10"]
-          result[:coding] = [{ code: code, system: system_url }]
+          result[:coding] = [ { code: code, system: system_url } ]
         end
         result[:text] = display if display
         result
@@ -109,11 +109,11 @@ module Lakeraven
         return nil unless snomed_code
 
         {
-          coding: [{
+          coding: [ {
             system: "http://snomed.info/sct",
             code: snomed_code,
             display: severity.capitalize
-          }]
+          } ]
         }
       end
     end

--- a/app/models/lakeraven/ehr/condition.rb
+++ b/app/models/lakeraven/ehr/condition.rb
@@ -6,9 +6,25 @@ module Lakeraven
       include ActiveModel::Model
       include ActiveModel::Attributes
 
+      VALID_CLINICAL_STATUSES = %w[active recurrence relapse inactive remission resolved].freeze
+      VALID_CATEGORIES = %w[problem-list-item encounter-diagnosis health-concern].freeze
+      VALID_CODE_SYSTEMS = %w[icd10 snomed].freeze
+
+      SEVERITY_SNOMED = {
+        "severe" => "24484000",
+        "moderate" => "6736007",
+        "mild" => "255604002"
+      }.freeze
+
+      CODE_SYSTEM_URLS = {
+        "icd10" => "http://hl7.org/fhir/sid/icd-10-cm",
+        "snomed" => "http://snomed.info/sct"
+      }.freeze
+
       attribute :ien, :string
       attribute :patient_dfn, :string
       attribute :code, :string
+      attribute :code_system, :string
       attribute :display, :string
       attribute :clinical_status, :string
       attribute :verification_status, :string
@@ -17,36 +33,88 @@ module Lakeraven
       attribute :onset_datetime, :datetime
       attribute :recorded_date, :date
 
+      validates :patient_dfn, presence: true
+      validates :display, presence: true
+      validates :clinical_status, inclusion: { in: VALID_CLINICAL_STATUSES, allow_blank: true }
+      validates :category, inclusion: { in: VALID_CATEGORIES, allow_blank: true }
+      validates :code_system, inclusion: { in: VALID_CODE_SYSTEMS, allow_blank: true }
+
       def self.for_patient(dfn)
         ConditionGateway.for_patient(dfn)
+      end
+
+      def self.resource_class
+        "Condition"
+      end
+
+      def self.from_fhir_attributes(fhir_resource)
+        {
+          code: fhir_resource.code&.coding&.first&.code,
+          display: fhir_resource.code&.text || fhir_resource.code&.coding&.first&.display,
+          clinical_status: fhir_resource.clinicalStatus&.coding&.first&.code,
+          verification_status: fhir_resource.verificationStatus&.coding&.first&.code,
+          category: fhir_resource.category&.first&.coding&.first&.code
+        }
       end
 
       def active? = clinical_status == "active"
       def resolved? = clinical_status == "resolved"
       def problem_list_item? = category == "problem-list-item"
 
+      def persisted?
+        ien.present?
+      end
+
       def to_fhir
-        resource = {
+        {
           resourceType: "Condition",
           id: ien&.to_s,
           subject: patient_dfn ? { reference: "Patient/#{patient_dfn}" } : nil,
-          clinicalStatus: clinical_status ? { coding: [ { code: clinical_status } ] } : nil,
+          clinicalStatus: build_clinical_status,
           code: build_code,
-          category: category ? [ { coding: [ { code: category } ] } ] : nil
+          category: category ? [{ coding: [{ code: category }] }] : nil,
+          severity: build_severity
         }.compact
-
-        resource
       end
 
       private
+
+      def build_clinical_status
+        return nil unless clinical_status
+
+        {
+          coding: [{
+            system: "http://terminology.hl7.org/CodeSystem/condition-clinical",
+            code: clinical_status
+          }]
+        }
+      end
 
       def build_code
         return nil unless code || display
 
         result = {}
-        result[:coding] = [ { code: code } ] if code
+        if code
+          system_url = CODE_SYSTEM_URLS[code_system] || CODE_SYSTEM_URLS["icd10"]
+          result[:coding] = [{ code: code, system: system_url }]
+        end
         result[:text] = display if display
         result
+      end
+
+      def build_severity
+        return nil unless severity.present?
+
+        snomed_code = SEVERITY_SNOMED[severity&.downcase]
+        return nil unless snomed_code
+
+        {
+          coding: [{
+            system: "http://snomed.info/sct",
+            code: snomed_code,
+            display: severity.capitalize
+          }]
+        }
       end
     end
   end

--- a/app/models/lakeraven/ehr/coverage.rb
+++ b/app/models/lakeraven/ehr/coverage.rb
@@ -18,14 +18,19 @@ module Lakeraven
       PRC_STATUSES = %w[exhausted not_enrolled denied pending].freeze
       VALID_STATUSES = (FHIR_STATUSES + PRC_STATUSES).freeze
 
+      attribute :id, :string
+      attribute :created_at, :datetime
       attribute :patient_dfn, :string
       attribute :coverage_type, :string
       attribute :status, :string, default: "active"
       attribute :payor_name, :string
       attribute :payor_id, :string
+      attribute :payor_type, :string
       attribute :subscriber_id, :string
       attribute :member_id, :string
       attribute :group_id, :string
+      attribute :plan_name, :string
+      attribute :plan_id, :string
       attribute :dependent_number, :string
       attribute :relationship, :string, default: "self"
       attribute :start_date, :date
@@ -35,6 +40,12 @@ module Lakeraven
       validates :patient_dfn, presence: true
       validates :coverage_type, presence: true, inclusion: { in: COVERAGE_TYPES }
       validates :status, inclusion: { in: VALID_STATUSES }
+
+      def initialize(attributes = {})
+        attributes[:id] ||= SecureRandom.uuid
+        attributes[:created_at] ||= Time.current
+        super
+      end
 
       # -- Status helpers ----------------------------------------------------
 
@@ -79,14 +90,28 @@ module Lakeraven
         medicare? || medicaid? || va_benefits?
       end
 
+      # Display name for the payor
+      def payor_display
+        payor_name || default_payor_name
+      end
+
+      # Display name for the payor type (e.g., "Medicare Part A")
+      def payor_type_display
+        payor_type || default_payor_type
+      end
+
       # -- COB ---------------------------------------------------------------
 
+      def coordination_order
+        order || default_coordination_order
+      end
+
       def primary?
-        order == 1
+        coordination_order == 1
       end
 
       def secondary?
-        order == 2
+        coordination_order == 2
       end
 
       # -- FHIR serialization ------------------------------------------------
@@ -94,16 +119,82 @@ module Lakeraven
       def to_fhir
         {
           resourceType: "Coverage",
+          id: id,
           status: status,
           beneficiary: { reference: "Patient/#{patient_dfn}" },
-          payor: payor_name ? [ { display: payor_name } ] : [],
+          payor: [ payor_fhir_reference ],
           period: build_period,
           class: build_class_array,
           order: order
         }.compact
       end
 
+      # -- FHIR parsing (class methods) --------------------------------------
+
+      def self.from_fhir(fhir_hash)
+        new(
+          id: fhir_hash[:id] || fhir_hash["id"],
+          patient_dfn: extract_patient_dfn(fhir_hash),
+          status: fhir_hash[:status] || fhir_hash["status"] || "active",
+          coverage_type: extract_coverage_type(fhir_hash),
+          payor_name: extract_payor_name(fhir_hash),
+          **extract_period(fhir_hash),
+          **extract_class_info(fhir_hash)
+        )
+      end
+
+      def self.from_eligibility_response(response)
+        return nil unless response.enrolled?
+
+        new(
+          patient_dfn: response.patient_dfn,
+          coverage_type: response.coverage_type,
+          status: "active",
+          start_date: response.start_date,
+          end_date: response.end_date,
+          plan_name: response.plan_name,
+          member_id: response.policy_id,
+          group_id: response.group_id
+        )
+      end
+
       private
+
+      def default_payor_name
+        case coverage_type
+        when "medicare_a", "medicare_b", "medicare_d" then "Medicare"
+        when "medicaid" then "Medicaid"
+        when "va_benefits" then "Department of Veterans Affairs"
+        when "workers_comp" then "Workers Compensation"
+        when "auto_insurance" then "Auto Insurance"
+        when "state_program" then "State Health Program"
+        when "tribal_program" then "Tribal Health Program"
+        when "private_insurance" then "Private Insurance"
+        end
+      end
+
+      def default_payor_type
+        case coverage_type
+        when "medicare_a" then "Medicare Part A"
+        when "medicare_b" then "Medicare Part B"
+        when "medicare_d" then "Medicare Part D"
+        when "medicaid" then "Medicaid"
+        when "va_benefits" then "VA Benefits"
+        when "private_insurance" then "Private Insurance"
+        else coverage_type&.titleize
+        end
+      end
+
+      def default_coordination_order
+        case coverage_type
+        when "private_insurance" then 1
+        when "medicare_a", "medicare_b", "medicare_d" then 2
+        when "medicaid" then 3
+        when "va_benefits" then 2
+        when "workers_comp", "auto_insurance" then 1
+        else 4
+        end
+      end
 
       def build_period
         return nil unless start_date || end_date
@@ -117,8 +208,99 @@ module Lakeraven
       def build_class_array
         classes = []
         classes << { type: { coding: [ { code: "group" } ] }, value: group_id } if group_id
-        classes << { type: { coding: [ { code: "plan" } ] }, value: subscriber_id } if subscriber_id
+        if plan_name.present? || subscriber_id.present?
+          classes << {
+            type: { coding: [ { code: "plan" } ] },
+            value: subscriber_id || plan_name,
+            name: plan_name
+          }.compact
+        end
         classes.empty? ? nil : classes
+      end
+
+      def payor_fhir_reference
+        {
+          reference: payor_org_reference,
+          display: payor_display
+        }
+      end
+
+      def payor_org_reference
+        case coverage_type
+        when "medicare_a", "medicare_b", "medicare_d" then "Organization/CMS"
+        when "medicaid" then "Organization/StateMedicaid"
+        when "va_benefits" then "Organization/VA"
+        else "Organization/#{payor_id || coverage_type&.camelize}"
+        end
+      end
+
+      # -- FHIR parsing helpers (class-level) --------------------------------
+
+      def self.extract_patient_dfn(fhir_hash)
+        beneficiary = fhir_hash[:beneficiary] || fhir_hash["beneficiary"]
+        return nil unless beneficiary
+        reference = beneficiary[:reference] || beneficiary["reference"]
+        reference&.gsub("Patient/", "")
+      end
+
+      def self.extract_coverage_type(fhir_hash)
+        type = fhir_hash[:type] || fhir_hash["type"]
+        return nil unless type
+        coding = type[:coding]&.first || type["coding"]&.first
+        code = coding&.dig(:code) || coding&.dig("code")
+
+        case code
+        when "MEDICARE" then "medicare_a"
+        when "MEDICAID" then "medicaid"
+        when "HIP" then "private_insurance"
+        when "VET" then "va_benefits"
+        when "WCBPOL" then "workers_comp"
+        when "AUTOPOL" then "auto_insurance"
+        else "private_insurance"
+        end
+      end
+
+      def self.extract_payor_name(fhir_hash)
+        payors = fhir_hash[:payor] || fhir_hash["payor"]
+        return nil unless payors&.any?
+        payors.first[:display] || payors.first["display"]
+      end
+
+      def self.extract_period(fhir_hash)
+        period = fhir_hash[:period] || fhir_hash["period"]
+        return {} unless period
+        {
+          start_date: parse_date(period[:start] || period["start"]),
+          end_date: parse_date(period[:end] || period["end"])
+        }
+      end
+
+      def self.extract_class_info(fhir_hash)
+        classes = fhir_hash[:class] || fhir_hash["class"]
+        return {} unless classes
+
+        result = {}
+        classes.each do |cls|
+          type_coding = cls[:type]&.dig(:coding, 0) || cls["type"]&.dig("coding", 0)
+          code = type_coding&.dig(:code) || type_coding&.dig("code")
+
+          case code
+          when "group"
+            result[:group_id] = cls[:value] || cls["value"]
+          when "plan"
+            result[:plan_name] = cls[:name] || cls["name"]
+          when "rxid"
+            result[:member_id] = cls[:value] || cls["value"]
+          end
+        end
+        result
+      end
+
+      def self.parse_date(value)
+        return nil unless value
+        Date.parse(value)
+      rescue ArgumentError
+        nil
       end
     end
   end

--- a/app/models/lakeraven/ehr/coverage_eligibility_response.rb
+++ b/app/models/lakeraven/ehr/coverage_eligibility_response.rb
@@ -171,10 +171,10 @@ module Lakeraven
       def build_insurance
         return nil unless enrolled?
 
-        [{
+        [ {
           coverage: { display: coverage_type },
           benefitPeriod: build_period
-        }.compact]
+        }.compact ]
       end
 
       def build_period

--- a/app/models/lakeraven/ehr/coverage_eligibility_response.rb
+++ b/app/models/lakeraven/ehr/coverage_eligibility_response.rb
@@ -15,6 +15,8 @@ module Lakeraven
       TERMINAL_STATUSES = %w[enrolled not_enrolled denied exhausted].freeze
       TRANSIENT_ERROR_CODES = %w[42 80].freeze
 
+      attribute :id, :string
+      attribute :created_at, :datetime
       attribute :patient_dfn, :string
       attribute :coverage_type, :string
       attribute :status, :string
@@ -28,8 +30,16 @@ module Lakeraven
       attribute :end_date, :date
       attribute :error_code, :string
       attribute :error_message, :string
+      attribute :request_id, :string
+      attribute :disposition, :string
 
       validates :status, inclusion: { in: VALID_STATUSES }
+
+      def initialize(attributes = {})
+        attributes[:id] ||= SecureRandom.uuid
+        attributes[:created_at] ||= Time.current
+        super
+      end
 
       # -- Status helpers ----------------------------------------------------
 
@@ -78,17 +88,74 @@ module Lakeraven
         error? && TRANSIENT_ERROR_CODES.include?(error_code)
       end
 
+      # -- Coverage details --------------------------------------------------
+
+      def coverage_details
+        return nil unless enrolled?
+
+        {
+          type: coverage_type,
+          status: status,
+          period: coverage_period,
+          plan: plan_info,
+          insurer: insurer_info
+        }.compact
+      end
+
+      def coverage_period
+        return nil unless start_date || end_date
+
+        { start: start_date, end: end_date }.compact
+      end
+
+      def plan_info
+        return nil unless plan_name || policy_id || group_id
+
+        {
+          name: plan_name,
+          policy_id: policy_id,
+          group_id: group_id,
+          subscriber_id: subscriber_id
+        }.compact
+      end
+
+      def insurer_info
+        return nil unless insurer_name || insurer_id
+
+        { name: insurer_name, id: insurer_id }.compact
+      end
+
       # -- FHIR serialization ------------------------------------------------
 
       def to_fhir
         {
           resourceType: "CoverageEligibilityResponse",
+          id: id,
           status: "active",
           outcome: fhir_outcome,
-          patient: { reference: "Patient/#{patient_dfn}" },
+          patient: patient_dfn ? { reference: "Patient/#{patient_dfn}" } : nil,
+          request: request_id ? { reference: "CoverageEligibilityRequest/#{request_id}" } : nil,
           insurer: insurer_name ? { display: insurer_name } : nil,
           insurance: build_insurance
         }.compact
+      end
+
+      # -- FHIR deserialization -----------------------------------------------
+
+      def self.from_fhir(fhir_hash)
+        fhir_hash = fhir_hash.with_indifferent_access if fhir_hash.respond_to?(:with_indifferent_access)
+
+        insurance = fhir_hash["insurance"] || fhir_hash[:insurance]
+        outcome = fhir_hash["outcome"] || fhir_hash[:outcome]
+
+        new(
+          id: fhir_hash["id"] || fhir_hash[:id],
+          patient_dfn: extract_patient_dfn(fhir_hash),
+          request_id: extract_request_id(fhir_hash),
+          status: outcome_to_status(outcome, insurance: insurance),
+          disposition: fhir_hash["disposition"] || fhir_hash[:disposition],
+          **extract_coverage_details(fhir_hash)
+        )
       end
 
       private
@@ -104,10 +171,10 @@ module Lakeraven
       def build_insurance
         return nil unless enrolled?
 
-        [ {
+        [{
           coverage: { display: coverage_type },
           benefitPeriod: build_period
-        }.compact ]
+        }.compact]
       end
 
       def build_period
@@ -117,6 +184,59 @@ module Lakeraven
         p[:start] = start_date.iso8601 if start_date
         p[:end] = end_date.iso8601 if end_date
         p
+      end
+
+      def self.extract_patient_dfn(fhir_hash)
+        patient_ref = fhir_hash["patient"] || fhir_hash[:patient]
+        return nil unless patient_ref
+
+        reference = patient_ref["reference"] || patient_ref[:reference]
+        reference&.gsub("Patient/", "")
+      end
+
+      def self.extract_request_id(fhir_hash)
+        request_ref = fhir_hash["request"] || fhir_hash[:request]
+        return nil unless request_ref
+
+        reference = request_ref["reference"] || request_ref[:reference]
+        reference&.gsub("CoverageEligibilityRequest/", "")
+      end
+
+      def self.outcome_to_status(outcome, insurance: nil)
+        case outcome
+        when "complete"
+          has_active_coverage?(insurance) ? "enrolled" : "not_enrolled"
+        when "queued" then "pending"
+        when "error" then "error"
+        else "not_enrolled"
+        end
+      end
+
+      def self.has_active_coverage?(insurance)
+        return false if insurance.nil? || insurance.empty?
+
+        insurance.any? do |ins|
+          ins[:inforce] == true || ins["inforce"] == true
+        end
+      end
+
+      def self.extract_coverage_details(fhir_hash)
+        insurance = (fhir_hash["insurance"] || fhir_hash[:insurance])&.first
+        return {} unless insurance
+
+        period = insurance["benefitPeriod"] || insurance[:benefitPeriod]
+        {
+          start_date: parse_date(period&.dig(:start) || period&.dig("start")),
+          end_date: parse_date(period&.dig(:end) || period&.dig("end"))
+        }
+      end
+
+      def self.parse_date(value)
+        return nil unless value
+
+        Date.parse(value)
+      rescue ArgumentError
+        nil
       end
     end
   end

--- a/app/models/lakeraven/ehr/document_reference.rb
+++ b/app/models/lakeraven/ehr/document_reference.rb
@@ -5,6 +5,40 @@ module Lakeraven
     class DocumentReference
       include ActiveModel::Model
       include ActiveModel::Attributes
+      include ActiveModel::Validations
+
+      # Document status codes (FHIR DocumentReference status)
+      STATUSES = {
+        "current" => "Current",
+        "superseded" => "Superseded",
+        "entered-in-error" => "Entered in Error"
+      }.freeze
+
+      # Document category codes (US Core DocumentReference categories)
+      CATEGORIES = {
+        "clinical-note" => "Clinical Note",
+        "discharge-summary" => "Discharge Summary",
+        "imaging" => "Imaging",
+        "imaging-result" => "Imaging Result",
+        "laboratory" => "Laboratory",
+        "lab-report" => "Lab Report",
+        "pathology" => "Pathology",
+        "pathology-report" => "Pathology Report",
+        "procedure-note" => "Procedure Note",
+        "progress-note" => "Progress Note",
+        "consult-note" => "Consultation Note"
+      }.freeze
+
+      # Common LOINC document type codes
+      LOINC_TYPES = {
+        "11488-4" => "Consultation Note",
+        "18842-5" => "Discharge Summary",
+        "34117-2" => "History and Physical Note",
+        "11506-3" => "Progress Note",
+        "28570-0" => "Procedure Note",
+        "18748-4" => "Diagnostic Imaging Report",
+        "11502-2" => "Laboratory Report"
+      }.freeze
 
       attribute :id, :string
       attribute :status, :string, default: "current"
@@ -17,18 +51,183 @@ module Lakeraven
       attribute :description, :string
       attribute :content_url, :string
       attribute :content_type, :string
+      attribute :context_service_request_ien, :string
+
+      # Validations
+      validates :subject_patient_dfn, presence: true
+      validates :type_code, presence: true
+      validates :status, inclusion: { in: STATUSES.keys }, allow_blank: true
+      validates :category, inclusion: { in: CATEGORIES.keys }, allow_blank: true
+
+      # =============================================================================
+      # PERSISTENCE
+      # =============================================================================
+
+      def persisted?
+        id.present?
+      end
+
+      # =============================================================================
+      # STATUS HELPERS
+      # =============================================================================
 
       def current? = status == "current"
+      def superseded? = status == "superseded"
+      def entered_in_error? = status == "entered-in-error"
+      def active? = current?
+
+      def status_display
+        STATUSES[status] || "Unknown"
+      end
+
+      # =============================================================================
+      # CATEGORY HELPERS
+      # =============================================================================
+
+      def category_display
+        CATEGORIES[category] || "Unknown"
+      end
+
+      def clinical_note? = category == "clinical-note"
+      def imaging? = category == "imaging"
+      def laboratory? = category == "laboratory"
+
+      # =============================================================================
+      # TYPE HELPERS
+      # =============================================================================
+
+      def type_display_from_loinc
+        LOINC_TYPES[type_code] || type_display
+      end
+
+      # =============================================================================
+      # FHIR SERIALIZATION
+      # =============================================================================
 
       def to_fhir
         {
           resourceType: "DocumentReference",
+          id: id,
           status: status,
-          type: type_display ? { text: type_display } : nil,
+          type: build_fhir_type,
+          category: build_fhir_category,
           subject: subject_patient_dfn ? { reference: "Patient/#{subject_patient_dfn}" } : nil,
+          author: build_fhir_author,
+          date: date&.strftime("%Y-%m-%d"),
           description: description,
-          content: content_url ? [ { attachment: { url: content_url, contentType: content_type } } ] : []
+          content: build_fhir_content,
+          context: build_fhir_context
         }.compact
+      end
+
+      def self.resource_class
+        "DocumentReference"
+      end
+
+      def self.from_fhir(fhir_resource)
+        new(from_fhir_attributes(fhir_resource))
+      end
+
+      def self.from_fhir_attributes(fhir_resource)
+        attrs = { status: fhir_resource.status }
+
+        if fhir_resource.respond_to?(:type) && fhir_resource.type&.coding&.any?
+          coding = fhir_resource.type.coding.first
+          attrs[:type_code] = coding.code
+          attrs[:type_display] = coding.display
+        end
+
+        if fhir_resource.respond_to?(:category) && fhir_resource.category&.any?
+          cat = fhir_resource.category.first
+          attrs[:category] = cat.coding.first.code if cat.coding&.any?
+        end
+
+        if fhir_resource.respond_to?(:subject) && fhir_resource.subject&.reference.present?
+          ref = fhir_resource.subject.reference
+          if ref.include?("Patient/")
+            dfn = ref.split("/").last.gsub(/\D/, "")
+            attrs[:subject_patient_dfn] = dfn if dfn.present?
+          end
+        end
+
+        if fhir_resource.respond_to?(:author) && fhir_resource.author&.any?
+          ref = fhir_resource.author.first&.reference
+          if ref&.include?("Practitioner/")
+            ien = ref.split("/").last.gsub(/\D/, "")
+            attrs[:author_ien] = ien if ien.present?
+          end
+        end
+
+        if fhir_resource.respond_to?(:date) && fhir_resource.date.present?
+          date_value = fhir_resource.date
+          attrs[:date] = date_value.is_a?(String) ? Date.parse(date_value) : date_value
+        end
+
+        attrs[:description] = fhir_resource.description if fhir_resource.respond_to?(:description)
+
+        if fhir_resource.respond_to?(:content) && fhir_resource.content&.any?
+          attachment = fhir_resource.content.first&.attachment
+          if attachment
+            attrs[:content_url] = attachment.url if attachment.respond_to?(:url)
+            attrs[:content_type] = attachment.contentType if attachment.respond_to?(:contentType)
+          end
+        end
+
+        attrs
+      end
+
+      private
+
+      def build_fhir_type
+        return nil if type_code.blank?
+
+        {
+          coding: [
+            {
+              system: "http://loinc.org",
+              code: type_code,
+              display: type_display_from_loinc
+            }
+          ]
+        }
+      end
+
+      def build_fhir_category
+        return [] if category.blank?
+
+        [
+          {
+            coding: [
+              {
+                system: "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category",
+                code: category,
+                display: category_display
+              }
+            ]
+          }
+        ]
+      end
+
+      def build_fhir_author
+        return [] if author_ien.blank?
+
+        [ { reference: "Practitioner/rpms-practitioner-#{author_ien}" } ]
+      end
+
+      def build_fhir_content
+        return [] unless content_url.present? || content_type.present?
+
+        [ { attachment: { contentType: content_type, url: content_url } } ]
+      end
+
+      def build_fhir_context
+        return nil if context_service_request_ien.blank?
+
+        {
+          related: [
+            { reference: "ServiceRequest/rpms-service-request-#{context_service_request_ien}" }
+          ]
+        }
       end
     end
   end

--- a/app/models/lakeraven/ehr/encounter.rb
+++ b/app/models/lakeraven/ehr/encounter.rb
@@ -36,6 +36,10 @@ module Lakeraven
       attribute :practitioner_identifier, :string
       attribute :patient_dfn, :integer
       attribute :location_ien, :integer
+      attribute :service_provider_organization_ien, :integer
+
+      # Array attribute — not natively typed by ActiveModel, use plain accessor
+      attr_accessor :participant_practitioner_iens
 
       validates :status, inclusion: { in: VALID_STATUSES }
       validates :class_code, inclusion: { in: VALID_CLASS_CODES }
@@ -51,12 +55,14 @@ module Lakeraven
       def finished? = status == "finished"
       def cancelled? = status == "cancelled"
       def planned? = status == "planned"
+      def arrived? = status == "arrived"
 
       # -- Class predicates --------------------------------------------------
 
       def ambulatory? = class_code == "AMB"
       def emergency? = class_code == "EMER"
       def inpatient? = class_code == "IMP"
+      def virtual? = class_code == "VR"
 
       # -- Workflow methods --------------------------------------------------
 
@@ -80,6 +86,15 @@ module Lakeraven
         self.status = "cancelled"
       end
 
+      # -- Period helpers ----------------------------------------------------
+
+      def within_period?
+        now = DateTime.current
+        start_ok = period_start.nil? || period_start <= now
+        end_ok = period_end.nil? || period_end >= now
+        start_ok && end_ok
+      end
+
       # -- FHIR serialization ------------------------------------------------
 
       US_CORE_PROFILE = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
@@ -100,12 +115,37 @@ module Lakeraven
         resource[:subject] = { reference: "Patient/#{patient_identifier}" } if patient_identifier
         if practitioner_identifier
           resource[:participant] = [ { individual: { reference: "Practitioner/#{practitioner_identifier}" } } ]
+        elsif participant_practitioner_iens.is_a?(Array) && participant_practitioner_iens.any?
+          resource[:participant] = participant_practitioner_iens.map do |ien|
+            { individual: { reference: "Practitioner/rpms-practitioner-#{ien}" } }
+          end
+        end
+
+        if location_ien
+          resource[:location] = [ { location: { reference: "Location/rpms-location-#{location_ien}" } } ]
+        end
+
+        if service_provider_organization_ien
+          resource[:serviceProvider] = { reference: "Organization/rpms-organization-#{service_provider_organization_ien}" }
         end
 
         resource
       end
 
+      def self.resource_class
+        "Encounter"
+      end
+
       # -- FHIR deserialization ----------------------------------------------
+
+      def self.from_fhir_attributes(fhir)
+        attrs = { status: fhir[:status] }
+        attrs[:class_code] = fhir.dig(:class, :code) if fhir.dig(:class, :code)
+        if fhir.dig(:subject, :reference)&.include?("Patient/")
+          attrs[:patient_identifier] = fhir.dig(:subject, :reference).split("/").last
+        end
+        attrs
+      end
 
       def self.from_fhir(fhir)
         new(

--- a/app/models/lakeraven/ehr/immunization.rb
+++ b/app/models/lakeraven/ehr/immunization.rb
@@ -15,14 +15,39 @@ module Lakeraven
       attribute :expiration_date, :date
       attribute :site, :string
       attribute :route, :string
+      attribute :performer_duz, :string
       attribute :performer_name, :string
       attribute :occurrence_datetime, :datetime
       attribute :dose_quantity, :float
       attribute :dose_unit, :string
       attribute :manufacturer, :string
 
+      # VIS (Vaccine Information Statement) metadata
+      attribute :vis_edition_date, :date
+      attribute :vis_presentation_date, :date
+      attribute :vis_document_uri, :string
+
+      # VFC eligibility and funding
+      attribute :vfc_eligibility_code, :string
+      attribute :funding_source, :string
+
+      validates :patient_dfn, presence: true
+      validates :vaccine_display, presence: true
+      validates :status, inclusion: {
+        in: %w[completed entered-in-error not-done],
+        allow_blank: true
+      }
+
       def self.for_patient(dfn)
         ImmunizationGateway.for_patient(dfn)
+      end
+
+      def self.resource_class
+        "Immunization"
+      end
+
+      def persisted?
+        ien.present?
       end
 
       def completed? = status == "completed"
@@ -33,10 +58,18 @@ module Lakeraven
         {
           resourceType: "Immunization",
           id: ien&.to_s,
+          meta: { profile: [ "http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization" ] },
           status: status,
           patient: patient_dfn ? { reference: "Patient/#{patient_dfn}" } : nil,
           vaccineCode: build_vaccine_code,
-          lotNumber: lot_number
+          occurrenceDateTime: occurrence_datetime&.iso8601,
+          lotNumber: lot_number,
+          site: site.present? ? { text: site } : nil,
+          route: route.present? ? { text: route } : nil,
+          performer: build_performers,
+          education: build_education,
+          programEligibility: build_program_eligibility,
+          fundingSource: build_funding_source
         }.compact
       end
 
@@ -46,9 +79,76 @@ module Lakeraven
         return nil unless vaccine_code || vaccine_display
 
         result = {}
-        result[:coding] = [ { code: vaccine_code } ] if vaccine_code
+        if vaccine_code
+          result[:coding] = [ { system: "http://hl7.org/fhir/sid/cvx", code: vaccine_code } ]
+        end
         result[:text] = vaccine_display if vaccine_display
         result
+      end
+
+      def build_performers
+        return nil if performer_duz.blank?
+
+        [ {
+          actor: {
+            reference: "Practitioner/#{performer_duz}",
+            display: performer_name
+          }
+        } ]
+      end
+
+      def build_education
+        return nil if vis_edition_date.blank? && vis_presentation_date.blank?
+
+        [ {
+          reference: vis_document_uri,
+          publicationDate: vis_edition_date&.iso8601,
+          presentationDate: vis_presentation_date&.iso8601
+        } ]
+      end
+
+      # VFC eligibility V-code -> HL7 standard eligible/ineligible mapping
+      VFC_ELIGIBLE_CODES = %w[V02 V03 V04 V05 V06 V07].freeze
+
+      def build_program_eligibility
+        return nil if vfc_eligibility_code.blank?
+
+        standard_code = VFC_ELIGIBLE_CODES.include?(vfc_eligibility_code) ? "eligible" : "ineligible"
+
+        [ {
+          coding: [
+            {
+              system: "https://www.ihs.gov/rpms/fhir/CodeSystem/vfc-eligibility",
+              code: vfc_eligibility_code
+            },
+            {
+              system: "http://terminology.hl7.org/CodeSystem/immunization-program-eligibility",
+              code: standard_code
+            }
+          ]
+        } ]
+      end
+
+      # Funding source -> HL7 standard public/private mapping
+      FUNDING_SOURCE_PUBLIC = %w[VFC VFA].freeze
+
+      def build_funding_source
+        return nil if funding_source.blank?
+
+        standard_code = FUNDING_SOURCE_PUBLIC.include?(funding_source) ? "public" : "private"
+
+        {
+          coding: [
+            {
+              system: "https://www.ihs.gov/rpms/fhir/CodeSystem/immunization-funding-source",
+              code: funding_source
+            },
+            {
+              system: "http://terminology.hl7.org/CodeSystem/immunization-funding-source",
+              code: standard_code
+            }
+          ]
+        }
       end
     end
   end

--- a/app/models/lakeraven/ehr/location.rb
+++ b/app/models/lakeraven/ehr/location.rb
@@ -5,12 +5,59 @@ module Lakeraven
     class Location
       include ActiveModel::Model
       include ActiveModel::Attributes
+      include ActiveModel::Validations
+
+      # Location type codes
+      TYPES = {
+        "site" => "Site",
+        "building" => "Building",
+        "wing" => "Wing",
+        "room" => "Room",
+        "vehicle" => "Vehicle"
+      }.freeze
+
+      # Physical type codes (FHIR location-physical-type)
+      PHYSICAL_TYPES = {
+        "si" => "Site",
+        "bu" => "Building",
+        "wi" => "Wing",
+        "wa" => "Ward",
+        "lvl" => "Level",
+        "co" => "Corridor",
+        "ro" => "Room",
+        "bd" => "Bed",
+        "ve" => "Vehicle",
+        "ho" => "House",
+        "ca" => "Cabinet",
+        "rd" => "Road",
+        "area" => "Area",
+        "jdn" => "Jurisdiction"
+      }.freeze
+
+      # Status values (FHIR location-status)
+      STATUSES = %w[active suspended inactive].freeze
 
       attribute :ien, :integer
       attribute :name, :string
       attribute :abbreviation, :string
       attribute :type, :string
       attribute :division, :string
+      attribute :location_type, :string
+      attribute :status, :string, default: "active"
+      attribute :managing_organization_ien, :integer
+      attribute :address_line1, :string
+      attribute :city, :string
+      attribute :state, :string
+      attribute :zip_code, :string
+      attribute :phone, :string
+      attribute :physical_type, :string
+
+      # Validations
+      validates :name, presence: true
+      validates :location_type, inclusion: { in: TYPES.keys }, allow_blank: true
+      validates :status, inclusion: { in: STATUSES }, allow_blank: true
+      validates :physical_type, inclusion: { in: PHYSICAL_TYPES.keys }, allow_blank: true
+      validate :ien_valid_if_present
 
       def self.find_by_ien(ien)
         return nil unless ien.present? && ien.to_i > 0
@@ -19,13 +66,84 @@ module Lakeraven
         attrs ? new(**attrs) : nil
       end
 
+      # =============================================================================
+      # STATUS HELPERS
+      # =============================================================================
+
+      def active?
+        status == "active"
+      end
+
+      def suspended?
+        status == "suspended"
+      end
+
+      def inactive?
+        status == "inactive"
+      end
+
+      def available_for_scheduling?
+        active?
+      end
+
+      # =============================================================================
+      # TYPE HELPERS
+      # =============================================================================
+
+      def type_display
+        TYPES[location_type] || "Unknown"
+      end
+
+      def physical_type_display
+        PHYSICAL_TYPES[physical_type] || "Unknown"
+      end
+
+      # =============================================================================
+      # ADDRESS HELPERS
+      # =============================================================================
+
+      def full_address
+        parts = [ address_line1, city, state, zip_code ].compact.reject(&:blank?)
+        parts.join(", ")
+      end
+
+      # =============================================================================
+      # FHIR SERIALIZATION
+      # =============================================================================
+
       def to_fhir
         {
           resourceType: "Location",
           id: ien.to_s,
           name: name,
+          status: status,
+          mode: "instance",
           alias: abbreviation.present? ? [ abbreviation ] : [],
-          mode: "instance"
+          identifier: build_fhir_identifiers,
+          type: build_fhir_type,
+          physicalType: build_fhir_physical_type,
+          address: build_fhir_address,
+          telecom: build_fhir_telecom,
+          managingOrganization: build_fhir_managing_organization
+        }.compact
+      end
+
+      def self.resource_class
+        "Location"
+      end
+
+      def self.from_fhir(fhir_resource)
+        attrs = from_fhir_attributes(fhir_resource)
+        new(attrs)
+      end
+
+      def self.from_fhir_attributes(fhir_resource)
+        {
+          name: fhir_resource.name,
+          status: fhir_resource.status || "active",
+          location_type: extract_type_from_fhir(fhir_resource),
+          physical_type: extract_physical_type_from_fhir(fhir_resource),
+          managing_organization_ien: extract_org_ien_from_fhir(fhir_resource)
         }
       end
 
@@ -35,8 +153,76 @@ module Lakeraven
         ien.present? && ien.to_i.positive?
       end
 
-      def active?
-        true # Default; RPMS locations are active if returned
+      private
+
+      def ien_valid_if_present
+        if ien.present? && ien.to_i <= 0
+          errors.add(:ien, "must be greater than 0")
+        end
+      end
+
+      def build_fhir_identifiers
+        return [] unless ien.present?
+
+        [ { use: "usual", system: "http://ihs.gov/rpms/location-id", value: ien.to_s } ]
+      end
+
+      def build_fhir_type
+        return [] if location_type.blank?
+
+        [ { coding: [ { system: "http://terminology.hl7.org/CodeSystem/location-type",
+                         code: location_type, display: type_display } ] } ]
+      end
+
+      def build_fhir_physical_type
+        return nil if physical_type.blank?
+
+        { coding: [ { system: "http://terminology.hl7.org/CodeSystem/location-physical-type",
+                       code: physical_type, display: physical_type_display } ] }
+      end
+
+      def build_fhir_address
+        return nil if address_line1.blank? && city.blank?
+
+        { use: "work", line: [ address_line1 ].compact, city: city,
+          state: state, postalCode: zip_code, country: "US" }.compact
+      end
+
+      def build_fhir_telecom
+        return [] unless phone.present?
+
+        [ { system: "phone", value: phone, use: "work" } ]
+      end
+
+      def build_fhir_managing_organization
+        return nil unless managing_organization_ien.present?
+
+        { reference: "Organization/rpms-organization-#{managing_organization_ien}" }
+      end
+
+      def self.extract_type_from_fhir(fhir_resource)
+        return nil unless fhir_resource.type&.any?
+
+        fhir_resource.type.first.coding&.first&.code
+      end
+
+      def self.extract_physical_type_from_fhir(fhir_resource)
+        return nil unless fhir_resource.physicalType
+
+        fhir_resource.physicalType.coding&.first&.code
+      end
+
+      def self.extract_org_ien_from_fhir(fhir_resource)
+        return nil unless fhir_resource.managingOrganization
+
+        ref = fhir_resource.managingOrganization.reference
+        return nil unless ref
+
+        if (match = ref.match(/rpms-organization-(\d+)/))
+          match[1].to_i
+        elsif (match = ref.match(%r{Organization/(\d+)}))
+          match[1].to_i
+        end
       end
     end
   end

--- a/app/models/lakeraven/ehr/medication_request.rb
+++ b/app/models/lakeraven/ehr/medication_request.rb
@@ -6,32 +6,68 @@ module Lakeraven
       include ActiveModel::Model
       include ActiveModel::Attributes
 
+      VALID_STATUSES = %w[active on-hold cancelled completed stopped draft entered-in-error].freeze
+      VALID_INTENTS = %w[proposal plan order original-order reflex-order filler-order instance-order option].freeze
+
       attribute :ien, :string
       attribute :patient_dfn, :string
       attribute :medication_code, :string
       attribute :medication_display, :string
       attribute :status, :string
+      attribute :intent, :string
       attribute :dosage_instruction, :string
       attribute :dose_quantity, :string
+      attribute :dose_unit, :string
       attribute :route, :string
       attribute :frequency, :string
       attribute :authored_on, :datetime
+      attribute :requester_duz, :string
       attribute :requester_name, :string
+      attribute :dispense_quantity, :integer
+      attribute :dispense_unit, :string
+      attribute :refills, :integer
+      attribute :days_supply, :integer
+
+      validates :patient_dfn, presence: true
+      validates :medication_display, presence: true
+      validates :status, inclusion: { in: VALID_STATUSES, allow_blank: true }
+      validates :intent, inclusion: { in: VALID_INTENTS, allow_blank: true }
 
       def self.for_patient(dfn)
         MedicationRequestGateway.for_patient(dfn)
       end
 
+      def self.resource_class
+        "MedicationRequest"
+      end
+
+      def self.from_fhir_attributes(fhir_resource)
+        {
+          medication_code: fhir_resource.medicationCodeableConcept&.coding&.first&.code,
+          medication_display: fhir_resource.medicationCodeableConcept&.text ||
+                              fhir_resource.medicationCodeableConcept&.coding&.first&.display,
+          status: fhir_resource.status,
+          intent: fhir_resource.intent
+        }
+      end
+
       def active? = status == "active"
+
+      def persisted?
+        ien.present?
+      end
 
       def to_fhir
         {
           resourceType: "MedicationRequest",
           id: ien&.to_s,
           status: status,
+          intent: intent,
           subject: patient_dfn ? { reference: "Patient/#{patient_dfn}" } : nil,
           medicationCodeableConcept: build_medication_code,
-          dosageInstruction: dosage_instruction ? [ { text: dosage_instruction } ] : nil
+          dosageInstruction: build_dosage_instructions,
+          dispenseRequest: build_dispense_request,
+          requester: build_requester
         }.compact
       end
 
@@ -41,9 +77,51 @@ module Lakeraven
         return nil unless medication_code || medication_display
 
         result = {}
-        result[:coding] = [ { code: medication_code } ] if medication_code
+        if medication_code
+          result[:coding] = [{
+            system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+            code: medication_code,
+            display: medication_display
+          }.compact]
+        end
         result[:text] = medication_display if medication_display
         result
+      end
+
+      def build_dosage_instructions
+        return nil if dosage_instruction.blank? && dose_quantity.blank?
+
+        instruction = { text: dosage_instruction }
+        instruction[:route] = { text: route } if route.present?
+        instruction[:timing] = { code: { text: frequency } } if frequency.present?
+
+        [instruction]
+      end
+
+      def build_dispense_request
+        return nil if dispense_quantity.blank? && refills.blank? && days_supply.blank?
+
+        dr = {}
+        dr[:numberOfRepeatsAllowed] = refills if refills.present?
+        if dispense_quantity.present?
+          dr[:quantity] = { value: dispense_quantity, unit: dispense_unit || "each" }
+        end
+        if days_supply.present?
+          dr[:expectedSupplyDuration] = {
+            value: days_supply, unit: "days",
+            system: "http://unitsofmeasure.org", code: "d"
+          }
+        end
+        dr
+      end
+
+      def build_requester
+        return nil if requester_duz.blank?
+
+        {
+          reference: "Practitioner/#{requester_duz}",
+          display: requester_name
+        }.compact
       end
     end
   end

--- a/app/models/lakeraven/ehr/medication_request.rb
+++ b/app/models/lakeraven/ehr/medication_request.rb
@@ -78,11 +78,11 @@ module Lakeraven
 
         result = {}
         if medication_code
-          result[:coding] = [{
+          result[:coding] = [ {
             system: "http://www.nlm.nih.gov/research/umls/rxnorm",
             code: medication_code,
             display: medication_display
-          }.compact]
+          }.compact ]
         end
         result[:text] = medication_display if medication_display
         result
@@ -95,7 +95,7 @@ module Lakeraven
         instruction[:route] = { text: route } if route.present?
         instruction[:timing] = { code: { text: frequency } } if frequency.present?
 
-        [instruction]
+        [ instruction ]
       end
 
       def build_dispense_request

--- a/app/models/lakeraven/ehr/organization.rb
+++ b/app/models/lakeraven/ehr/organization.rb
@@ -5,15 +5,46 @@ module Lakeraven
     class Organization
       include ActiveModel::Model
       include ActiveModel::Attributes
+      include ActiveModel::Validations
+
+      # Organization type codes (aligned with FHIR organization-type ValueSet)
+      TYPES = {
+        "prov" => "Healthcare Provider",
+        "pay" => "Payer",
+        "govt" => "Government",
+        "ins" => "Insurance Company",
+        "edu" => "Educational Institute",
+        "reli" => "Religious Institution",
+        "cg" => "Community Group",
+        "bus" => "Business",
+        "other" => "Other"
+      }.freeze
 
       attribute :ien, :integer
       attribute :name, :string
       attribute :station_number, :string
+      attribute :org_type, :string
+      attribute :npi, :string
+      attribute :tax_id, :string
+      attribute :active, :boolean, default: true
       attribute :address, :string
       attribute :city, :string
       attribute :state, :string
       attribute :zip_code, :string
       attribute :phone, :string
+      attribute :fax, :string
+      attribute :email, :string
+      attribute :parent_organization_ien, :integer
+
+      # Validations
+      validates :name, presence: true
+      validates :org_type, inclusion: { in: TYPES.keys }, allow_blank: true
+      validates :npi, length: { is: 10 }, allow_blank: true
+      validate :ien_valid_if_present
+
+      # =============================================================================
+      # FIND
+      # =============================================================================
 
       def self.find_by_ien(ien)
         return nil unless ien.present? && ien.to_i > 0
@@ -22,14 +53,77 @@ module Lakeraven
         attrs ? new(**attrs) : nil
       end
 
+      # =============================================================================
+      # TYPE HELPERS
+      # =============================================================================
+
+      def type_display
+        TYPES[org_type] || "Unknown"
+      end
+
+      def provider?
+        org_type == "prov"
+      end
+
+      def payer?
+        org_type == "pay"
+      end
+
+      def government?
+        org_type == "govt"
+      end
+
+      # =============================================================================
+      # ADDRESS HELPERS
+      # =============================================================================
+
+      def full_address
+        [address, city, state, zip_code].compact.reject(&:empty?).join(", ")
+      end
+
+      # =============================================================================
+      # HIERARCHY
+      # =============================================================================
+
+      def parent_organization
+        return nil unless parent_organization_ien.present?
+
+        @parent_organization ||= self.class.find_by_ien(parent_organization_ien)
+      end
+
+      # =============================================================================
+      # FHIR SERIALIZATION
+      # =============================================================================
+
       def to_fhir
         {
           resourceType: "Organization",
           id: ien.to_s,
           name: name,
-          identifier: station_number ? [ { system: "http://hl7.org/fhir/sid/us-npi", value: station_number } ] : [],
-          address: build_address,
-          telecom: phone.present? ? [ { system: "phone", value: phone } ] : []
+          active: active,
+          identifier: build_fhir_identifiers,
+          type: build_fhir_type,
+          address: build_fhir_address,
+          telecom: build_fhir_telecom,
+          partOf: build_fhir_part_of
+        }.compact
+      end
+
+      def self.resource_class
+        "Organization"
+      end
+
+      def self.from_fhir(fhir_resource)
+        attrs = from_fhir_attributes(fhir_resource)
+        new(attrs)
+      end
+
+      def self.from_fhir_attributes(fhir_resource)
+        {
+          name: fhir_resource.name,
+          npi: extract_npi_from_fhir(fhir_resource),
+          org_type: extract_type_from_fhir(fhir_resource),
+          active: fhir_resource.active.nil? ? true : fhir_resource.active
         }
       end
 
@@ -39,16 +133,85 @@ module Lakeraven
         ien.present? && ien.to_i.positive?
       end
 
-      def full_address
-        [ address, city, state, zip_code ].compact.reject(&:empty?).join(", ")
-      end
-
       private
 
-      def build_address
-        return [] if address.blank?
+      def ien_valid_if_present
+        if ien.present? && ien.to_i <= 0
+          errors.add(:ien, "must be greater than 0")
+        end
+      end
 
-        [ { line: [ address ], city: city, state: state, postalCode: zip_code, country: "US" }.compact ]
+      def build_fhir_identifiers
+        identifiers = []
+
+        # IEN / RPMS identifier
+        if ien.present?
+          identifiers << { use: "usual", system: "http://ihs.gov/rpms/organization-id", value: ien.to_s }
+        end
+
+        # Station number
+        if station_number.present?
+          identifiers << { system: "http://hl7.org/fhir/sid/us-npi", value: station_number }
+        end
+
+        # NPI identifier
+        if npi.present?
+          identifiers << { use: "official", system: "http://hl7.org/fhir/sid/us-npi", value: npi }
+        end
+
+        # Tax ID identifier
+        if tax_id.present?
+          identifiers << { use: "official", system: "urn:oid:2.16.840.1.113883.4.4", value: tax_id }
+        end
+
+        identifiers
+      end
+
+      def build_fhir_type
+        return [] if org_type.blank?
+
+        [{
+          coding: [{
+            system: "http://terminology.hl7.org/CodeSystem/organization-type",
+            code: org_type,
+            display: type_display
+          }]
+        }]
+      end
+
+      def build_fhir_address
+        return [] if address.blank? && city.blank?
+
+        [{ line: [address].compact, city: city, state: state, postalCode: zip_code, country: "US" }.compact]
+      end
+
+      def build_fhir_telecom
+        telecom = []
+        telecom << { system: "phone", value: phone, use: "work" } if phone.present?
+        telecom << { system: "fax", value: fax, use: "work" } if fax.present?
+        telecom << { system: "email", value: email, use: "work" } if email.present?
+        telecom
+      end
+
+      def build_fhir_part_of
+        return nil unless parent_organization_ien.present?
+
+        { reference: "Organization/#{parent_organization_ien}" }
+      end
+
+      def self.extract_npi_from_fhir(fhir_resource)
+        return nil unless fhir_resource.identifier&.any?
+
+        npi_id = fhir_resource.identifier.find { |id| id.system&.include?("npi") }
+        npi_id&.value
+      end
+
+      def self.extract_type_from_fhir(fhir_resource)
+        return nil unless fhir_resource.type&.any?
+
+        type = fhir_resource.type.first
+        coding = type.coding&.first
+        coding&.code
       end
     end
   end

--- a/app/models/lakeraven/ehr/organization.rb
+++ b/app/models/lakeraven/ehr/organization.rb
@@ -78,7 +78,7 @@ module Lakeraven
       # =============================================================================
 
       def full_address
-        [address, city, state, zip_code].compact.reject(&:empty?).join(", ")
+        [ address, city, state, zip_code ].compact.reject(&:empty?).join(", ")
       end
 
       # =============================================================================
@@ -170,19 +170,19 @@ module Lakeraven
       def build_fhir_type
         return [] if org_type.blank?
 
-        [{
-          coding: [{
+        [ {
+          coding: [ {
             system: "http://terminology.hl7.org/CodeSystem/organization-type",
             code: org_type,
             display: type_display
-          }]
-        }]
+          } ]
+        } ]
       end
 
       def build_fhir_address
         return [] if address.blank? && city.blank?
 
-        [{ line: [address].compact, city: city, state: state, postalCode: zip_code, country: "US" }.compact]
+        [ { line: [ address ].compact, city: city, state: state, postalCode: zip_code, country: "US" }.compact ]
       end
 
       def build_fhir_telecom

--- a/app/models/lakeraven/ehr/patient.rb
+++ b/app/models/lakeraven/ehr/patient.rb
@@ -180,10 +180,55 @@ module Lakeraven
         TribalEnrollmentGateway.tribe_info(tribe_code)
       end
 
+      # -- Providers (ported from rpms_redux) ----------------------------------
+
+      def providers
+        all_srs = service_requests || []
+        provider_iens = (all_srs.map(&:requesting_provider_ien) +
+                         all_srs.map { |sr| sr.respond_to?(:referred_provider_ien) ? sr.referred_provider_ien : nil })
+                        .compact.uniq.select(&:positive?)
+        provider_iens.filter_map { |ien| Practitioner.find_by_ien(ien) }
+      end
+
       # -- FHIR serialization -----------------------------------------------
 
       def to_fhir
         FHIR::PatientSerializer.call(self)
+      end
+
+      # -- FHIR deserialization (ported from rpms_redux) ---------------------
+
+      def self.from_fhir_attributes(fhir_resource)
+        gender_code = map_fhir_gender_to_sex(fhir_resource.gender)
+        {
+          name: extract_name_from_fhir(fhir_resource),
+          dob: fhir_resource.birthDate ? Date.parse(fhir_resource.birthDate) : nil,
+          sex: gender_code,
+          ssn: extract_ssn_from_fhir(fhir_resource)
+        }
+      end
+
+      def self.extract_name_from_fhir(fhir_resource)
+        return nil unless fhir_resource.name&.any?
+        name_obj = fhir_resource.name.first
+        return name_obj.text if name_obj.respond_to?(:text) && name_obj.text.present?
+        family = name_obj.family
+        given = name_obj.given&.join(" ")
+        given.present? ? "#{family},#{given}" : family
+      end
+
+      def self.map_fhir_gender_to_sex(gender)
+        case gender&.downcase
+        when "male" then "M"
+        when "female" then "F"
+        else "U"
+        end
+      end
+
+      def self.extract_ssn_from_fhir(fhir_resource)
+        return nil unless fhir_resource.identifier&.any?
+        ssn_id = fhir_resource.identifier.find { |id| id.system&.include?("ssn") }
+        ssn_id&.value
       end
 
       private

--- a/app/models/lakeraven/ehr/practitioner.rb
+++ b/app/models/lakeraven/ehr/practitioner.rb
@@ -56,15 +56,55 @@ module Lakeraven
       end
 
       def persisted?
-        ien.present? && ien.to_i.positive?
+        ien.present? && ien.to_i > 0
       end
 
       def can_prescribe_controlled?
-        dea_number.present? && !dea_number.empty?
+        dea_number.present? && !dea_number.strip.empty?
       end
 
       def credentials_summary
         [ title, specialty ].compact.reject(&:empty?).join(", ")
+      end
+
+      # -- Class methods (FHIR) -----------------------------------------------
+
+      def self.resource_class
+        "Practitioner"
+      end
+
+      def self.from_fhir_attributes(fhir_resource)
+        {
+          name: extract_name_from_fhir(fhir_resource),
+          npi: extract_npi_from_fhir(fhir_resource),
+          specialty: extract_specialty_from_fhir(fhir_resource)
+        }
+      end
+
+      def self.extract_name_from_fhir(fhir_resource)
+        return nil unless fhir_resource.name&.any?
+
+        name_obj = fhir_resource.name.first
+        family = name_obj.family
+        given = name_obj.given&.join(" ")
+
+        given.present? ? "#{family}, #{given}" : family
+      end
+
+      def self.extract_npi_from_fhir(fhir_resource)
+        return nil unless fhir_resource.identifier&.any?
+
+        npi_identifier = fhir_resource.identifier.find do |id|
+          id.system&.include?("npi")
+        end
+
+        npi_identifier&.value
+      end
+
+      def self.extract_specialty_from_fhir(fhir_resource)
+        return nil unless fhir_resource.qualification&.any?
+
+        fhir_resource.qualification.first&.code&.text
       end
 
       # -- FHIR serialization -----------------------------------------------

--- a/app/models/lakeraven/ehr/practitioner_role.rb
+++ b/app/models/lakeraven/ehr/practitioner_role.rb
@@ -5,6 +5,7 @@ module Lakeraven
     class PractitionerRole
       include ActiveModel::Model
       include ActiveModel::Attributes
+      include ActiveModel::Validations
 
       ROLES = {
         "doctor" => "Doctor",
@@ -23,24 +24,123 @@ module Lakeraven
       attribute :period_end, :date
       attribute :location_iens # Array
 
+      # =========================================================================
+      # VALIDATIONS
+      # =========================================================================
+
+      validates :practitioner_ien, presence: true, numericality: { greater_than: 0 }
+      validates :organization_ien, presence: true, numericality: { greater_than: 0 }
+      validates :role, inclusion: { in: ROLES.keys }, allow_blank: true
+
+      # =========================================================================
+      # STATUS HELPERS
+      # =========================================================================
+
       def active? = active
-      def role_display = ROLES[role] || role
+
+      def valid_for_scheduling?
+        active? && within_period?
+      end
 
       def within_period?
         today = Date.current
         (period_start.nil? || today >= period_start) && (period_end.nil? || today <= period_end)
       end
 
+      # =========================================================================
+      # ROLE HELPERS
+      # =========================================================================
+
+      def role_display
+        return "Unknown" if role.blank?
+        ROLES[role] || "Unknown"
+      end
+
+      # =========================================================================
+      # FHIR SERIALIZATION
+      # =========================================================================
+
       def to_fhir
-        {
+        fhir = {
           resourceType: "PractitionerRole",
           active: active,
-          practitioner: { reference: "Practitioner/#{practitioner_ien}" },
+          practitioner: practitioner_ien ? { reference: "Practitioner/#{practitioner_ien}" } : nil,
           organization: organization_ien ? { reference: "Organization/#{organization_ien}" } : nil,
-          code: role ? [ { text: role_display } ] : [],
-          specialty: specialty ? [ { text: specialty } ] : []
+          code: build_fhir_code,
+          specialty: specialty ? [ { text: specialty } ] : [],
+          location: build_fhir_locations,
+          period: build_fhir_period
+        }.compact
+        fhir
+      end
+
+      def self.resource_class
+        "PractitionerRole"
+      end
+
+      def self.from_fhir(fhir_resource)
+        attrs = from_fhir_attributes(fhir_resource)
+        new(attrs)
+      end
+
+      def self.from_fhir_attributes(fhir_resource)
+        {
+          practitioner_ien: extract_ien_from_reference(fhir_resource.practitioner&.reference),
+          organization_ien: extract_ien_from_reference(fhir_resource.organization&.reference),
+          specialty: extract_specialty_from_fhir(fhir_resource),
+          active: fhir_resource.active.nil? ? true : fhir_resource.active,
+          period_start: extract_period_date(fhir_resource.period&.start),
+          period_end: extract_period_date(fhir_resource.period&.end)
+        }
+      end
+
+      private
+
+      def build_fhir_code
+        return [] if role.blank?
+
+        [ {
+          coding: [ {
+            system: "http://terminology.hl7.org/CodeSystem/practitioner-role",
+            code: role,
+            display: role_display
+          } ]
+        } ]
+      end
+
+      def build_fhir_locations
+        iens = location_iens || []
+        return [] if iens.empty?
+        iens.map { |ien| { reference: "Location/#{ien}" } }
+      end
+
+      def build_fhir_period
+        return nil if period_start.nil? && period_end.nil?
+        {
+          start: period_start&.iso8601,
+          end: period_end&.iso8601
         }.compact
       end
+
+      def self.extract_ien_from_reference(ref)
+        return nil unless ref
+        match = ref.match(%r{/(\d+)\z})
+        match ? match[1].to_i : nil
+      end
+
+      def self.extract_specialty_from_fhir(fhir_resource)
+        return nil unless fhir_resource.specialty&.any?
+        fhir_resource.specialty.first.text
+      end
+
+      def self.extract_period_date(value)
+        return nil unless value
+        Date.parse(value)
+      rescue StandardError
+        nil
+      end
+
+      private_class_method :extract_ien_from_reference, :extract_specialty_from_fhir, :extract_period_date
     end
   end
 end

--- a/app/models/lakeraven/ehr/procedure.rb
+++ b/app/models/lakeraven/ehr/procedure.rb
@@ -6,20 +6,50 @@ module Lakeraven
       include ActiveModel::Model
       include ActiveModel::Attributes
 
+      VALID_STATUSES = %w[preparation in-progress not-done on-hold stopped completed entered-in-error unknown].freeze
+
+      CODE_SYSTEM_URLS = {
+        "cpt" => "http://www.ama-assn.org/go/cpt",
+        "snomed" => "http://snomed.info/sct"
+      }.freeze
+
       attribute :ien, :string
       attribute :patient_dfn, :string
       attribute :code, :string
+      attribute :code_system, :string
       attribute :display, :string
       attribute :status, :string
       attribute :performed_datetime, :datetime
+      attribute :performer_duz, :string
       attribute :performer_name, :string
+      attribute :location_ien, :string
       attribute :location_name, :string
+
+      validates :patient_dfn, presence: true
+      validates :display, presence: true
+      validates :status, inclusion: { in: VALID_STATUSES, allow_blank: true }
 
       def self.for_patient(dfn)
         ProcedureGateway.for_patient(dfn)
       end
 
+      def self.resource_class
+        "Procedure"
+      end
+
+      def self.from_fhir_attributes(fhir_resource)
+        {
+          code: fhir_resource.code&.coding&.first&.code,
+          display: fhir_resource.code&.text || fhir_resource.code&.coding&.first&.display,
+          status: fhir_resource.status
+        }
+      end
+
       def completed? = status == "completed"
+
+      def persisted?
+        ien.present?
+      end
 
       def to_fhir
         {
@@ -27,7 +57,10 @@ module Lakeraven
           id: ien&.to_s,
           status: status,
           subject: patient_dfn ? { reference: "Patient/#{patient_dfn}" } : nil,
-          code: build_code
+          code: build_code,
+          performedDateTime: performed_datetime&.iso8601,
+          performer: build_performers,
+          location: build_location
         }.compact
       end
 
@@ -37,9 +70,32 @@ module Lakeraven
         return nil unless code || display
 
         result = {}
-        result[:coding] = [ { code: code } ] if code
+        if code
+          system_url = CODE_SYSTEM_URLS[code_system]
+          result[:coding] = [{ code: code, system: system_url }.compact]
+        end
         result[:text] = display if display
         result
+      end
+
+      def build_performers
+        return nil if performer_duz.blank?
+
+        [{
+          actor: {
+            reference: "Practitioner/#{performer_duz}",
+            display: performer_name
+          }.compact
+        }]
+      end
+
+      def build_location
+        return nil if location_ien.blank?
+
+        {
+          reference: "Location/#{location_ien}",
+          display: location_name
+        }.compact
       end
     end
   end

--- a/app/models/lakeraven/ehr/procedure.rb
+++ b/app/models/lakeraven/ehr/procedure.rb
@@ -72,7 +72,7 @@ module Lakeraven
         result = {}
         if code
           system_url = CODE_SYSTEM_URLS[code_system]
-          result[:coding] = [{ code: code, system: system_url }.compact]
+          result[:coding] = [ { code: code, system: system_url }.compact ]
         end
         result[:text] = display if display
         result
@@ -81,12 +81,12 @@ module Lakeraven
       def build_performers
         return nil if performer_duz.blank?
 
-        [{
+        [ {
           actor: {
             reference: "Practitioner/#{performer_duz}",
             display: performer_name
           }.compact
-        }]
+        } ]
       end
 
       def build_location

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -30,9 +30,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_25_010000) do
     t.text "outcome_desc"
     t.string "tenant_identifier"
     t.datetime "updated_at", null: false
-    t.index ["created_at"], name: "index_lakeraven_ehr_audit_events_on_created_at"
-    t.index ["entity_type"], name: "index_lakeraven_ehr_audit_events_on_entity_type"
-    t.index ["tenant_identifier"], name: "index_lakeraven_ehr_audit_events_on_tenant_identifier"
+    t.index [ "created_at" ], name: "index_lakeraven_ehr_audit_events_on_created_at"
+    t.index [ "entity_type" ], name: "index_lakeraven_ehr_audit_events_on_entity_type"
+    t.index [ "tenant_identifier" ], name: "index_lakeraven_ehr_audit_events_on_tenant_identifier"
   end
 
   create_table "lakeraven_ehr_launch_contexts", force: :cascade do |t|
@@ -44,7 +44,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_25_010000) do
     t.string "oauth_application_uid", null: false
     t.string "patient_dfn"
     t.datetime "updated_at", null: false
-    t.index ["launch_token"], name: "index_lakeraven_ehr_launch_contexts_on_launch_token", unique: true
+    t.index [ "launch_token" ], name: "index_lakeraven_ehr_launch_contexts_on_launch_token", unique: true
   end
 
   create_table "lakeraven_ehr_patient_supplements", force: :cascade do |t|
@@ -53,7 +53,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_25_010000) do
     t.integer "patient_dfn", null: false
     t.string "sexual_orientation"
     t.datetime "updated_at", null: false
-    t.index ["patient_dfn"], name: "index_lakeraven_ehr_patient_supplements_on_patient_dfn", unique: true
+    t.index [ "patient_dfn" ], name: "index_lakeraven_ehr_patient_supplements_on_patient_dfn", unique: true
   end
 
   create_table "oauth_access_grants", force: :cascade do |t|
@@ -65,9 +65,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_25_010000) do
     t.datetime "revoked_at"
     t.string "scopes", default: "", null: false
     t.string "token", null: false
-    t.index ["application_id"], name: "index_oauth_access_grants_on_application_id"
-    t.index ["resource_owner_id"], name: "index_oauth_access_grants_on_resource_owner_id"
-    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
+    t.index [ "application_id" ], name: "index_oauth_access_grants_on_application_id"
+    t.index [ "resource_owner_id" ], name: "index_oauth_access_grants_on_resource_owner_id"
+    t.index [ "token" ], name: "index_oauth_access_grants_on_token", unique: true
   end
 
   create_table "oauth_access_tokens", force: :cascade do |t|
@@ -80,10 +80,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_25_010000) do
     t.datetime "revoked_at"
     t.string "scopes"
     t.string "token", null: false
-    t.index ["application_id"], name: "index_oauth_access_tokens_on_application_id"
-    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
-    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
-    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
+    t.index [ "application_id" ], name: "index_oauth_access_tokens_on_application_id"
+    t.index [ "refresh_token" ], name: "index_oauth_access_tokens_on_refresh_token", unique: true
+    t.index [ "resource_owner_id" ], name: "index_oauth_access_tokens_on_resource_owner_id"
+    t.index [ "token" ], name: "index_oauth_access_tokens_on_token", unique: true
   end
 
   create_table "oauth_applications", force: :cascade do |t|
@@ -95,7 +95,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_25_010000) do
     t.string "secret", null: false
     t.string "uid", null: false
     t.datetime "updated_at", null: false
-    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
+    t.index [ "uid" ], name: "index_oauth_applications_on_uid", unique: true
   end
 
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"

--- a/test/models/lakeraven/ehr/audit_event_test.rb
+++ b/test/models/lakeraven/ehr/audit_event_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "ostruct"
 
 module Lakeraven
   module EHR
@@ -228,6 +229,258 @@ module Lakeraven
         assert_includes event.errors[:action], "can't be blank"
         assert_includes event.errors[:outcome], "can't be blank"
         assert_includes event.errors[:entity_type], "can't be blank"
+      end
+
+      # =============================================================================
+      # ACTION VALIDATION
+      # =============================================================================
+
+      test "validates action is in allowed list" do
+        event = AuditEvent.new(
+          event_type: "rest", action: "X", outcome: "0",
+          entity_type: "Patient", agent_who_identifier: "101"
+        )
+        refute event.valid?
+        assert_includes event.errors[:action], "is not included in the list"
+      end
+
+      test "validates outcome is in allowed list" do
+        event = AuditEvent.new(
+          event_type: "rest", action: "R", outcome: "99",
+          entity_type: "Patient", agent_who_identifier: "101"
+        )
+        refute event.valid?
+        assert_includes event.errors[:outcome], "is not included in the list"
+      end
+
+      # =============================================================================
+      # EVENT TYPE HELPER TESTS
+      # =============================================================================
+
+      test "event_type_display returns human-readable type" do
+        event = AuditEvent.new(event_type: "rest")
+        assert_equal "RESTful Operation", event.event_type_display
+
+        event.event_type = "security"
+        assert_equal "Security", event.event_type_display
+      end
+
+      # =============================================================================
+      # ACTION HELPER TESTS
+      # =============================================================================
+
+      test "create_action? returns true for C action" do
+        assert AuditEvent.new(action: "C").create_action?
+      end
+
+      test "read_action? returns true for R action" do
+        assert AuditEvent.new(action: "R").read_action?
+      end
+
+      test "update_action? returns true for U action" do
+        assert AuditEvent.new(action: "U").update_action?
+      end
+
+      test "delete_action? returns true for D action" do
+        assert AuditEvent.new(action: "D").delete_action?
+      end
+
+      test "execute_action? returns true for E action" do
+        assert AuditEvent.new(action: "E").execute_action?
+      end
+
+      test "action_display returns human-readable action" do
+        assert_equal "Read", AuditEvent.new(action: "R").action_display
+        assert_equal "Create", AuditEvent.new(action: "C").action_display
+      end
+
+      # =============================================================================
+      # OUTCOME HELPER TESTS
+      # =============================================================================
+
+      test "success? returns true for outcome 0" do
+        assert AuditEvent.new(outcome: "0").success?
+      end
+
+      test "minor_failure? returns true for outcome 4" do
+        assert AuditEvent.new(outcome: "4").minor_failure?
+      end
+
+      test "serious_failure? returns true for outcome 8" do
+        assert AuditEvent.new(outcome: "8").serious_failure?
+      end
+
+      test "major_failure? returns true for outcome 12" do
+        assert AuditEvent.new(outcome: "12").major_failure?
+      end
+
+      test "outcome_display returns human-readable outcome" do
+        assert_equal "Success", AuditEvent.new(outcome: "0").outcome_display
+        assert_equal "Serious Failure", AuditEvent.new(outcome: "8").outcome_display
+      end
+
+      # =============================================================================
+      # ENTITY HELPER TESTS
+      # =============================================================================
+
+      test "has_entity? returns true when entity is present" do
+        event = AuditEvent.new(
+          event_type: "rest", action: "R", outcome: "0",
+          entity_type: "Patient", entity_identifier: "12345"
+        )
+        assert event.has_entity?
+      end
+
+      test "has_entity? returns false when entity is not present" do
+        event = AuditEvent.new(
+          event_type: "rest", action: "R", outcome: "0",
+          entity_type: "Patient"
+        )
+        refute event.has_entity?
+      end
+
+      # =============================================================================
+      # FHIR SERIALIZATION TESTS
+      # =============================================================================
+
+      test "to_fhir returns valid FHIR AuditEvent resource" do
+        event = AuditEvent.create!(
+          event_type: "rest", action: "R", outcome: "0",
+          entity_type: "Patient", entity_identifier: "1",
+          agent_who_type: "Practitioner", agent_who_identifier: "101"
+        )
+        fhir = event.to_fhir
+        assert_equal "AuditEvent", fhir[:resourceType]
+        assert fhir[:id].present?
+      end
+
+      test "to_fhir includes type" do
+        event = AuditEvent.new(
+          event_type: "rest", action: "R", outcome: "0",
+          entity_type: "Patient", agent_who_identifier: "101"
+        )
+        fhir = event.to_fhir
+        assert_equal "rest", fhir.dig(:type, :code)
+      end
+
+      test "to_fhir includes action" do
+        event = AuditEvent.new(
+          event_type: "rest", action: "R", outcome: "0",
+          entity_type: "Patient", agent_who_identifier: "101"
+        )
+        fhir = event.to_fhir
+        assert_equal "R", fhir[:action]
+      end
+
+      test "to_fhir includes outcome" do
+        event = AuditEvent.new(
+          event_type: "rest", action: "R", outcome: "0",
+          entity_type: "Patient", agent_who_identifier: "101"
+        )
+        fhir = event.to_fhir
+        assert_equal "0", fhir[:outcome]
+      end
+
+      test "to_fhir includes recorded timestamp" do
+        event = AuditEvent.create!(
+          event_type: "rest", action: "R", outcome: "0",
+          entity_type: "Patient", entity_identifier: "1",
+          agent_who_type: "Practitioner", agent_who_identifier: "101"
+        )
+        fhir = event.to_fhir
+        assert fhir[:recorded].present?
+      end
+
+      test "to_fhir includes agent" do
+        event = AuditEvent.new(
+          event_type: "rest", action: "R", outcome: "0",
+          entity_type: "Patient",
+          agent_who_type: "Practitioner", agent_who_identifier: "101"
+        )
+        fhir = event.to_fhir
+        assert fhir[:agent]&.any?
+        agent = fhir[:agent].first
+        assert agent.dig(:who, :reference)&.include?("Practitioner/101")
+      end
+
+      test "to_fhir includes entity when present" do
+        event = AuditEvent.new(
+          event_type: "rest", action: "R", outcome: "0",
+          entity_type: "Patient", entity_identifier: "12345",
+          agent_who_identifier: "101"
+        )
+        fhir = event.to_fhir
+        assert fhir[:entity]&.any?
+        entity = fhir[:entity].first
+        assert entity.dig(:what, :reference)&.include?("Patient/12345")
+      end
+
+      test "to_fhir entity is empty when no entity_identifier" do
+        event = AuditEvent.new(
+          event_type: "rest", action: "R", outcome: "0",
+          entity_type: "Patient",
+          agent_who_identifier: "101"
+        )
+        fhir = event.to_fhir
+        assert_empty(fhir[:entity] || [])
+      end
+
+      test "to_fhir agent is empty when no agent_who_identifier" do
+        event = AuditEvent.new(
+          event_type: "rest", action: "R", outcome: "0",
+          entity_type: "Patient"
+        )
+        fhir = event.to_fhir
+        assert_empty(fhir[:agent] || [])
+      end
+
+      test "to_fhir includes agent network address" do
+        event = AuditEvent.new(
+          event_type: "rest", action: "R", outcome: "0",
+          entity_type: "Patient",
+          agent_who_type: "Practitioner", agent_who_identifier: "101",
+          agent_network_address: "192.168.1.100"
+        )
+        fhir = event.to_fhir
+        agent = fhir[:agent].first
+        assert_equal "192.168.1.100", agent.dig(:network, :address)
+      end
+
+      test "to_fhir agent network is nil when no address" do
+        event = AuditEvent.new(
+          event_type: "rest", action: "R", outcome: "0",
+          entity_type: "Patient",
+          agent_who_type: "Practitioner", agent_who_identifier: "101",
+          agent_network_address: nil
+        )
+        fhir = event.to_fhir
+        agent = fhir[:agent].first
+        assert_nil agent[:network]
+      end
+
+      # =============================================================================
+      # RESOURCE CLASS
+      # =============================================================================
+
+      test "resource_class returns AuditEvent" do
+        assert_equal "AuditEvent", AuditEvent.resource_class
+      end
+
+      # =============================================================================
+      # FROM_FHIR_ATTRIBUTES
+      # =============================================================================
+
+      test "from_fhir_attributes extracts attributes" do
+        fhir_resource = OpenStruct.new(
+          type: OpenStruct.new(code: "rest"),
+          action: "R",
+          outcome: "0"
+        )
+
+        attrs = AuditEvent.from_fhir_attributes(fhir_resource)
+        assert_equal "rest", attrs[:event_type]
+        assert_equal "R", attrs[:action]
+        assert_equal "0", attrs[:outcome]
       end
     end
   end

--- a/test/models/lakeraven/ehr/condition_test.rb
+++ b/test/models/lakeraven/ehr/condition_test.rb
@@ -214,18 +214,18 @@ module Lakeraven
       test "from_fhir_attributes extracts attributes" do
         fhir_resource = OpenStruct.new(
           code: OpenStruct.new(
-            coding: [OpenStruct.new(code: "E11.9", display: "Type 2 diabetes")],
+            coding: [ OpenStruct.new(code: "E11.9", display: "Type 2 diabetes") ],
             text: "Type 2 diabetes"
           ),
           clinicalStatus: OpenStruct.new(
-            coding: [OpenStruct.new(code: "active")]
+            coding: [ OpenStruct.new(code: "active") ]
           ),
           verificationStatus: OpenStruct.new(
-            coding: [OpenStruct.new(code: "confirmed")]
+            coding: [ OpenStruct.new(code: "confirmed") ]
           ),
-          category: [OpenStruct.new(
-            coding: [OpenStruct.new(code: "problem-list-item")]
-          )]
+          category: [ OpenStruct.new(
+            coding: [ OpenStruct.new(code: "problem-list-item") ]
+          ) ]
         )
 
         attrs = Condition.from_fhir_attributes(fhir_resource)

--- a/test/models/lakeraven/ehr/condition_test.rb
+++ b/test/models/lakeraven/ehr/condition_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "ostruct"
 
 module Lakeraven
   module EHR
@@ -106,6 +107,134 @@ module Lakeraven
         c = Condition.new(ien: "42")
         fhir = c.to_fhir
         assert_nil fhir[:subject]
+      end
+
+      # -- validations -----------------------------------------------------------
+
+      test "validates patient_dfn presence" do
+        c = Condition.new(display: "Diabetes")
+        refute c.valid?
+        assert_includes c.errors[:patient_dfn], "can't be blank"
+      end
+
+      test "validates display presence" do
+        c = Condition.new(patient_dfn: "123")
+        refute c.valid?
+        assert_includes c.errors[:display], "can't be blank"
+      end
+
+      test "validates clinical_status values" do
+        c = Condition.new(patient_dfn: "123", display: "Diabetes", clinical_status: "invalid")
+        refute c.valid?
+        assert_includes c.errors[:clinical_status], "is not included in the list"
+      end
+
+      test "allows valid clinical_status values" do
+        %w[active recurrence relapse inactive remission resolved].each do |status|
+          c = Condition.new(patient_dfn: "123", display: "Diabetes", clinical_status: status)
+          assert c.valid?, "Expected #{status} to be valid"
+        end
+      end
+
+      test "validates category values" do
+        c = Condition.new(patient_dfn: "123", display: "Diabetes", category: "invalid")
+        refute c.valid?
+        assert_includes c.errors[:category], "is not included in the list"
+      end
+
+      test "allows valid category values" do
+        %w[problem-list-item encounter-diagnosis health-concern].each do |cat|
+          c = Condition.new(patient_dfn: "123", display: "Diabetes", category: cat)
+          assert c.valid?, "Expected #{cat} to be valid"
+        end
+      end
+
+      # -- resource_class --------------------------------------------------------
+
+      test "resource_class returns Condition" do
+        assert_equal "Condition", Condition.resource_class
+      end
+
+      # -- persisted? ------------------------------------------------------------
+
+      test "persisted? true when ien present" do
+        c = Condition.new(ien: "123", patient_dfn: "456", display: "Test")
+        assert c.persisted?
+      end
+
+      test "persisted? false when ien blank" do
+        c = Condition.new(patient_dfn: "456", display: "Test")
+        refute c.persisted?
+      end
+
+      # -- to_fhir includes clinicalStatus system --------------------------------
+
+      test "to_fhir clinicalStatus includes system" do
+        c = Condition.new(ien: "1", patient_dfn: "100", clinical_status: "active")
+        fhir = c.to_fhir
+        coding = fhir.dig(:clinicalStatus, :coding, 0)
+        assert_equal "http://terminology.hl7.org/CodeSystem/condition-clinical", coding[:system]
+      end
+
+      # -- to_fhir includes ICD-10 code system URL -------------------------------
+
+      test "to_fhir includes ICD-10 code system URL" do
+        c = Condition.new(
+          ien: "1", patient_dfn: "100",
+          code: "E11.9", code_system: "icd10", display: "Type 2 diabetes"
+        )
+        fhir = c.to_fhir
+        coding = fhir.dig(:code, :coding, 0)
+        assert_equal "http://hl7.org/fhir/sid/icd-10-cm", coding[:system]
+      end
+
+      test "to_fhir includes SNOMED code system URL" do
+        c = Condition.new(
+          ien: "1", patient_dfn: "100",
+          code: "44054006", code_system: "snomed", display: "Type 2 diabetes"
+        )
+        fhir = c.to_fhir
+        coding = fhir.dig(:code, :coding, 0)
+        assert_equal "http://snomed.info/sct", coding[:system]
+      end
+
+      # -- to_fhir includes severity ---------------------------------------------
+
+      test "to_fhir includes severity with SNOMED code" do
+        c = Condition.new(
+          ien: "1", patient_dfn: "100", display: "Diabetes", severity: "moderate"
+        )
+        fhir = c.to_fhir
+        assert_equal "6736007", fhir.dig(:severity, :coding, 0, :code)
+        assert_equal "Moderate", fhir.dig(:severity, :coding, 0, :display)
+      end
+
+      # -- from_fhir_attributes --------------------------------------------------
+
+      test "from_fhir_attributes extracts attributes" do
+        fhir_resource = OpenStruct.new(
+          code: OpenStruct.new(
+            coding: [OpenStruct.new(code: "E11.9", display: "Type 2 diabetes")],
+            text: "Type 2 diabetes"
+          ),
+          clinicalStatus: OpenStruct.new(
+            coding: [OpenStruct.new(code: "active")]
+          ),
+          verificationStatus: OpenStruct.new(
+            coding: [OpenStruct.new(code: "confirmed")]
+          ),
+          category: [OpenStruct.new(
+            coding: [OpenStruct.new(code: "problem-list-item")]
+          )]
+        )
+
+        attrs = Condition.from_fhir_attributes(fhir_resource)
+
+        assert_equal "E11.9", attrs[:code]
+        assert_equal "Type 2 diabetes", attrs[:display]
+        assert_equal "active", attrs[:clinical_status]
+        assert_equal "confirmed", attrs[:verification_status]
+        assert_equal "problem-list-item", attrs[:category]
       end
     end
   end

--- a/test/models/lakeraven/ehr/coverage_eligibility_response_test.rb
+++ b/test/models/lakeraven/ehr/coverage_eligibility_response_test.rb
@@ -188,6 +188,164 @@ module Lakeraven
         fhir = resp.to_fhir
         assert_equal "complete", fhir[:outcome]
       end
+
+      # -- UUID generation -------------------------------------------------------
+
+      test "generates UUID for id if not provided" do
+        resp = CoverageEligibilityResponse.new(status: "enrolled")
+        assert resp.id.present?
+        assert_match(/^[0-9a-f-]{36}$/, resp.id)
+      end
+
+      test "sets created_at to current time if not provided" do
+        resp = CoverageEligibilityResponse.new(status: "enrolled")
+        assert resp.created_at.present?
+        assert_in_delta Time.current, resp.created_at, 1.second
+      end
+
+      # -- coverage_details ------------------------------------------------------
+
+      test "coverage_details returns nil when not enrolled" do
+        resp = CoverageEligibilityResponse.new(status: "not_enrolled")
+        assert_nil resp.coverage_details
+      end
+
+      test "coverage_details returns hash when enrolled" do
+        resp = CoverageEligibilityResponse.new(
+          status: "enrolled", coverage_type: "medicare_a",
+          start_date: Date.new(2024, 1, 1), end_date: Date.new(2024, 12, 31)
+        )
+        details = resp.coverage_details
+        assert_equal "medicare_a", details[:type]
+        assert_equal "enrolled", details[:status]
+        assert details[:period].present?
+      end
+
+      # -- coverage_period -------------------------------------------------------
+
+      test "coverage_period returns start and end dates" do
+        resp = CoverageEligibilityResponse.new(
+          status: "enrolled",
+          start_date: Date.new(2024, 1, 1), end_date: Date.new(2024, 12, 31)
+        )
+        period = resp.coverage_period
+        assert_equal Date.new(2024, 1, 1), period[:start]
+        assert_equal Date.new(2024, 12, 31), period[:end]
+      end
+
+      test "coverage_period returns nil when no dates" do
+        resp = CoverageEligibilityResponse.new(status: "enrolled")
+        assert_nil resp.coverage_period
+      end
+
+      # -- plan_info -------------------------------------------------------------
+
+      test "plan_info returns plan details" do
+        resp = CoverageEligibilityResponse.new(
+          status: "enrolled", plan_name: "Blue Cross PPO",
+          policy_id: "BC123456", group_id: "GRP001"
+        )
+        plan = resp.plan_info
+        assert_equal "Blue Cross PPO", plan[:name]
+        assert_equal "BC123456", plan[:policy_id]
+        assert_equal "GRP001", plan[:group_id]
+      end
+
+      test "plan_info returns nil when no plan details" do
+        resp = CoverageEligibilityResponse.new(status: "enrolled")
+        assert_nil resp.plan_info
+      end
+
+      # -- insurer_info ----------------------------------------------------------
+
+      test "insurer_info returns insurer details" do
+        resp = CoverageEligibilityResponse.new(
+          status: "enrolled", insurer_name: "Blue Cross Blue Shield", insurer_id: "BCBS001"
+        )
+        insurer = resp.insurer_info
+        assert_equal "Blue Cross Blue Shield", insurer[:name]
+        assert_equal "BCBS001", insurer[:id]
+      end
+
+      # -- to_fhir includes request reference ------------------------------------
+
+      test "to_fhir includes request reference when provided" do
+        resp = CoverageEligibilityResponse.new(
+          status: "enrolled", request_id: "req-123"
+        )
+        fhir = resp.to_fhir
+        assert_equal "CoverageEligibilityRequest/req-123", fhir.dig(:request, :reference)
+      end
+
+      # -- to_fhir includes insurance when enrolled ------------------------------
+
+      test "to_fhir includes insurance when enrolled" do
+        resp = CoverageEligibilityResponse.new(
+          status: "enrolled", patient_dfn: "1", coverage_type: "medicare_a",
+          start_date: Date.new(2024, 1, 1)
+        )
+        fhir = resp.to_fhir
+        assert fhir[:insurance].present?
+      end
+
+      test "to_fhir does not include insurance when not enrolled" do
+        resp = CoverageEligibilityResponse.new(
+          status: "not_enrolled", patient_dfn: "1"
+        )
+        fhir = resp.to_fhir
+        assert_nil fhir[:insurance]
+      end
+
+      # -- from_fhir -------------------------------------------------------------
+
+      test "from_fhir creates response from FHIR hash" do
+        fhir_hash = {
+          resourceType: "CoverageEligibilityResponse",
+          id: "resp-123",
+          patient: { reference: "Patient/12345" },
+          request: { reference: "CoverageEligibilityRequest/req-456" },
+          outcome: "complete",
+          disposition: "Coverage active",
+          insurance: [{ inforce: true }]
+        }
+
+        resp = CoverageEligibilityResponse.from_fhir(fhir_hash)
+        assert_equal "resp-123", resp.id
+        assert_equal "12345", resp.patient_dfn
+        assert_equal "req-456", resp.request_id
+        assert_equal "Coverage active", resp.disposition
+        assert_equal "enrolled", resp.status
+      end
+
+      test "from_fhir handles string keys" do
+        fhir_hash = {
+          "resourceType" => "CoverageEligibilityResponse",
+          "id" => "resp-789",
+          "patient" => { "reference" => "Patient/67890" },
+          "outcome" => "queued"
+        }
+
+        resp = CoverageEligibilityResponse.from_fhir(fhir_hash)
+        assert_equal "resp-789", resp.id
+        assert_equal "67890", resp.patient_dfn
+        assert_equal "pending", resp.status
+      end
+
+      test "from_fhir extracts coverage period" do
+        fhir_hash = {
+          resourceType: "CoverageEligibilityResponse",
+          id: "resp-123",
+          outcome: "complete",
+          insurance: [{
+            inforce: true,
+            benefitPeriod: { start: "2024-01-01", end: "2024-12-31" }
+          }]
+        }
+
+        resp = CoverageEligibilityResponse.from_fhir(fhir_hash)
+        assert_equal Date.new(2024, 1, 1), resp.start_date
+        assert_equal Date.new(2024, 12, 31), resp.end_date
+      end
     end
   end
 end

--- a/test/models/lakeraven/ehr/coverage_eligibility_response_test.rb
+++ b/test/models/lakeraven/ehr/coverage_eligibility_response_test.rb
@@ -306,7 +306,7 @@ module Lakeraven
           request: { reference: "CoverageEligibilityRequest/req-456" },
           outcome: "complete",
           disposition: "Coverage active",
-          insurance: [{ inforce: true }]
+          insurance: [ { inforce: true } ]
         }
 
         resp = CoverageEligibilityResponse.from_fhir(fhir_hash)
@@ -336,10 +336,10 @@ module Lakeraven
           resourceType: "CoverageEligibilityResponse",
           id: "resp-123",
           outcome: "complete",
-          insurance: [{
+          insurance: [ {
             inforce: true,
             benefitPeriod: { start: "2024-01-01", end: "2024-12-31" }
-          }]
+          } ]
         }
 
         resp = CoverageEligibilityResponse.from_fhir(fhir_hash)

--- a/test/models/lakeraven/ehr/coverage_test.rb
+++ b/test/models/lakeraven/ehr/coverage_test.rb
@@ -131,6 +131,62 @@ module Lakeraven
         assert_not Coverage.new(order: 1).secondary?
       end
 
+      # -- Payor display ---------------------------------------------------------
+
+      test "payor_display returns default for Medicare" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicare_a")
+        assert_equal "Medicare", cov.payor_display
+      end
+
+      test "payor_display returns default for Medicaid" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid")
+        assert_equal "Medicaid", cov.payor_display
+      end
+
+      test "payor_display returns default for VA" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "va_benefits")
+        assert_equal "Department of Veterans Affairs", cov.payor_display
+      end
+
+      test "payor_display uses custom payor_name when provided" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "private_insurance", payor_name: "Blue Cross")
+        assert_equal "Blue Cross", cov.payor_display
+      end
+
+      # -- Payor type display ---------------------------------------------------
+
+      test "payor_type_display for Medicare Part A" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicare_a")
+        assert_equal "Medicare Part A", cov.payor_type_display
+      end
+
+      test "payor_type_display for Medicare Part B" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicare_b")
+        assert_equal "Medicare Part B", cov.payor_type_display
+      end
+
+      test "payor_type_display for Medicaid" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid")
+        assert_equal "Medicaid", cov.payor_type_display
+      end
+
+      # -- Coordination of benefits defaults ------------------------------------
+
+      test "coordination_order defaults to 1 for private insurance" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "private_insurance")
+        assert_equal 1, cov.coordination_order
+      end
+
+      test "coordination_order defaults to 2 for Medicare" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicare_a")
+        assert_equal 2, cov.coordination_order
+      end
+
+      test "coordination_order defaults to 3 for Medicaid" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid")
+        assert_equal 3, cov.coordination_order
+      end
+
       # -- FHIR serialization ----------------------------------------------------
 
       test "to_fhir returns Coverage resource" do
@@ -157,11 +213,13 @@ module Lakeraven
         assert_equal "2025-12-31", fhir.dig(:period, :end)
       end
 
-      test "to_fhir includes payor" do
-        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicaid", payor_name: "State Medicaid")
+      test "to_fhir includes payor with org reference" do
+        cov = Coverage.new(patient_dfn: "1", coverage_type: "medicare_a")
         fhir = cov.to_fhir
 
-        assert_equal "State Medicaid", fhir[:payor].first[:display]
+        assert fhir[:payor].present?
+        assert_equal "Organization/CMS", fhir[:payor].first[:reference]
+        assert_equal "Medicare", fhir[:payor].first[:display]
       end
 
       test "to_fhir includes class with subscriber_id" do
@@ -170,6 +228,100 @@ module Lakeraven
 
         plan_class = fhir[:class]&.find { |c| c.dig(:type, :coding, 0, :code) == "plan" }
         assert_equal "MCD123", plan_class[:value]
+      end
+
+      test "to_fhir includes class for group and plan" do
+        cov = Coverage.new(
+          patient_dfn: "1", coverage_type: "private_insurance",
+          group_id: "GRP001", plan_name: "PPO Gold"
+        )
+        fhir = cov.to_fhir
+
+        assert fhir[:class].present?
+        group = fhir[:class].find { |c| c.dig(:type, :coding, 0, :code) == "group" }
+        assert_equal "GRP001", group[:value]
+
+        plan = fhir[:class].find { |c| c.dig(:type, :coding, 0, :code) == "plan" }
+        assert_equal "PPO Gold", plan[:name]
+      end
+
+      # -- FHIR parsing ---------------------------------------------------------
+
+      test "from_fhir creates coverage from FHIR hash" do
+        fhir = {
+          resourceType: "Coverage",
+          id: "cov-123",
+          status: "active",
+          beneficiary: { reference: "Patient/12345" },
+          payor: [ { reference: "Organization/CMS", display: "Medicare" } ]
+        }
+
+        cov = Coverage.from_fhir(fhir)
+
+        assert_equal "cov-123", cov.id
+        assert_equal "12345", cov.patient_dfn
+        assert_equal "active", cov.status
+      end
+
+      test "from_fhir extracts period" do
+        fhir = {
+          resourceType: "Coverage",
+          beneficiary: { reference: "Patient/12345" },
+          period: { start: "2024-01-01", end: "2024-12-31" }
+        }
+
+        cov = Coverage.from_fhir(fhir)
+
+        assert_equal Date.new(2024, 1, 1), cov.start_date
+        assert_equal Date.new(2024, 12, 31), cov.end_date
+      end
+
+      test "from_fhir extracts class info" do
+        fhir = {
+          resourceType: "Coverage",
+          beneficiary: { reference: "Patient/12345" },
+          class: [
+            { type: { coding: [ { code: "group" } ] }, value: "GRP001" },
+            { type: { coding: [ { code: "plan" } ] }, value: "PLAN123", name: "PPO Gold" }
+          ]
+        }
+
+        cov = Coverage.from_fhir(fhir)
+
+        assert_equal "GRP001", cov.group_id
+        assert_equal "PPO Gold", cov.plan_name
+      end
+
+      # -- Factory: from_eligibility_response ------------------------------------
+
+      test "from_eligibility_response creates coverage when enrolled" do
+        response = CoverageEligibilityResponse.new(
+          patient_dfn: "12345",
+          coverage_type: "medicare_a",
+          status: "enrolled",
+          start_date: Date.new(2024, 1, 1),
+          end_date: Date.new(2024, 12, 31),
+          plan_name: "Medicare Part A"
+        )
+
+        cov = Coverage.from_eligibility_response(response)
+
+        assert cov.present?
+        assert_equal "12345", cov.patient_dfn
+        assert_equal "medicare_a", cov.coverage_type
+        assert_equal Date.new(2024, 1, 1), cov.start_date
+      end
+
+      test "from_eligibility_response returns nil when not enrolled" do
+        response = CoverageEligibilityResponse.new(
+          patient_dfn: "12345",
+          coverage_type: "medicare_a",
+          status: "not_enrolled"
+        )
+
+        cov = Coverage.from_eligibility_response(response)
+
+        assert_nil cov
       end
     end
   end

--- a/test/models/lakeraven/ehr/document_reference_test.rb
+++ b/test/models/lakeraven/ehr/document_reference_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "ostruct"
 
 module Lakeraven
   module EHR
@@ -47,6 +48,72 @@ module Lakeraven
         assert_equal "Cardiology consultation", doc.description
       end
 
+      test "stores context_service_request_ien" do
+        doc = DocumentReference.new(context_service_request_ien: "500")
+        assert_equal "500", doc.context_service_request_ien
+      end
+
+      # =============================================================================
+      # VALIDATION TESTS
+      # =============================================================================
+
+      test "should be valid with required attributes" do
+        doc = DocumentReference.new(
+          subject_patient_dfn: "12345",
+          type_code: "11488-4"
+        )
+        assert doc.valid?, "DocumentReference should be valid with patient and type code"
+      end
+
+      test "should require subject_patient_dfn" do
+        doc = DocumentReference.new(type_code: "11488-4")
+        refute doc.valid?
+        assert doc.errors[:subject_patient_dfn].any?
+      end
+
+      test "should require type_code" do
+        doc = DocumentReference.new(subject_patient_dfn: "12345")
+        refute doc.valid?
+        assert doc.errors[:type_code].any?
+      end
+
+      test "should validate status if present" do
+        doc = DocumentReference.new(
+          subject_patient_dfn: "12345",
+          type_code: "11488-4",
+          status: "invalid"
+        )
+        refute doc.valid?
+        assert_includes doc.errors[:status], "is not included in the list"
+      end
+
+      test "should allow blank status" do
+        doc = DocumentReference.new(
+          subject_patient_dfn: "12345",
+          type_code: "11488-4",
+          status: nil
+        )
+        assert doc.valid?
+      end
+
+      test "should validate category if present" do
+        doc = DocumentReference.new(
+          subject_patient_dfn: "12345",
+          type_code: "11488-4",
+          category: "invalid-category"
+        )
+        refute doc.valid?
+        assert_includes doc.errors[:category], "is not included in the list"
+      end
+
+      test "should allow blank category" do
+        doc = DocumentReference.new(
+          subject_patient_dfn: "12345",
+          type_code: "11488-4"
+        )
+        assert doc.valid?
+      end
+
       # =============================================================================
       # STATUS HELPER TESTS
       # =============================================================================
@@ -69,6 +136,105 @@ module Lakeraven
         refute doc.current?
       end
 
+      test "superseded? returns true for superseded status" do
+        doc = DocumentReference.new(status: "superseded")
+        assert doc.superseded?
+      end
+
+      test "entered_in_error? returns true for entered-in-error status" do
+        doc = DocumentReference.new(status: "entered-in-error")
+        assert doc.entered_in_error?
+      end
+
+      test "active? returns true for current documents" do
+        doc = DocumentReference.new(status: "current")
+        assert doc.active?
+      end
+
+      test "active? returns false for superseded documents" do
+        doc = DocumentReference.new(status: "superseded")
+        refute doc.active?
+      end
+
+      test "status_display returns human-readable status" do
+        doc = DocumentReference.new(status: "current")
+        assert_equal "Current", doc.status_display
+
+        doc.status = "superseded"
+        assert_equal "Superseded", doc.status_display
+
+        doc.status = "entered-in-error"
+        assert_equal "Entered in Error", doc.status_display
+
+        doc.status = nil
+        assert_equal "Unknown", doc.status_display
+      end
+
+      # =============================================================================
+      # CATEGORY HELPER TESTS
+      # =============================================================================
+
+      test "category_display returns human-readable category" do
+        doc = DocumentReference.new(category: "clinical-note")
+        assert_equal "Clinical Note", doc.category_display
+
+        doc.category = "discharge-summary"
+        assert_equal "Discharge Summary", doc.category_display
+
+        doc.category = nil
+        assert_equal "Unknown", doc.category_display
+      end
+
+      test "clinical_note? returns true for clinical-note category" do
+        assert DocumentReference.new(category: "clinical-note").clinical_note?
+      end
+
+      test "imaging? returns true for imaging category" do
+        assert DocumentReference.new(category: "imaging").imaging?
+      end
+
+      test "laboratory? returns true for laboratory category" do
+        assert DocumentReference.new(category: "laboratory").laboratory?
+      end
+
+      # =============================================================================
+      # TYPE HELPER TESTS
+      # =============================================================================
+
+      test "type_display_from_loinc returns LOINC display for known codes" do
+        doc = DocumentReference.new(type_code: "11488-4")
+        assert_equal "Consultation Note", doc.type_display_from_loinc
+
+        doc.type_code = "18842-5"
+        assert_equal "Discharge Summary", doc.type_display_from_loinc
+      end
+
+      test "type_display_from_loinc falls back to type_display for unknown codes" do
+        doc = DocumentReference.new(
+          type_code: "99999-9",
+          type_display: "Custom Document"
+        )
+        assert_equal "Custom Document", doc.type_display_from_loinc
+      end
+
+      # =============================================================================
+      # PERSISTENCE TESTS
+      # =============================================================================
+
+      test "persisted? returns false for new document" do
+        doc = DocumentReference.new(subject_patient_dfn: "12345", type_code: "11488-4")
+        refute doc.persisted?
+      end
+
+      test "persisted? returns true for document with id" do
+        doc = DocumentReference.new(
+          id: SecureRandom.uuid,
+          subject_patient_dfn: "12345",
+          type_code: "11488-4"
+        )
+        assert doc.persisted?
+      end
+
       # =============================================================================
       # FHIR SERIALIZATION TESTS
       # =============================================================================
@@ -80,16 +246,59 @@ module Lakeraven
         assert_equal "current", fhir[:status]
       end
 
+      test "to_fhir includes id" do
+        doc = DocumentReference.new(id: "test-uuid", status: "current", subject_patient_dfn: "100")
+        fhir = doc.to_fhir
+        assert_equal "test-uuid", fhir[:id]
+      end
+
       test "to_fhir includes subject" do
         doc = DocumentReference.new(subject_patient_dfn: "100")
         fhir = doc.to_fhir
         assert_equal "Patient/100", fhir.dig(:subject, :reference)
       end
 
-      test "to_fhir includes type" do
-        doc = DocumentReference.new(type_display: "Discharge summary")
+      test "to_fhir includes type with LOINC coding" do
+        doc = DocumentReference.new(
+          subject_patient_dfn: "12345",
+          type_code: "11488-4",
+          type_display: "Consultation Note"
+        )
         fhir = doc.to_fhir
-        assert_equal "Discharge summary", fhir.dig(:type, :text)
+
+        assert_not_nil fhir[:type]
+        coding = fhir[:type][:coding].first
+        assert_equal "11488-4", coding[:code]
+        assert_equal "http://loinc.org", coding[:system]
+        assert_equal "Consultation Note", coding[:display]
+      end
+
+      test "to_fhir includes category" do
+        doc = DocumentReference.new(
+          subject_patient_dfn: "12345",
+          type_code: "11488-4",
+          category: "clinical-note"
+        )
+        fhir = doc.to_fhir
+
+        assert fhir[:category].any?
+        coding = fhir[:category].first[:coding].first
+        assert_equal "clinical-note", coding[:code]
+        assert_equal "Clinical Note", coding[:display]
+      end
+
+      test "to_fhir includes author reference" do
+        doc = DocumentReference.new(
+          subject_patient_dfn: "12345",
+          type_code: "11488-4",
+          author_ien: "101"
+        )
+        fhir = doc.to_fhir
+
+        assert fhir[:author].any?
+        author = fhir[:author].first
+        assert_includes author[:reference], "Practitioner"
+        assert_includes author[:reference], "101"
       end
 
       test "to_fhir includes content with URL" do
@@ -118,22 +327,172 @@ module Lakeraven
         assert_equal "Cardiology consultation", fhir[:description]
       end
 
+      test "to_fhir includes date" do
+        doc = DocumentReference.new(
+          subject_patient_dfn: "12345",
+          type_code: "11488-4",
+          date: Date.parse("2024-06-15")
+        )
+        fhir = doc.to_fhir
+        assert_equal "2024-06-15", fhir[:date]
+      end
+
+      test "to_fhir includes context for service request" do
+        doc = DocumentReference.new(
+          subject_patient_dfn: "12345",
+          type_code: "11488-4",
+          context_service_request_ien: "500"
+        )
+        fhir = doc.to_fhir
+
+        assert_not_nil fhir[:context]
+        related = fhir[:context][:related].first
+        assert_includes related[:reference], "ServiceRequest"
+        assert_includes related[:reference], "500"
+      end
+
       test "to_fhir omits subject when subject_patient_dfn is nil" do
         doc = DocumentReference.new(subject_patient_dfn: nil)
         fhir = doc.to_fhir
         assert_nil fhir[:subject]
       end
 
-      test "to_fhir omits type when type_display is nil" do
-        doc = DocumentReference.new(type_display: nil)
-        fhir = doc.to_fhir
-        assert_nil fhir[:type]
-      end
-
       test "to_fhir omits description when nil" do
         doc = DocumentReference.new(description: nil)
         fhir = doc.to_fhir
         refute fhir.key?(:description)
+      end
+
+      test "resource_class returns DocumentReference" do
+        assert_equal "DocumentReference", DocumentReference.resource_class
+      end
+
+      test "from_fhir_attributes extracts attributes" do
+        fhir_resource = OpenStruct.new(
+          status: "current",
+          type: OpenStruct.new(
+            coding: [ OpenStruct.new(code: "11488-4", display: "Consultation Note") ]
+          ),
+          category: [
+            OpenStruct.new(coding: [ OpenStruct.new(code: "clinical-note") ])
+          ],
+          subject: OpenStruct.new(reference: "Patient/12345"),
+          date: "2024-06-15",
+          description: "Test description"
+        )
+
+        attrs = DocumentReference.from_fhir_attributes(fhir_resource)
+        assert_equal "current", attrs[:status]
+        assert_equal "11488-4", attrs[:type_code]
+        assert_equal "Consultation Note", attrs[:type_display]
+        assert_equal "clinical-note", attrs[:category]
+        assert_equal "12345", attrs[:subject_patient_dfn]
+        assert_equal Date.parse("2024-06-15"), attrs[:date]
+        assert_equal "Test description", attrs[:description]
+      end
+
+      test "from_fhir creates document reference from FHIR resource" do
+        fhir_resource = OpenStruct.new(
+          status: "current",
+          type: OpenStruct.new(
+            coding: [ OpenStruct.new(code: "11488-4", display: "Consultation Note") ]
+          ),
+          subject: OpenStruct.new(reference: "Patient/12345")
+        )
+
+        doc = DocumentReference.from_fhir(fhir_resource)
+        assert doc.is_a?(DocumentReference)
+        assert_equal "current", doc.status
+        assert_equal "11488-4", doc.type_code
+        assert_equal "12345", doc.subject_patient_dfn
+      end
+
+      # =============================================================================
+      # US CORE COMPLIANCE TESTS
+      # =============================================================================
+
+      test "document reference FHIR is US Core compliant" do
+        doc = DocumentReference.new(
+          subject_patient_dfn: "12345",
+          type_code: "11488-4",
+          type_display: "Consultation Note",
+          category: "clinical-note",
+          status: "current"
+        )
+        fhir = doc.to_fhir
+
+        assert fhir[:status].present?, "US Core requires status"
+        assert fhir[:type].present?, "US Core requires type"
+        assert fhir[:category].any?, "US Core requires category"
+        assert fhir[:subject].present?, "US Core requires subject"
+      end
+
+      test "document type uses LOINC coding system" do
+        doc = DocumentReference.new(
+          subject_patient_dfn: "12345",
+          type_code: "11488-4"
+        )
+        fhir = doc.to_fhir
+
+        coding = fhir[:type][:coding].first
+        assert_equal "http://loinc.org", coding[:system]
+      end
+
+      test "document reference FHIR can be serialized to JSON" do
+        doc = DocumentReference.new(
+          subject_patient_dfn: "12345",
+          type_code: "11488-4",
+          category: "clinical-note"
+        )
+
+        assert_nothing_raised do
+          doc.to_fhir.to_json
+        end
+      end
+
+      # =============================================================================
+      # EDGE CASE TESTS
+      # =============================================================================
+
+      test "handles nil author in FHIR" do
+        doc = DocumentReference.new(
+          subject_patient_dfn: "12345",
+          type_code: "11488-4",
+          author_ien: nil
+        )
+        fhir = doc.to_fhir
+        assert_equal [], fhir[:author]
+      end
+
+      test "handles nil content in FHIR" do
+        doc = DocumentReference.new(
+          subject_patient_dfn: "12345",
+          type_code: "11488-4",
+          content_url: nil,
+          content_type: nil
+        )
+        fhir = doc.to_fhir
+        assert_equal [], fhir[:content]
+      end
+
+      test "handles nil context in FHIR" do
+        doc = DocumentReference.new(
+          subject_patient_dfn: "12345",
+          type_code: "11488-4",
+          context_service_request_ien: nil
+        )
+        fhir = doc.to_fhir
+        assert_nil fhir[:context]
+      end
+
+      test "handles nil category in FHIR" do
+        doc = DocumentReference.new(
+          subject_patient_dfn: "12345",
+          type_code: "11488-4",
+          category: nil
+        )
+        fhir = doc.to_fhir
+        assert_equal [], fhir[:category]
       end
     end
   end

--- a/test/models/lakeraven/ehr/encounter_test.rb
+++ b/test/models/lakeraven/ehr/encounter_test.rb
@@ -80,6 +80,14 @@ module Lakeraven
         assert Encounter.new(status: "planned", class_code: "IMP").inpatient?
       end
 
+      test "arrived? true for arrived status" do
+        assert Encounter.new(status: "arrived", class_code: "AMB").arrived?
+      end
+
+      test "virtual? true for VR class" do
+        assert Encounter.new(status: "planned", class_code: "VR").virtual?
+      end
+
       # =============================================================================
       # DISPLAY HELPERS
       # =============================================================================
@@ -93,6 +101,40 @@ module Lakeraven
         assert_equal "Ambulatory", Encounter.new(status: "planned", class_code: "AMB").class_display
         assert_equal "Emergency", Encounter.new(status: "planned", class_code: "EMER").class_display
         assert_equal "Inpatient", Encounter.new(status: "planned", class_code: "IMP").class_display
+      end
+
+      # =============================================================================
+      # PERIOD HELPERS
+      # =============================================================================
+
+      test "within_period? returns true when no period set" do
+        enc = Encounter.new(status: "in-progress", class_code: "AMB")
+        assert enc.within_period?
+      end
+
+      test "within_period? returns true when within period" do
+        enc = Encounter.new(
+          status: "in-progress", class_code: "AMB",
+          period_start: DateTime.current - 1.hour,
+          period_end: DateTime.current + 1.hour
+        )
+        assert enc.within_period?
+      end
+
+      test "within_period? returns false when before period" do
+        enc = Encounter.new(
+          status: "planned", class_code: "AMB",
+          period_start: DateTime.current + 1.day
+        )
+        refute enc.within_period?
+      end
+
+      test "within_period? returns false when after period" do
+        enc = Encounter.new(
+          status: "finished", class_code: "AMB",
+          period_end: DateTime.current - 1.day
+        )
+        refute enc.within_period?
       end
 
       # =============================================================================
@@ -187,6 +229,58 @@ module Lakeraven
         enc = Encounter.new(status: "finished", class_code: "AMB", reason_display: "Chest pain", reason_code: "R07.9")
         fhir = enc.to_fhir
         assert_equal "Chest pain", fhir[:reasonCode].first[:text]
+      end
+
+      test "to_fhir includes location when present" do
+        enc = Encounter.new(status: "in-progress", class_code: "AMB", location_ien: 201)
+        fhir = enc.to_fhir
+        assert fhir[:location].any?
+        assert fhir[:location].first.dig(:location, :reference).include?("Location")
+      end
+
+      test "to_fhir includes service provider when present" do
+        enc = Encounter.new(status: "in-progress", class_code: "AMB", service_provider_organization_ien: 301)
+        fhir = enc.to_fhir
+        assert_not_nil fhir[:serviceProvider]
+        assert fhir[:serviceProvider][:reference].include?("Organization")
+      end
+
+      test "resource_class returns Encounter" do
+        assert_equal "Encounter", Encounter.resource_class
+      end
+
+      test "from_fhir_attributes extracts attributes from hash" do
+        fhir = {
+          status: "finished",
+          class: { code: "AMB" },
+          subject: { reference: "Patient/12345" }
+        }
+        attrs = Encounter.from_fhir_attributes(fhir)
+        assert_equal "finished", attrs[:status]
+        assert_equal "AMB", attrs[:class_code]
+        assert_equal "12345", attrs[:patient_identifier]
+      end
+
+      # =============================================================================
+      # EDGE CASES
+      # =============================================================================
+
+      test "to_fhir handles empty participant_practitioner_iens" do
+        enc = Encounter.new(status: "in-progress", class_code: "AMB", participant_practitioner_iens: [])
+        fhir = enc.to_fhir
+        assert_nil fhir[:participant]
+      end
+
+      test "to_fhir handles nil location" do
+        enc = Encounter.new(status: "in-progress", class_code: "AMB", location_ien: nil)
+        fhir = enc.to_fhir
+        assert_nil fhir[:location]
+      end
+
+      test "to_fhir handles nil type" do
+        enc = Encounter.new(status: "in-progress", class_code: "AMB", type_display: nil)
+        fhir = enc.to_fhir
+        assert_nil fhir[:type]
       end
 
       # =============================================================================

--- a/test/models/lakeraven/ehr/immunization_test.rb
+++ b/test/models/lakeraven/ehr/immunization_test.rb
@@ -109,6 +109,225 @@ module Lakeraven
         fhir = imm.to_fhir
         assert_nil fhir[:patient]
       end
+
+      # -- Validations ---------------------------------------------------------
+
+      test "validates patient_dfn presence" do
+        imm = Immunization.new(vaccine_display: "Flu shot")
+        assert_not imm.valid?
+        assert_includes imm.errors[:patient_dfn], "can't be blank"
+      end
+
+      test "validates vaccine_display presence" do
+        imm = Immunization.new(patient_dfn: "123")
+        assert_not imm.valid?
+        assert_includes imm.errors[:vaccine_display], "can't be blank"
+      end
+
+      test "validates status values" do
+        imm = Immunization.new(
+          patient_dfn: "123", vaccine_display: "Flu shot", status: "invalid"
+        )
+        assert_not imm.valid?
+        assert_includes imm.errors[:status], "is not included in the list"
+      end
+
+      test "allows valid status values" do
+        %w[completed entered-in-error not-done].each do |status|
+          imm = Immunization.new(
+            patient_dfn: "123", vaccine_display: "Flu shot", status: status
+          )
+          assert imm.valid?, "Expected #{status} to be valid"
+        end
+      end
+
+      # -- FHIR meta profile ---------------------------------------------------
+
+      test "to_fhir includes US Core immunization profile in meta" do
+        imm = Immunization.new(ien: "1", patient_dfn: "100", vaccine_display: "Flu")
+        fhir = imm.to_fhir
+        assert_includes fhir.dig(:meta, :profile),
+          "http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization"
+      end
+
+      # -- FHIR CVX system ----------------------------------------------------
+
+      test "to_fhir includes CVX system in vaccine coding" do
+        imm = Immunization.new(ien: "1", vaccine_code: "141", vaccine_display: "Influenza")
+        fhir = imm.to_fhir
+        coding = fhir.dig(:vaccineCode, :coding, 0)
+        assert_equal "http://hl7.org/fhir/sid/cvx", coding[:system]
+      end
+
+      # -- FHIR occurrence datetime -------------------------------------------
+
+      test "to_fhir includes occurrenceDateTime" do
+        time = DateTime.new(2026, 1, 15, 10, 30)
+        imm = Immunization.new(ien: "1", patient_dfn: "100",
+          vaccine_display: "Flu", occurrence_datetime: time)
+        fhir = imm.to_fhir
+        assert_equal time.iso8601, fhir[:occurrenceDateTime]
+      end
+
+      # -- FHIR site and route ------------------------------------------------
+
+      test "to_fhir includes site and route" do
+        imm = Immunization.new(ien: "1", patient_dfn: "100",
+          vaccine_display: "Flu", site: "Left arm", route: "Intramuscular")
+        fhir = imm.to_fhir
+        assert_equal "Left arm", fhir.dig(:site, :text)
+        assert_equal "Intramuscular", fhir.dig(:route, :text)
+      end
+
+      # -- FHIR performer -----------------------------------------------------
+
+      test "has performer_duz attribute" do
+        imm = Immunization.new(performer_duz: "789", performer_name: "Nurse Smith")
+        assert_equal "789", imm.performer_duz
+        assert_equal "Nurse Smith", imm.performer_name
+      end
+
+      test "to_fhir includes performer" do
+        imm = Immunization.new(ien: "1", patient_dfn: "100",
+          vaccine_display: "Flu", performer_duz: "789", performer_name: "Nurse Smith")
+        fhir = imm.to_fhir
+        assert_equal 1, fhir[:performer].length
+        assert_equal "Practitioner/789", fhir[:performer].first.dig(:actor, :reference)
+      end
+
+      # -- VIS attributes ------------------------------------------------------
+
+      test "has VIS attributes" do
+        imm = Immunization.new(
+          ien: "1", patient_dfn: "100", vaccine_display: "Flu",
+          vis_edition_date: Date.new(2025, 8, 1),
+          vis_presentation_date: Date.new(2026, 1, 15),
+          vis_document_uri: "https://www.cdc.gov/vaccines/hcp/vis/vis-statements/flu.html"
+        )
+        assert_equal Date.new(2025, 8, 1), imm.vis_edition_date
+        assert_equal Date.new(2026, 1, 15), imm.vis_presentation_date
+        assert_equal "https://www.cdc.gov/vaccines/hcp/vis/vis-statements/flu.html", imm.vis_document_uri
+      end
+
+      # -- VFC eligibility attributes ------------------------------------------
+
+      test "has VFC eligibility attributes" do
+        imm = Immunization.new(
+          ien: "1", patient_dfn: "100", vaccine_display: "Flu",
+          vfc_eligibility_code: "V02", funding_source: "VFC"
+        )
+        assert_equal "V02", imm.vfc_eligibility_code
+        assert_equal "VFC", imm.funding_source
+      end
+
+      # -- FHIR education (VIS) -----------------------------------------------
+
+      test "to_fhir includes education element with VIS dates" do
+        imm = Immunization.new(
+          ien: "1", patient_dfn: "100", vaccine_display: "Flu",
+          vis_edition_date: Date.new(2025, 8, 1),
+          vis_presentation_date: Date.new(2026, 1, 15),
+          vis_document_uri: "https://www.cdc.gov/vaccines/hcp/vis/vis-statements/flu.html"
+        )
+        fhir = imm.to_fhir
+        assert_not_nil fhir[:education]
+        edu = fhir[:education].first
+        assert_equal "2025-08-01", edu[:publicationDate]
+        assert_equal "2026-01-15", edu[:presentationDate]
+        assert_equal "https://www.cdc.gov/vaccines/hcp/vis/vis-statements/flu.html", edu[:reference]
+      end
+
+      test "to_fhir omits education when no VIS data" do
+        imm = Immunization.new(ien: "1", patient_dfn: "100", vaccine_display: "Flu")
+        fhir = imm.to_fhir
+        assert_nil fhir[:education]
+      end
+
+      # -- FHIR programEligibility (VFC) --------------------------------------
+
+      test "to_fhir includes programEligibility with RPMS and HL7 codings" do
+        imm = Immunization.new(
+          ien: "1", patient_dfn: "100", vaccine_display: "Flu",
+          vfc_eligibility_code: "V02"
+        )
+        fhir = imm.to_fhir
+        assert_not_nil fhir[:programEligibility]
+        codings = fhir[:programEligibility].first[:coding]
+        assert_equal 2, codings.length
+
+        rpms_coding = codings.find { |c| c[:system].include?("ihs.gov") }
+        assert_equal "V02", rpms_coding[:code]
+
+        hl7_coding = codings.find { |c| c[:system].include?("hl7.org") }
+        assert_equal "eligible", hl7_coding[:code]
+      end
+
+      test "to_fhir maps V01 to ineligible in HL7 coding" do
+        imm = Immunization.new(
+          ien: "1", patient_dfn: "100", vaccine_display: "Flu",
+          vfc_eligibility_code: "V01"
+        )
+        fhir = imm.to_fhir
+        hl7_coding = fhir[:programEligibility].first[:coding].find { |c| c[:system].include?("hl7.org") }
+        assert_equal "ineligible", hl7_coding[:code]
+      end
+
+      test "to_fhir omits programEligibility when no eligibility code" do
+        imm = Immunization.new(ien: "1", patient_dfn: "100", vaccine_display: "Flu")
+        fhir = imm.to_fhir
+        assert_nil fhir[:programEligibility]
+      end
+
+      # -- FHIR fundingSource --------------------------------------------------
+
+      test "to_fhir includes fundingSource with RPMS and HL7 codings" do
+        imm = Immunization.new(
+          ien: "1", patient_dfn: "100", vaccine_display: "Flu",
+          funding_source: "VFC"
+        )
+        fhir = imm.to_fhir
+        assert_not_nil fhir[:fundingSource]
+        codings = fhir[:fundingSource][:coding]
+        assert_equal 2, codings.length
+
+        rpms_coding = codings.find { |c| c[:system].include?("ihs.gov") }
+        assert_equal "VFC", rpms_coding[:code]
+
+        hl7_coding = codings.find { |c| c[:system].include?("hl7.org") }
+        assert_equal "public", hl7_coding[:code]
+      end
+
+      test "to_fhir maps private funding to private in HL7 coding" do
+        imm = Immunization.new(
+          ien: "1", patient_dfn: "100", vaccine_display: "Flu",
+          funding_source: "private"
+        )
+        fhir = imm.to_fhir
+        hl7_coding = fhir[:fundingSource][:coding].find { |c| c[:system].include?("hl7.org") }
+        assert_equal "private", hl7_coding[:code]
+      end
+
+      test "to_fhir omits fundingSource when no funding data" do
+        imm = Immunization.new(ien: "1", patient_dfn: "100", vaccine_display: "Flu")
+        fhir = imm.to_fhir
+        assert_nil fhir[:fundingSource]
+      end
+
+      # -- persisted? and resource_class ---------------------------------------
+
+      test "persisted? returns true when ien present" do
+        imm = Immunization.new(ien: "123", patient_dfn: "100", vaccine_display: "Test")
+        assert imm.persisted?
+      end
+
+      test "persisted? returns false when ien blank" do
+        imm = Immunization.new(patient_dfn: "100", vaccine_display: "Test")
+        assert_not imm.persisted?
+      end
+
+      test "resource_class returns Immunization" do
+        assert_equal "Immunization", Immunization.resource_class
+      end
     end
   end
 end

--- a/test/models/lakeraven/ehr/location_test.rb
+++ b/test/models/lakeraven/ehr/location_test.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "ostruct"
 
 module Lakeraven
   module EHR
     class LocationTest < ActiveSupport::TestCase
+      # =============================================================================
+      # EXISTING TESTS (find_by_ien, persisted?, active?, to_fhir basics)
+      # =============================================================================
+
       test "find_by_ien returns Location for known IEN" do
         loc = Location.find_by_ien(1)
         assert_not_nil loc
@@ -78,6 +83,296 @@ module Lakeraven
         loc = Location.new(ien: 1, name: "Test", type: "clinic", division: "D1")
         assert_equal "clinic", loc.type
         assert_equal "D1", loc.division
+      end
+
+      # =============================================================================
+      # VALIDATION TESTS (ported from rpms_redux)
+      # =============================================================================
+
+      test "should be valid with required attributes" do
+        location = Location.new(name: "Test Location", location_type: "site")
+        assert location.valid?, "Location should be valid with name and type"
+      end
+
+      test "should require name" do
+        location = Location.new(location_type: "site")
+        refute location.valid?
+        assert_includes location.errors[:name], "can't be blank"
+      end
+
+      test "should validate location_type if present" do
+        location = Location.new(name: "Test", location_type: "invalid")
+        refute location.valid?
+        assert_includes location.errors[:location_type], "is not included in the list"
+      end
+
+      test "should allow blank location_type" do
+        location = Location.new(name: "Test")
+        assert location.valid?
+      end
+
+      test "should validate status if present" do
+        location = Location.new(name: "Test", status: "invalid")
+        refute location.valid?
+        assert_includes location.errors[:status], "is not included in the list"
+      end
+
+      test "should default status to active" do
+        location = Location.new(name: "Test")
+        assert_equal "active", location.status
+      end
+
+      test "should validate physical_type if present" do
+        location = Location.new(name: "Test", physical_type: "invalid")
+        refute location.valid?
+        assert_includes location.errors[:physical_type], "is not included in the list"
+      end
+
+      test "should validate ien if present and positive" do
+        location = Location.new(name: "Test", ien: 0)
+        refute location.valid?
+        assert_includes location.errors[:ien], "must be greater than 0"
+
+        location.ien = 100
+        assert location.valid?
+      end
+
+      # =============================================================================
+      # STATUS HELPER TESTS (ported from rpms_redux)
+      # =============================================================================
+
+      test "active? returns true for active status" do
+        location = Location.new(name: "Test", status: "active")
+        assert location.active?
+        refute location.suspended?
+        refute location.inactive?
+      end
+
+      test "suspended? returns true for suspended status" do
+        location = Location.new(name: "Test", status: "suspended")
+        assert location.suspended?
+        refute location.active?
+        refute location.inactive?
+      end
+
+      test "inactive? returns true for inactive status" do
+        location = Location.new(name: "Test", status: "inactive")
+        assert location.inactive?
+        refute location.active?
+        refute location.suspended?
+      end
+
+      test "available_for_scheduling? returns true only for active locations" do
+        location = Location.new(name: "Test", status: "active")
+        assert location.available_for_scheduling?
+
+        location.status = "suspended"
+        refute location.available_for_scheduling?
+
+        location.status = "inactive"
+        refute location.available_for_scheduling?
+      end
+
+      # =============================================================================
+      # TYPE HELPER TESTS (ported from rpms_redux)
+      # =============================================================================
+
+      test "type_display returns human-readable type" do
+        location = Location.new(name: "Test", location_type: "site")
+        assert_equal "Site", location.type_display
+
+        location.location_type = "building"
+        assert_equal "Building", location.type_display
+
+        location.location_type = "room"
+        assert_equal "Room", location.type_display
+
+        location.location_type = nil
+        assert_equal "Unknown", location.type_display
+      end
+
+      test "physical_type_display returns human-readable physical type" do
+        location = Location.new(name: "Test", physical_type: "bu")
+        assert_equal "Building", location.physical_type_display
+
+        location.physical_type = "ro"
+        assert_equal "Room", location.physical_type_display
+
+        location.physical_type = "si"
+        assert_equal "Site", location.physical_type_display
+
+        location.physical_type = nil
+        assert_equal "Unknown", location.physical_type_display
+      end
+
+      # =============================================================================
+      # ADDRESS HELPER TESTS (ported from rpms_redux)
+      # =============================================================================
+
+      test "full_address combines address parts" do
+        location = Location.new(
+          name: "Test",
+          address_line1: "123 Main St",
+          city: "Anchorage",
+          state: "AK",
+          zip_code: "99501"
+        )
+        assert_equal "123 Main St, Anchorage, AK, 99501", location.full_address
+      end
+
+      test "full_address handles missing parts" do
+        location = Location.new(name: "Test", city: "Anchorage", state: "AK")
+        assert_equal "Anchorage, AK", location.full_address
+
+        location = Location.new(name: "Test")
+        assert_equal "", location.full_address
+      end
+
+      # =============================================================================
+      # FHIR SERIALIZATION TESTS (ported from rpms_redux, hash-based)
+      # =============================================================================
+
+      test "to_fhir includes status" do
+        location = Location.new(ien: 100, name: "Test Clinic", status: "active")
+        fhir = location.to_fhir
+
+        assert_equal "active", fhir[:status]
+      end
+
+      test "to_fhir includes RPMS identifier" do
+        location = Location.new(ien: 100, name: "Test")
+        fhir = location.to_fhir
+
+        rpms_id = fhir[:identifier].find { |id| id[:system].include?("rpms") }
+        assert_not_nil rpms_id
+        assert_equal "100", rpms_id[:value]
+        assert_equal "usual", rpms_id[:use]
+      end
+
+      test "to_fhir includes type coding" do
+        location = Location.new(ien: 100, name: "Test", location_type: "site")
+        fhir = location.to_fhir
+
+        assert fhir[:type].any?
+        type = fhir[:type].first
+        coding = type[:coding].first
+        assert_equal "site", coding[:code]
+        assert_equal "Site", coding[:display]
+      end
+
+      test "to_fhir includes physical type" do
+        location = Location.new(ien: 100, name: "Test", physical_type: "bu")
+        fhir = location.to_fhir
+
+        assert_not_nil fhir[:physicalType]
+        coding = fhir[:physicalType][:coding].first
+        assert_equal "bu", coding[:code]
+        assert_equal "Building", coding[:display]
+      end
+
+      test "to_fhir includes address" do
+        location = Location.new(
+          ien: 100,
+          name: "Test",
+          address_line1: "123 Main St",
+          city: "Anchorage",
+          state: "AK",
+          zip_code: "99501"
+        )
+        fhir = location.to_fhir
+
+        assert_not_nil fhir[:address]
+        assert_equal "Anchorage", fhir[:address][:city]
+        assert_equal "AK", fhir[:address][:state]
+        assert_equal "99501", fhir[:address][:postalCode]
+      end
+
+      test "to_fhir includes telecom" do
+        location = Location.new(ien: 100, name: "Test", phone: "907-555-1234")
+        fhir = location.to_fhir
+
+        assert_equal 1, fhir[:telecom].count
+        phone = fhir[:telecom].first
+        assert_equal "phone", phone[:system]
+        assert_equal "907-555-1234", phone[:value]
+      end
+
+      test "to_fhir includes managing organization reference" do
+        location = Location.new(ien: 100, name: "Test", managing_organization_ien: 50)
+        fhir = location.to_fhir
+
+        assert_not_nil fhir[:managingOrganization]
+        assert fhir[:managingOrganization][:reference].include?("50")
+      end
+
+      test "resource_class returns Location" do
+        assert_equal "Location", Location.resource_class
+      end
+
+      test "from_fhir_attributes extracts attributes" do
+        fhir_resource = OpenStruct.new(
+          name: "FHIR Clinic",
+          status: "active",
+          type: [
+            OpenStruct.new(coding: [ OpenStruct.new(code: "site") ])
+          ],
+          physicalType: OpenStruct.new(
+            coding: [ OpenStruct.new(code: "bu") ]
+          ),
+          managingOrganization: OpenStruct.new(
+            reference: "Organization/rpms-organization-100"
+          )
+        )
+
+        attrs = Location.from_fhir_attributes(fhir_resource)
+        assert_equal "FHIR Clinic", attrs[:name]
+        assert_equal "active", attrs[:status]
+        assert_equal "site", attrs[:location_type]
+        assert_equal "bu", attrs[:physical_type]
+        assert_equal 100, attrs[:managing_organization_ien]
+      end
+
+      test "from_fhir creates location from FHIR resource" do
+        fhir_resource = OpenStruct.new(
+          name: "External Clinic",
+          status: "active",
+          type: [],
+          physicalType: nil,
+          managingOrganization: nil
+        )
+
+        location = Location.from_fhir(fhir_resource)
+        assert location.is_a?(Location)
+        assert_equal "External Clinic", location.name
+        assert_equal "active", location.status
+      end
+
+      # =============================================================================
+      # US CORE / TEFCA COMPLIANCE TESTS (ported from rpms_redux)
+      # =============================================================================
+
+      test "location FHIR is US Core compliant" do
+        location = Location.new(ien: 100, name: "US Core Compliant Location", status: "active")
+        fhir = location.to_fhir
+
+        assert fhir[:name].present?, "US Core requires name"
+        assert fhir[:status].present?, "Should have status"
+      end
+
+      test "location FHIR can be serialized to JSON" do
+        location = Location.new(
+          ien: 100,
+          name: "JSON Test",
+          location_type: "site",
+          status: "active"
+        )
+
+        json = nil
+        assert_nothing_raised do
+          json = location.to_fhir.to_json
+        end
+        parsed = JSON.parse(json)
+        assert_equal "Location", parsed["resourceType"]
       end
     end
   end

--- a/test/models/lakeraven/ehr/medication_request_test.rb
+++ b/test/models/lakeraven/ehr/medication_request_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "ostruct"
 
 module Lakeraven
   module EHR
@@ -68,6 +69,135 @@ module Lakeraven
         mr = MedicationRequest.new(ien: "1", dosage_instruction: "Take 5mg daily")
         fhir = mr.to_fhir
         assert_equal "Take 5mg daily", fhir[:dosageInstruction]&.first&.dig(:text)
+      end
+
+      # -- validations -----------------------------------------------------------
+
+      test "validates patient_dfn presence" do
+        mr = MedicationRequest.new(medication_display: "Lisinopril")
+        refute mr.valid?
+        assert_includes mr.errors[:patient_dfn], "can't be blank"
+      end
+
+      test "validates medication_display presence" do
+        mr = MedicationRequest.new(patient_dfn: "123")
+        refute mr.valid?
+        assert_includes mr.errors[:medication_display], "can't be blank"
+      end
+
+      test "validates status values" do
+        mr = MedicationRequest.new(patient_dfn: "123", medication_display: "Lisinopril", status: "invalid")
+        refute mr.valid?
+        assert_includes mr.errors[:status], "is not included in the list"
+      end
+
+      test "allows valid status values" do
+        %w[active on-hold cancelled completed stopped draft entered-in-error].each do |status|
+          mr = MedicationRequest.new(patient_dfn: "123", medication_display: "Lisinopril", status: status)
+          assert mr.valid?, "Expected #{status} to be valid"
+        end
+      end
+
+      test "validates intent values" do
+        mr = MedicationRequest.new(patient_dfn: "123", medication_display: "Lisinopril", intent: "invalid")
+        refute mr.valid?
+        assert_includes mr.errors[:intent], "is not included in the list"
+      end
+
+      # -- resource_class --------------------------------------------------------
+
+      test "resource_class returns MedicationRequest" do
+        assert_equal "MedicationRequest", MedicationRequest.resource_class
+      end
+
+      # -- persisted? ------------------------------------------------------------
+
+      test "persisted? true when ien present" do
+        mr = MedicationRequest.new(ien: "123", patient_dfn: "456", medication_display: "Test")
+        assert mr.persisted?
+      end
+
+      test "persisted? false when ien blank" do
+        mr = MedicationRequest.new(patient_dfn: "456", medication_display: "Test")
+        refute mr.persisted?
+      end
+
+      # -- to_fhir includes RxNorm system ----------------------------------------
+
+      test "to_fhir includes RxNorm code system" do
+        mr = MedicationRequest.new(ien: "1", medication_code: "29046", medication_display: "Lisinopril 10mg")
+        fhir = mr.to_fhir
+        coding = fhir.dig(:medicationCodeableConcept, :coding, 0)
+        assert coding[:system]&.include?("rxnorm")
+      end
+
+      # -- to_fhir includes intent -----------------------------------------------
+
+      test "to_fhir includes intent" do
+        mr = MedicationRequest.new(ien: "1", patient_dfn: "100", medication_display: "Lisinopril", intent: "order")
+        fhir = mr.to_fhir
+        assert_equal "order", fhir[:intent]
+      end
+
+      # -- to_fhir includes dosage with route and timing -------------------------
+
+      test "to_fhir includes dosage with route and timing" do
+        mr = MedicationRequest.new(
+          ien: "1", patient_dfn: "100", medication_display: "Lisinopril",
+          dosage_instruction: "Take 1 tablet by mouth daily",
+          route: "oral", frequency: "QD"
+        )
+        fhir = mr.to_fhir
+        instruction = fhir[:dosageInstruction]&.first
+        assert_equal "Take 1 tablet by mouth daily", instruction[:text]
+        assert_equal "oral", instruction.dig(:route, :text)
+        assert_equal "QD", instruction.dig(:timing, :code, :text)
+      end
+
+      # -- to_fhir includes dispense request -------------------------------------
+
+      test "to_fhir includes dispense request" do
+        mr = MedicationRequest.new(
+          ien: "1", patient_dfn: "100", medication_display: "Lisinopril",
+          dispense_quantity: 30, refills: 3, days_supply: 30
+        )
+        fhir = mr.to_fhir
+        dr = fhir[:dispenseRequest]
+        assert_equal 3, dr[:numberOfRepeatsAllowed]
+        assert_equal 30, dr.dig(:quantity, :value)
+        assert_equal 30, dr.dig(:expectedSupplyDuration, :value)
+        assert_equal "days", dr.dig(:expectedSupplyDuration, :unit)
+      end
+
+      # -- to_fhir includes requester reference ----------------------------------
+
+      test "to_fhir includes requester reference" do
+        mr = MedicationRequest.new(
+          ien: "1", patient_dfn: "100", medication_display: "Lisinopril",
+          requester_duz: "789", requester_name: "Dr. Smith"
+        )
+        fhir = mr.to_fhir
+        assert_equal "Practitioner/789", fhir.dig(:requester, :reference)
+        assert_equal "Dr. Smith", fhir.dig(:requester, :display)
+      end
+
+      # -- from_fhir_attributes --------------------------------------------------
+
+      test "from_fhir_attributes extracts attributes" do
+        fhir_resource = OpenStruct.new(
+          medicationCodeableConcept: OpenStruct.new(
+            coding: [OpenStruct.new(code: "29046", display: "Lisinopril 10mg")],
+            text: "Lisinopril 10mg"
+          ),
+          status: "active",
+          intent: "order"
+        )
+
+        attrs = MedicationRequest.from_fhir_attributes(fhir_resource)
+        assert_equal "29046", attrs[:medication_code]
+        assert_equal "Lisinopril 10mg", attrs[:medication_display]
+        assert_equal "active", attrs[:status]
+        assert_equal "order", attrs[:intent]
       end
     end
   end

--- a/test/models/lakeraven/ehr/medication_request_test.rb
+++ b/test/models/lakeraven/ehr/medication_request_test.rb
@@ -186,7 +186,7 @@ module Lakeraven
       test "from_fhir_attributes extracts attributes" do
         fhir_resource = OpenStruct.new(
           medicationCodeableConcept: OpenStruct.new(
-            coding: [OpenStruct.new(code: "29046", display: "Lisinopril 10mg")],
+            coding: [ OpenStruct.new(code: "29046", display: "Lisinopril 10mg") ],
             text: "Lisinopril 10mg"
           ),
           status: "active",

--- a/test/models/lakeraven/ehr/organization_test.rb
+++ b/test/models/lakeraven/ehr/organization_test.rb
@@ -272,7 +272,7 @@ module Lakeraven
             OpenStruct.new(system: "http://hl7.org/fhir/sid/us-npi", value: "9876543210")
           ],
           type: [
-            OpenStruct.new(coding: [OpenStruct.new(code: "prov")])
+            OpenStruct.new(coding: [ OpenStruct.new(code: "prov") ])
           ]
         )
 

--- a/test/models/lakeraven/ehr/organization_test.rb
+++ b/test/models/lakeraven/ehr/organization_test.rb
@@ -1,10 +1,101 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "ostruct"
 
 module Lakeraven
   module EHR
     class OrganizationTest < ActiveSupport::TestCase
+      # =============================================================================
+      # VALIDATION TESTS
+      # =============================================================================
+
+      test "should be valid with required attributes" do
+        org = Organization.new(name: "Test Organization", org_type: "prov")
+        assert org.valid?, "Organization should be valid with name and type"
+      end
+
+      test "should require name" do
+        org = Organization.new(org_type: "prov")
+        refute org.valid?
+        assert_includes org.errors[:name], "can't be blank"
+      end
+
+      test "should validate org_type if present" do
+        org = Organization.new(name: "Test", org_type: "invalid")
+        refute org.valid?
+        assert_includes org.errors[:org_type], "is not included in the list"
+      end
+
+      test "should allow blank org_type" do
+        org = Organization.new(name: "Test")
+        assert org.valid?
+      end
+
+      test "should validate NPI length if present" do
+        org = Organization.new(name: "Test", npi: "12345")
+        refute org.valid?
+        assert org.errors[:npi].any?
+
+        org.npi = "1234567890"
+        assert org.valid?
+      end
+
+      test "should allow blank NPI" do
+        org = Organization.new(name: "Test")
+        assert org.valid?
+      end
+
+      test "should validate ien if present and positive" do
+        org = Organization.new(name: "Test", ien: 0)
+        refute org.valid?
+        assert_includes org.errors[:ien], "must be greater than 0"
+
+        org.ien = 100
+        assert org.valid?
+      end
+
+      # =============================================================================
+      # TYPE HELPER TESTS
+      # =============================================================================
+
+      test "type_display returns human-readable type" do
+        org = Organization.new(name: "Test", org_type: "prov")
+        assert_equal "Healthcare Provider", org.type_display
+
+        org.org_type = "pay"
+        assert_equal "Payer", org.type_display
+
+        org.org_type = "govt"
+        assert_equal "Government", org.type_display
+
+        org.org_type = nil
+        assert_equal "Unknown", org.type_display
+      end
+
+      test "provider? returns true for prov type" do
+        org = Organization.new(name: "Test", org_type: "prov")
+        assert org.provider?
+        refute org.payer?
+        refute org.government?
+      end
+
+      test "payer? returns true for pay type" do
+        org = Organization.new(name: "Test", org_type: "pay")
+        assert org.payer?
+        refute org.provider?
+      end
+
+      test "government? returns true for govt type" do
+        org = Organization.new(name: "Test", org_type: "govt")
+        assert org.government?
+        refute org.provider?
+      end
+
+      # =============================================================================
+      # FIND / PERSISTENCE TESTS (existing)
+      # =============================================================================
+
       test "find_by_ien returns Organization for known IEN" do
         org = Organization.find_by_ien(1)
         assert_not_nil org
@@ -24,6 +115,10 @@ module Lakeraven
         refute Organization.new(name: "Test").persisted?
       end
 
+      # =============================================================================
+      # ADDRESS HELPER TESTS (existing)
+      # =============================================================================
+
       test "full_address combines parts" do
         org = Organization.new(address: "123 Main St", city: "Anchorage", state: "AK", zip_code: "99508")
         assert_equal "123 Main St, Anchorage, AK, 99508", org.full_address
@@ -33,6 +128,25 @@ module Lakeraven
         org = Organization.new(city: "Anchorage", state: "AK")
         assert_equal "Anchorage, AK", org.full_address
       end
+
+      test "full_address with all parts" do
+        org = Organization.new(address: "4315 Diplomacy Dr", city: "Anchorage", state: "AK", zip_code: "99508")
+        assert_equal "4315 Diplomacy Dr, Anchorage, AK, 99508", org.full_address
+      end
+
+      test "full_address with only city and state" do
+        org = Organization.new(city: "Fairbanks", state: "AK")
+        assert_equal "Fairbanks, AK", org.full_address
+      end
+
+      test "full_address with no parts" do
+        org = Organization.new
+        assert_equal "", org.full_address
+      end
+
+      # =============================================================================
+      # FHIR SERIALIZATION TESTS (existing)
+      # =============================================================================
 
       test "to_fhir returns Organization resource" do
         org = Organization.find_by_ien(1)
@@ -65,7 +179,173 @@ module Lakeraven
         assert fhir[:identifier]&.any?
       end
 
-      # -- edge cases ----------------------------------------------------------
+      test "to_fhir for organization without address" do
+        org = Organization.new(ien: 99, name: "Minimal Org")
+        fhir = org.to_fhir
+        assert_equal "Organization", fhir[:resourceType]
+        assert_equal "Minimal Org", fhir[:name]
+      end
+
+      # =============================================================================
+      # FHIR SERIALIZATION TESTS (new)
+      # =============================================================================
+
+      test "to_fhir includes NPI identifier" do
+        org = Organization.new(ien: 100, name: "Test", npi: "1234567890")
+        fhir = org.to_fhir
+
+        npi_id = fhir[:identifier].find { |id| id[:system]&.include?("npi") }
+        assert_not_nil npi_id
+        assert_equal "1234567890", npi_id[:value]
+        assert_equal "official", npi_id[:use]
+      end
+
+      test "to_fhir includes IEN identifier" do
+        org = Organization.new(ien: 100, name: "Test")
+        fhir = org.to_fhir
+
+        ien_id = fhir[:identifier].find { |id| id[:system]&.include?("rpms") || id[:system]&.include?("ihs") }
+        assert_not_nil ien_id
+        assert_equal "100", ien_id[:value]
+      end
+
+      test "to_fhir includes tax_id identifier" do
+        org = Organization.new(ien: 100, name: "Test", tax_id: "92-1234567")
+        fhir = org.to_fhir
+
+        tax_id = fhir[:identifier].find { |id| id[:value] == "92-1234567" }
+        assert_not_nil tax_id
+      end
+
+      test "to_fhir includes type coding" do
+        org = Organization.new(ien: 100, name: "Test", org_type: "prov")
+        fhir = org.to_fhir
+
+        assert fhir[:type]&.any?
+        type = fhir[:type].first
+        coding = type[:coding].first
+        assert_equal "prov", coding[:code]
+        assert_equal "Healthcare Provider", coding[:display]
+        assert_equal "http://terminology.hl7.org/CodeSystem/organization-type", coding[:system]
+      end
+
+      test "to_fhir includes partOf reference for parent" do
+        org = Organization.new(ien: 100, name: "Child Org", parent_organization_ien: 50)
+        fhir = org.to_fhir
+
+        assert_not_nil fhir[:partOf]
+        assert fhir[:partOf][:reference].include?("50")
+      end
+
+      test "to_fhir includes active status" do
+        org = Organization.new(ien: 100, name: "Test", active: true)
+        fhir = org.to_fhir
+
+        assert_equal true, fhir[:active]
+      end
+
+      test "to_fhir includes fax and email in telecom" do
+        org = Organization.new(
+          ien: 100, name: "Test",
+          phone: "907-555-1234", fax: "907-555-1235", email: "info@test.org"
+        )
+        fhir = org.to_fhir
+
+        assert_equal 3, fhir[:telecom].count
+        phone = fhir[:telecom].find { |t| t[:system] == "phone" }
+        assert_equal "907-555-1234", phone[:value]
+        fax = fhir[:telecom].find { |t| t[:system] == "fax" }
+        assert_equal "907-555-1235", fax[:value]
+        email = fhir[:telecom].find { |t| t[:system] == "email" }
+        assert_equal "info@test.org", email[:value]
+      end
+
+      test "resource_class returns Organization" do
+        assert_equal "Organization", Organization.resource_class
+      end
+
+      test "from_fhir_attributes extracts attributes" do
+        fhir_resource = OpenStruct.new(
+          name: "FHIR Hospital",
+          active: true,
+          identifier: [
+            OpenStruct.new(system: "http://hl7.org/fhir/sid/us-npi", value: "9876543210")
+          ],
+          type: [
+            OpenStruct.new(coding: [OpenStruct.new(code: "prov")])
+          ]
+        )
+
+        attrs = Organization.from_fhir_attributes(fhir_resource)
+        assert_equal "FHIR Hospital", attrs[:name]
+        assert_equal "9876543210", attrs[:npi]
+        assert_equal "prov", attrs[:org_type]
+        assert_equal true, attrs[:active]
+      end
+
+      test "from_fhir creates organization from FHIR resource" do
+        fhir_resource = OpenStruct.new(
+          name: "External Org",
+          active: true,
+          identifier: [],
+          type: []
+        )
+
+        org = Organization.from_fhir(fhir_resource)
+        assert org.is_a?(Organization)
+        assert_equal "External Org", org.name
+      end
+
+      # =============================================================================
+      # US CORE / TEFCA COMPLIANCE TESTS
+      # =============================================================================
+
+      test "organization FHIR is US Core compliant" do
+        org = Organization.new(
+          ien: 100, name: "US Core Compliant Org",
+          org_type: "prov", npi: "1234567890", active: true
+        )
+        fhir = org.to_fhir
+
+        assert fhir[:name].present?, "US Core requires name"
+        assert fhir[:identifier]&.any?, "US Core should have identifier"
+      end
+
+      test "organization with NPI ready for QHIN exchange" do
+        org = Organization.new(
+          ien: 100, name: "QHIN Exchange Org",
+          org_type: "prov", npi: "1234567890"
+        )
+        fhir = org.to_fhir
+
+        npi_id = fhir[:identifier].find { |id| id[:system]&.include?("npi") }
+        assert_not_nil npi_id, "NPI required for QHIN exchange"
+        assert_equal 10, npi_id[:value].length
+      end
+
+      test "organization FHIR can be serialized to JSON" do
+        org = Organization.new(
+          ien: 100, name: "JSON Test",
+          org_type: "prov", npi: "1234567890"
+        )
+
+        assert_nothing_raised do
+          org.to_fhir.to_json
+        end
+      end
+
+      # =============================================================================
+      # HIERARCHY TESTS
+      # =============================================================================
+
+      test "parent_organization returns nil when not set" do
+        org = Organization.new(name: "Standalone")
+        assert_nil org.parent_organization
+      end
+
+      # =============================================================================
+      # EDGE CASES (existing)
+      # =============================================================================
 
       test "find_by_ien returns nil for nil" do
         assert_nil Organization.find_by_ien(nil)
@@ -75,31 +355,9 @@ module Lakeraven
         assert_nil Organization.find_by_ien(0)
       end
 
-      test "full_address with all parts" do
-        org = Organization.new(address: "4315 Diplomacy Dr", city: "Anchorage", state: "AK", zip_code: "99508")
-        assert_equal "4315 Diplomacy Dr, Anchorage, AK, 99508", org.full_address
-      end
-
-      test "full_address with only city and state" do
-        org = Organization.new(city: "Fairbanks", state: "AK")
-        assert_equal "Fairbanks, AK", org.full_address
-      end
-
-      test "full_address with no parts" do
-        org = Organization.new
-        assert_equal "", org.full_address
-      end
-
       test "to_param returns IEN string" do
         org = Organization.new(ien: 1, name: "Test")
         assert_equal "1", org.to_param
-      end
-
-      test "to_fhir for organization without address" do
-        org = Organization.new(ien: 99, name: "Minimal Org")
-        fhir = org.to_fhir
-        assert_equal "Organization", fhir[:resourceType]
-        assert_equal "Minimal Org", fhir[:name]
       end
     end
   end

--- a/test/models/lakeraven/ehr/patient_test.rb
+++ b/test/models/lakeraven/ehr/patient_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "ostruct"
 
 module Lakeraven
   module EHR
@@ -291,6 +292,70 @@ module Lakeraven
       test "tribal_enrollment_valid? false without enrollment number" do
         patient = Patient.new(dfn: 1, name: "DOE,JOHN", sex: "M")
         refute patient.tribal_enrollment_valid?
+      end
+
+      # -- from_fhir_attributes (ported from rpms_redux) -------------------------
+
+      test "from_fhir_attributes parses FHIR resource" do
+        fhir = OpenStruct.new(
+          name: [ OpenStruct.new(family: "Parser", given: [ "Test", "Middle" ]) ],
+          gender: "female",
+          birthDate: "1990-05-15",
+          identifier: [ OpenStruct.new(system: "http://hl7.org/fhir/sid/us-ssn", value: "555-55-5555") ]
+        )
+        attrs = Patient.from_fhir_attributes(fhir)
+        assert_equal "Parser,Test Middle", attrs[:name]
+        assert_equal "F", attrs[:sex]
+        assert_equal Date.parse("1990-05-15"), attrs[:dob]
+        assert_equal "555-55-5555", attrs[:ssn]
+      end
+
+      test "from_fhir_attributes handles missing name" do
+        fhir = OpenStruct.new(name: [], gender: "male", birthDate: nil, identifier: [])
+        attrs = Patient.from_fhir_attributes(fhir)
+        assert_nil attrs[:name]
+        assert_equal "M", attrs[:sex]
+      end
+
+      # -- FHIR US Core / TEFCA (ported from rpms_redux) -------------------------
+
+      test "to_fhir includes tribal enrollment extension for TEFCA" do
+        patient = Patient.new(dfn: 1, name: "TEST,TEFCA", sex: "M",
+                              tribal_enrollment_number: "ANLC-12345")
+        fhir = patient.to_fhir
+        extensions = fhir[:extension] || []
+        tribal_ext = extensions.find { |e| e[:url]&.include?("tribal") }
+        assert tribal_ext, "TEFCA requires tribal enrollment extension"
+      end
+
+      test "to_fhir supports US Core Patient profile requirements" do
+        patient = Patient.find_by_dfn(1)
+        fhir = patient.to_fhir
+
+        assert fhir[:identifier]&.any?, "US Core requires identifier"
+        assert fhir[:name]&.any?, "US Core requires name"
+        assert fhir[:gender].present?, "US Core requires gender"
+        assert fhir[:birthDate].present?, "US Core requires birthDate"
+
+        extensions = fhir[:extension] || []
+        race_ext = extensions.find { |e| e[:url]&.include?("race") }
+        assert race_ext, "US Core requires race extension"
+      end
+
+      test "to_fhir ready for QHIN exchange" do
+        patient = Patient.find_by_dfn(1)
+        fhir = patient.to_fhir
+
+        assert_equal "Patient", fhir[:resourceType]
+        assert fhir[:id].present?, "QHIN requires resource ID"
+        assert fhir[:identifier]&.any?, "QHIN requires identifiers"
+      end
+
+      # -- providers association (ported from rpms_redux) ------------------------
+
+      test "providers returns empty array when no service requests" do
+        patient = Patient.new(dfn: 99999, name: "NOREFS,PATIENT", sex: "M")
+        assert_equal [], patient.providers
       end
     end
   end

--- a/test/models/lakeraven/ehr/practitioner_role_test.rb
+++ b/test/models/lakeraven/ehr/practitioner_role_test.rb
@@ -1,10 +1,23 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "ostruct"
 
 module Lakeraven
   module EHR
     class PractitionerRoleTest < ActiveSupport::TestCase
+      # =========================================================================
+      # HELPERS
+      # =========================================================================
+
+      def valid_attributes
+        { practitioner_ien: 101, organization_ien: 100 }
+      end
+
+      # =========================================================================
+      # ATTRIBUTE TESTS
+      # =========================================================================
+
       test "has practitioner and organization references" do
         pr = PractitionerRole.new(practitioner_ien: 101, organization_ien: 1, role: "doctor", specialty: "Cardiology")
         assert_equal 101, pr.practitioner_ien
@@ -14,6 +27,76 @@ module Lakeraven
       test "defaults to active" do
         assert PractitionerRole.new.active?
       end
+
+      # =========================================================================
+      # VALIDATION TESTS
+      # =========================================================================
+
+      test "valid with required attributes" do
+        pr = PractitionerRole.new(valid_attributes)
+        assert pr.valid?, "PractitionerRole should be valid: #{pr.errors.full_messages}"
+      end
+
+      test "requires practitioner_ien" do
+        pr = PractitionerRole.new(valid_attributes.merge(practitioner_ien: nil))
+        refute pr.valid?
+        assert pr.errors[:practitioner_ien].any?
+      end
+
+      test "requires organization_ien" do
+        pr = PractitionerRole.new(valid_attributes.merge(organization_ien: nil))
+        refute pr.valid?
+        assert pr.errors[:organization_ien].any?
+      end
+
+      test "validates practitioner_ien is positive" do
+        pr = PractitionerRole.new(valid_attributes.merge(practitioner_ien: 0))
+        refute pr.valid?
+        assert pr.errors[:practitioner_ien].any?
+      end
+
+      test "validates organization_ien is positive" do
+        pr = PractitionerRole.new(valid_attributes.merge(organization_ien: 0))
+        refute pr.valid?
+        assert pr.errors[:organization_ien].any?
+      end
+
+      test "validates role if present" do
+        pr = PractitionerRole.new(valid_attributes.merge(role: "invalid"))
+        refute pr.valid?
+        assert_includes pr.errors[:role], "is not included in the list"
+      end
+
+      test "allows blank role" do
+        pr = PractitionerRole.new(valid_attributes)
+        assert pr.valid?
+      end
+
+      # =========================================================================
+      # STATUS HELPER TESTS
+      # =========================================================================
+
+      test "active? returns true for active roles" do
+        pr = PractitionerRole.new(valid_attributes.merge(active: true))
+        assert pr.active?
+      end
+
+      test "active? returns false for inactive roles" do
+        pr = PractitionerRole.new(valid_attributes.merge(active: false))
+        refute pr.active?
+      end
+
+      test "valid_for_scheduling? checks active and period" do
+        pr = PractitionerRole.new(valid_attributes.merge(active: true))
+        assert pr.valid_for_scheduling?
+
+        pr.active = false
+        refute pr.valid_for_scheduling?
+      end
+
+      # =========================================================================
+      # PERIOD TESTS
+      # =========================================================================
 
       test "within_period? true when no dates" do
         assert PractitionerRole.new.within_period?
@@ -28,6 +111,52 @@ module Lakeraven
         pr = PractitionerRole.new(period_start: 2.years.ago, period_end: 1.year.ago)
         refute pr.within_period?
       end
+
+      test "within_period? true when end_date in future" do
+        pr = PractitionerRole.new(period_start: 1.month.ago, period_end: 1.month.from_now)
+        assert pr.within_period?
+      end
+
+      test "within_period? false when end_date in past" do
+        pr = PractitionerRole.new(period_start: 2.years.ago, period_end: 1.year.ago)
+        refute pr.within_period?
+      end
+
+      test "within_period? true when only start_date" do
+        pr = PractitionerRole.new(period_start: 1.year.ago)
+        assert pr.within_period?
+      end
+
+      test "within_period? false when before period start" do
+        pr = PractitionerRole.new(valid_attributes.merge(period_start: Date.current + 1.month))
+        refute pr.within_period?
+      end
+
+      # =========================================================================
+      # ROLE DISPLAY TESTS
+      # =========================================================================
+
+      test "role_display capitalizes role" do
+        pr = PractitionerRole.new(role: "nurse")
+        assert_equal "Nurse", pr.role_display
+      end
+
+      test "role_display returns Unknown for nil" do
+        pr = PractitionerRole.new(role: nil)
+        assert_equal "Unknown", pr.role_display
+      end
+
+      test "role_display returns mapped display values" do
+        pr = PractitionerRole.new(role: "doctor")
+        assert_equal "Doctor", pr.role_display
+
+        pr.role = "pharmacist"
+        assert_equal "Pharmacist", pr.role_display
+      end
+
+      # =========================================================================
+      # FHIR SERIALIZATION TESTS
+      # =========================================================================
 
       test "to_fhir returns PractitionerRole resource" do
         pr = PractitionerRole.new(practitioner_ien: 101, organization_ien: 1, role: "doctor", active: true)
@@ -52,37 +181,111 @@ module Lakeraven
         pr = PractitionerRole.new(practitioner_ien: 101, specialty: "Cardiology")
         fhir = pr.to_fhir
         assert fhir[:specialty]&.any?
+        assert_equal "Cardiology", fhir[:specialty].first[:text]
       end
 
       test "to_fhir includes code for role" do
         pr = PractitionerRole.new(practitioner_ien: 101, role: "doctor")
         fhir = pr.to_fhir
         assert fhir[:code]&.any?
+        code = fhir[:code].first
+        assert_equal "doctor", code.dig(:coding, 0, :code)
+        assert_equal "Doctor", code.dig(:coding, 0, :display)
       end
 
-      test "within_period? true when end_date in future" do
-        pr = PractitionerRole.new(period_start: 1.month.ago, period_end: 1.month.from_now)
-        assert pr.within_period?
+      test "to_fhir includes location references" do
+        pr = PractitionerRole.new(valid_attributes.merge(location_iens: [ 200, 201 ]))
+        fhir = pr.to_fhir
+        assert_equal 2, fhir[:location].count
+        refs = fhir[:location].map { |l| l[:reference] }
+        assert refs.any? { |r| r.include?("200") }
+        assert refs.any? { |r| r.include?("201") }
       end
 
-      test "within_period? false when end_date in past" do
-        pr = PractitionerRole.new(period_start: 2.years.ago, period_end: 1.year.ago)
-        refute pr.within_period?
+      test "to_fhir includes period" do
+        pr = PractitionerRole.new(valid_attributes.merge(
+          period_start: Date.parse("2024-01-01"),
+          period_end: Date.parse("2024-12-31")
+        ))
+        fhir = pr.to_fhir
+        assert_not_nil fhir[:period]
+        assert_equal "2024-01-01", fhir[:period][:start]
+        assert_equal "2024-12-31", fhir[:period][:end]
       end
 
-      test "within_period? true when only start_date" do
-        pr = PractitionerRole.new(period_start: 1.year.ago)
-        assert pr.within_period?
+      test "to_fhir handles empty location_iens" do
+        pr = PractitionerRole.new(valid_attributes.merge(location_iens: []))
+        fhir = pr.to_fhir
+        assert_equal [], fhir[:location]
       end
 
-      test "role_display capitalizes role" do
-        pr = PractitionerRole.new(role: "nurse")
-        assert_equal "Nurse", pr.role_display
+      test "to_fhir handles nil period dates" do
+        pr = PractitionerRole.new(valid_attributes.merge(period_start: nil, period_end: nil))
+        fhir = pr.to_fhir
+        assert_nil fhir[:period]
       end
 
-      test "role_display handles nil" do
-        pr = PractitionerRole.new(role: nil)
-        assert_nil pr.role_display
+      test "resource_class returns PractitionerRole" do
+        assert_equal "PractitionerRole", PractitionerRole.resource_class
+      end
+
+      test "from_fhir_attributes extracts attributes" do
+        fhir_resource = OpenStruct.new(
+          active: true,
+          practitioner: OpenStruct.new(reference: "Practitioner/101"),
+          organization: OpenStruct.new(reference: "Organization/100"),
+          specialty: [ OpenStruct.new(text: "Family Medicine") ],
+          period: OpenStruct.new(start: "2024-01-01", end: "2024-12-31")
+        )
+
+        attrs = PractitionerRole.from_fhir_attributes(fhir_resource)
+        assert_equal 101, attrs[:practitioner_ien]
+        assert_equal 100, attrs[:organization_ien]
+        assert_equal "Family Medicine", attrs[:specialty]
+        assert_equal true, attrs[:active]
+        assert_equal Date.parse("2024-01-01"), attrs[:period_start]
+        assert_equal Date.parse("2024-12-31"), attrs[:period_end]
+      end
+
+      test "from_fhir creates practitioner role from FHIR resource" do
+        fhir_resource = OpenStruct.new(
+          active: true,
+          practitioner: OpenStruct.new(reference: "Practitioner/101"),
+          organization: OpenStruct.new(reference: "Organization/100"),
+          specialty: [],
+          period: nil
+        )
+
+        pr = PractitionerRole.from_fhir(fhir_resource)
+        assert pr.is_a?(PractitionerRole)
+        assert_equal 101, pr.practitioner_ien
+        assert_equal 100, pr.organization_ien
+      end
+
+      # =========================================================================
+      # US CORE / TEFCA COMPLIANCE TESTS
+      # =========================================================================
+
+      test "FHIR is US Core compliant with practitioner and organization" do
+        pr = PractitionerRole.new(valid_attributes.merge(
+          specialty: "Family Medicine", role: "doctor", active: true
+        ))
+        fhir = pr.to_fhir
+        assert fhir[:practitioner].present?, "US Core requires practitioner reference"
+        assert fhir[:organization].present?, "Should have organization reference"
+      end
+
+      test "supports external specialist lookup via FHIR" do
+        pr = PractitionerRole.new(valid_attributes.merge(specialty: "Cardiology"))
+        fhir = pr.to_fhir
+        assert fhir[:practitioner].present?
+        assert fhir[:organization].present?
+        assert fhir[:specialty]&.any?, "Specialty helps with specialist matching"
+      end
+
+      test "can be serialized to JSON" do
+        pr = PractitionerRole.new(valid_attributes.merge(specialty: "Cardiology"))
+        assert_nothing_raised { pr.as_json }
       end
     end
   end

--- a/test/models/lakeraven/ehr/practitioner_test.rb
+++ b/test/models/lakeraven/ehr/practitioner_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "ostruct"
 
 module Lakeraven
   module EHR
@@ -187,6 +188,186 @@ module Lakeraven
         prac = Practitioner.new(name: "DOE,JOHN MICHAEL")
         assert_equal "Doe", prac.last_name
         assert_equal "John michael", prac.first_name
+      end
+
+      # -- resource_class --------------------------------------------------------
+
+      test "resource_class returns Practitioner" do
+        assert_equal "Practitioner", Practitioner.resource_class
+      end
+
+      # -- from_fhir_attributes --------------------------------------------------
+
+      test "from_fhir_attributes extracts attributes from FHIR resource" do
+        fhir_resource = OpenStruct.new(
+          name: [OpenStruct.new(family: "SMITH", given: ["JANE", "M"])],
+          identifier: [
+            OpenStruct.new(system: "http://hl7.org/fhir/sid/us-npi", value: "9876543210")
+          ],
+          qualification: [
+            OpenStruct.new(code: OpenStruct.new(text: "EMERGENCY MEDICINE"))
+          ]
+        )
+
+        attributes = Practitioner.from_fhir_attributes(fhir_resource)
+
+        assert_equal "SMITH, JANE M", attributes[:name]
+        assert_equal "9876543210", attributes[:npi]
+        assert_equal "EMERGENCY MEDICINE", attributes[:specialty]
+      end
+
+      test "from_fhir_attributes handles missing data" do
+        fhir_resource = OpenStruct.new(
+          name: [OpenStruct.new(family: "DOE")],
+          identifier: [],
+          qualification: []
+        )
+
+        attributes = Practitioner.from_fhir_attributes(fhir_resource)
+
+        assert_equal "DOE", attributes[:name]
+        assert_nil attributes[:npi]
+        assert_nil attributes[:specialty]
+      end
+
+      # -- FHIR parsing helpers --------------------------------------------------
+
+      test "extract_name_from_fhir handles family and given names" do
+        fhir_resource = OpenStruct.new(
+          name: [OpenStruct.new(family: "DOE", given: ["JOHN", "MICHAEL"])]
+        )
+        assert_equal "DOE, JOHN MICHAEL", Practitioner.extract_name_from_fhir(fhir_resource)
+      end
+
+      test "extract_name_from_fhir handles family name only" do
+        fhir_resource = OpenStruct.new(
+          name: [OpenStruct.new(family: "DOE", given: nil)]
+        )
+        assert_equal "DOE", Practitioner.extract_name_from_fhir(fhir_resource)
+      end
+
+      test "extract_name_from_fhir handles empty names" do
+        assert_nil Practitioner.extract_name_from_fhir(OpenStruct.new(name: []))
+        assert_nil Practitioner.extract_name_from_fhir(OpenStruct.new(name: nil))
+      end
+
+      test "extract_npi_from_fhir finds NPI identifier" do
+        fhir_resource = OpenStruct.new(
+          identifier: [
+            OpenStruct.new(system: "http://ihs.gov/rpms/provider-id", value: "101"),
+            OpenStruct.new(system: "http://hl7.org/fhir/sid/us-npi", value: "1234567890"),
+            OpenStruct.new(system: "other-system", value: "other-value")
+          ]
+        )
+        assert_equal "1234567890", Practitioner.extract_npi_from_fhir(fhir_resource)
+      end
+
+      test "extract_npi_from_fhir returns nil when no NPI" do
+        fhir_resource = OpenStruct.new(
+          identifier: [OpenStruct.new(system: "other-system", value: "other-value")]
+        )
+        assert_nil Practitioner.extract_npi_from_fhir(fhir_resource)
+      end
+
+      test "extract_npi_from_fhir returns nil for empty identifiers" do
+        assert_nil Practitioner.extract_npi_from_fhir(OpenStruct.new(identifier: []))
+      end
+
+      test "extract_specialty_from_fhir finds specialty" do
+        fhir_resource = OpenStruct.new(
+          qualification: [OpenStruct.new(code: OpenStruct.new(text: "CARDIOLOGY"))]
+        )
+        assert_equal "CARDIOLOGY", Practitioner.extract_specialty_from_fhir(fhir_resource)
+      end
+
+      test "extract_specialty_from_fhir returns nil for empty qualifications" do
+        assert_nil Practitioner.extract_specialty_from_fhir(OpenStruct.new(qualification: []))
+        assert_nil Practitioner.extract_specialty_from_fhir(OpenStruct.new(qualification: nil))
+      end
+
+      # -- to_fhir missing optional data -----------------------------------------
+
+      test "to_fhir handles missing optional data" do
+        prac = Practitioner.new(
+          ien: 999,
+          name: "BARE,MINIMUM",
+          npi: nil,
+          dea_number: nil,
+          specialty: nil,
+          service_section: nil,
+          title: nil,
+          phone: nil
+        )
+        fhir = prac.to_fhir
+
+        assert_equal "Practitioner", fhir[:resourceType]
+        # Only RPMS ID when no NPI
+        rpms_ids = fhir[:identifier]&.select { |id| id[:system]&.include?("rpms") }
+        assert rpms_ids&.any?, "Should have RPMS identifier"
+        npi_ids = fhir[:identifier]&.select { |id| id[:system]&.include?("npi") } || []
+        assert_empty npi_ids, "Should not have NPI identifier"
+        assert_empty(fhir[:qualification] || [])
+        assert_empty(fhir[:telecom] || [])
+      end
+
+      # -- can_prescribe_controlled? with empty string ---------------------------
+
+      test "can_prescribe_controlled? false with empty string" do
+        prac = Practitioner.new(dea_number: "")
+        refute prac.can_prescribe_controlled?
+      end
+
+      # -- persisted? with zero IEN ----------------------------------------------
+
+      test "persisted? false with zero IEN" do
+        prac = Practitioner.new(ien: 0, name: "TEST,DOC")
+        refute prac.persisted?
+      end
+
+      # -- unicode and edge cases ------------------------------------------------
+
+      test "handles unicode characters in names" do
+        prac = Practitioner.new(name: "GARCIA,JOSE")
+        assert_equal "JOSE GARCIA", prac.display_name
+      end
+
+      test "handles very long names" do
+        long_name = "A" * 100 + "," + "B" * 100
+        prac = Practitioner.new(name: long_name)
+        assert prac.display_name.length > 200
+      end
+
+      # -- FHIR includes RPMS identifier -----------------------------------------
+
+      test "to_fhir includes RPMS identifier for provenance" do
+        prac = Practitioner.new(ien: 101, name: "DOE,JOHN", npi: "2222222222")
+        fhir = prac.to_fhir
+
+        rpms_id = fhir[:identifier]&.find { |id| id[:system]&.include?("rpms") }
+        npi_id = fhir[:identifier]&.find { |id| id[:system]&.include?("npi") }
+
+        assert_not_nil rpms_id, "Should have RPMS identifier"
+        assert_not_nil npi_id, "Should have NPI identifier"
+      end
+
+      # -- to_fhir includes given names ------------------------------------------
+
+      test "to_fhir includes given names" do
+        prac = Practitioner.new(ien: 101, name: "DOE,JOHN MICHAEL")
+        fhir = prac.to_fhir
+
+        name = fhir[:name]&.first
+        assert_equal "DOE", name[:family]
+        assert_includes name[:given], "JOHN"
+      end
+
+      test "to_fhir includes US Core profile" do
+        prac = Practitioner.new(ien: 101, name: "DOE,JOHN")
+        fhir = prac.to_fhir
+
+        assert fhir[:meta][:profile].include?(
+          "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+        )
       end
     end
   end

--- a/test/models/lakeraven/ehr/practitioner_test.rb
+++ b/test/models/lakeraven/ehr/practitioner_test.rb
@@ -200,7 +200,7 @@ module Lakeraven
 
       test "from_fhir_attributes extracts attributes from FHIR resource" do
         fhir_resource = OpenStruct.new(
-          name: [OpenStruct.new(family: "SMITH", given: ["JANE", "M"])],
+          name: [ OpenStruct.new(family: "SMITH", given: [ "JANE", "M" ]) ],
           identifier: [
             OpenStruct.new(system: "http://hl7.org/fhir/sid/us-npi", value: "9876543210")
           ],
@@ -218,7 +218,7 @@ module Lakeraven
 
       test "from_fhir_attributes handles missing data" do
         fhir_resource = OpenStruct.new(
-          name: [OpenStruct.new(family: "DOE")],
+          name: [ OpenStruct.new(family: "DOE") ],
           identifier: [],
           qualification: []
         )
@@ -234,14 +234,14 @@ module Lakeraven
 
       test "extract_name_from_fhir handles family and given names" do
         fhir_resource = OpenStruct.new(
-          name: [OpenStruct.new(family: "DOE", given: ["JOHN", "MICHAEL"])]
+          name: [ OpenStruct.new(family: "DOE", given: [ "JOHN", "MICHAEL" ]) ]
         )
         assert_equal "DOE, JOHN MICHAEL", Practitioner.extract_name_from_fhir(fhir_resource)
       end
 
       test "extract_name_from_fhir handles family name only" do
         fhir_resource = OpenStruct.new(
-          name: [OpenStruct.new(family: "DOE", given: nil)]
+          name: [ OpenStruct.new(family: "DOE", given: nil) ]
         )
         assert_equal "DOE", Practitioner.extract_name_from_fhir(fhir_resource)
       end
@@ -264,7 +264,7 @@ module Lakeraven
 
       test "extract_npi_from_fhir returns nil when no NPI" do
         fhir_resource = OpenStruct.new(
-          identifier: [OpenStruct.new(system: "other-system", value: "other-value")]
+          identifier: [ OpenStruct.new(system: "other-system", value: "other-value") ]
         )
         assert_nil Practitioner.extract_npi_from_fhir(fhir_resource)
       end
@@ -275,7 +275,7 @@ module Lakeraven
 
       test "extract_specialty_from_fhir finds specialty" do
         fhir_resource = OpenStruct.new(
-          qualification: [OpenStruct.new(code: OpenStruct.new(text: "CARDIOLOGY"))]
+          qualification: [ OpenStruct.new(code: OpenStruct.new(text: "CARDIOLOGY")) ]
         )
         assert_equal "CARDIOLOGY", Practitioner.extract_specialty_from_fhir(fhir_resource)
       end

--- a/test/models/lakeraven/ehr/procedure_test.rb
+++ b/test/models/lakeraven/ehr/procedure_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "ostruct"
 
 module Lakeraven
   module EHR
@@ -55,6 +56,117 @@ module Lakeraven
         fhir = p.to_fhir
         assert_equal "27447", fhir.dig(:code, :coding, 0, :code)
         assert_equal "Total knee replacement", fhir.dig(:code, :text)
+      end
+
+      # -- validations -----------------------------------------------------------
+
+      test "validates patient_dfn presence" do
+        p = Procedure.new(display: "Office visit")
+        refute p.valid?
+        assert_includes p.errors[:patient_dfn], "can't be blank"
+      end
+
+      test "validates display presence" do
+        p = Procedure.new(patient_dfn: "123")
+        refute p.valid?
+        assert_includes p.errors[:display], "can't be blank"
+      end
+
+      test "validates status values" do
+        p = Procedure.new(patient_dfn: "123", display: "Office visit", status: "invalid")
+        refute p.valid?
+        assert_includes p.errors[:status], "is not included in the list"
+      end
+
+      test "allows valid status values" do
+        %w[preparation in-progress not-done on-hold stopped completed entered-in-error unknown].each do |status|
+          p = Procedure.new(patient_dfn: "123", display: "Office visit", status: status)
+          assert p.valid?, "Expected #{status} to be valid"
+        end
+      end
+
+      # -- resource_class --------------------------------------------------------
+
+      test "resource_class returns Procedure" do
+        assert_equal "Procedure", Procedure.resource_class
+      end
+
+      # -- persisted? ------------------------------------------------------------
+
+      test "persisted? true when ien present" do
+        p = Procedure.new(ien: "123", patient_dfn: "456", display: "Test")
+        assert p.persisted?
+      end
+
+      test "persisted? false when ien blank" do
+        p = Procedure.new(patient_dfn: "456", display: "Test")
+        refute p.persisted?
+      end
+
+      # -- to_fhir code system URLs ----------------------------------------------
+
+      test "to_fhir includes CPT code system URL" do
+        p = Procedure.new(ien: "1", patient_dfn: "100", code: "99213", code_system: "cpt", display: "Office visit")
+        fhir = p.to_fhir
+        coding = fhir.dig(:code, :coding, 0)
+        assert_equal "http://www.ama-assn.org/go/cpt", coding[:system]
+      end
+
+      test "to_fhir includes SNOMED code system URL" do
+        p = Procedure.new(ien: "1", patient_dfn: "100", code: "71388002", code_system: "snomed", display: "Colonoscopy")
+        fhir = p.to_fhir
+        coding = fhir.dig(:code, :coding, 0)
+        assert_equal "http://snomed.info/sct", coding[:system]
+      end
+
+      # -- to_fhir includes performed_datetime -----------------------------------
+
+      test "to_fhir includes performed_datetime" do
+        dt = DateTime.new(2026, 1, 15, 10, 30)
+        p = Procedure.new(ien: "1", patient_dfn: "100", display: "Office visit", performed_datetime: dt)
+        fhir = p.to_fhir
+        assert_equal dt.iso8601, fhir[:performedDateTime]
+      end
+
+      # -- to_fhir includes performer -------------------------------------------
+
+      test "to_fhir includes performer" do
+        p = Procedure.new(
+          ien: "1", patient_dfn: "100", display: "Office visit",
+          performer_duz: "789", performer_name: "Dr. Smith"
+        )
+        fhir = p.to_fhir
+        assert fhir[:performer]&.any?
+        assert_equal "Practitioner/789", fhir[:performer].first.dig(:actor, :reference)
+      end
+
+      # -- to_fhir includes location --------------------------------------------
+
+      test "to_fhir includes location" do
+        p = Procedure.new(
+          ien: "1", patient_dfn: "100", display: "Office visit",
+          location_ien: "999", location_name: "Main Clinic"
+        )
+        fhir = p.to_fhir
+        assert_equal "Location/999", fhir.dig(:location, :reference)
+        assert_equal "Main Clinic", fhir.dig(:location, :display)
+      end
+
+      # -- from_fhir_attributes --------------------------------------------------
+
+      test "from_fhir_attributes extracts attributes" do
+        fhir_resource = OpenStruct.new(
+          code: OpenStruct.new(
+            coding: [OpenStruct.new(code: "99213", display: "Office visit")],
+            text: "Office visit"
+          ),
+          status: "completed"
+        )
+
+        attrs = Procedure.from_fhir_attributes(fhir_resource)
+        assert_equal "99213", attrs[:code]
+        assert_equal "Office visit", attrs[:display]
+        assert_equal "completed", attrs[:status]
       end
     end
   end

--- a/test/models/lakeraven/ehr/procedure_test.rb
+++ b/test/models/lakeraven/ehr/procedure_test.rb
@@ -157,7 +157,7 @@ module Lakeraven
       test "from_fhir_attributes extracts attributes" do
         fhir_resource = OpenStruct.new(
           code: OpenStruct.new(
-            coding: [OpenStruct.new(code: "99213", display: "Office visit")],
+            coding: [ OpenStruct.new(code: "99213", display: "Office visit") ],
             text: "Office visit"
           ),
           status: "completed"


### PR DESCRIPTION
## Summary

TDD port of 13 clinical models. Tests written first (red), then model code implemented (green).

| Model | Before | After |
|-------|--------|-------|
| Patient | 43 | 49 |
| Practitioner | 30 | 49 |
| PractitionerRole | 15 | 37 |
| ServiceRequest | 26 | 65 |
| Location | 14 | 42 |
| Organization | 17 | 42 |
| DocumentReference | 18 | 53 |
| Encounter | 31 | 44 |
| Coverage | 26 | 42 |
| Immunization | 16 | 39 |
| Condition | 17 | 31 |
| Procedure | 8 | 21 |
| MedicationRequest | 10 | 24 |
| CoverageEligibilityResponse | 22 | 37 |
| AuditEvent | 17 | 46 |
| CurrentUser | 0 | 24 |

900 minitest, 180 cucumber. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)