### PR TITLE
DI gateway rollout: all 12 clinical models injectable

### DIFF
--- a/app/models/lakeraven/ehr/allergy_intolerance.rb
+++ b/app/models/lakeraven/ehr/allergy_intolerance.rb
@@ -16,8 +16,18 @@ module Lakeraven
       attribute :category, :string
       attribute :criticality, :string
 
+      # -- Gateway DI -----------------------------------------------------------
+
+      class << self
+        attr_writer :gateway
+
+        def gateway
+          @gateway || AllergyIntoleranceGateway
+        end
+      end
+
       def self.for_patient(dfn)
-        AllergyIntoleranceGateway.for_patient(dfn)
+        gateway.for_patient(dfn)
       end
 
       def active? = clinical_status == "active"

--- a/app/models/lakeraven/ehr/condition.rb
+++ b/app/models/lakeraven/ehr/condition.rb
@@ -39,8 +39,18 @@ module Lakeraven
       validates :category, inclusion: { in: VALID_CATEGORIES, allow_blank: true }
       validates :code_system, inclusion: { in: VALID_CODE_SYSTEMS, allow_blank: true }
 
+      # -- Gateway DI -----------------------------------------------------------
+
+      class << self
+        attr_writer :gateway
+
+        def gateway
+          @gateway || ConditionGateway
+        end
+      end
+
       def self.for_patient(dfn)
-        ConditionGateway.for_patient(dfn)
+        gateway.for_patient(dfn)
       end
 
       def self.resource_class

--- a/app/models/lakeraven/ehr/encounter.rb
+++ b/app/models/lakeraven/ehr/encounter.rb
@@ -44,6 +44,20 @@ module Lakeraven
       validates :status, inclusion: { in: VALID_STATUSES }
       validates :class_code, inclusion: { in: VALID_CLASS_CODES }
 
+      # -- Gateway DI -----------------------------------------------------------
+
+      class << self
+        attr_writer :gateway
+
+        def gateway
+          @gateway || EncounterGateway
+        end
+      end
+
+      def self.for_patient(dfn)
+        gateway.for_patient(dfn)
+      end
+
       # -- Display helpers ---------------------------------------------------
 
       def status_display = STATUS_DISPLAY[status]

--- a/app/models/lakeraven/ehr/immunization.rb
+++ b/app/models/lakeraven/ehr/immunization.rb
@@ -38,8 +38,18 @@ module Lakeraven
         allow_blank: true
       }
 
+      # -- Gateway DI -----------------------------------------------------------
+
+      class << self
+        attr_writer :gateway
+
+        def gateway
+          @gateway || ImmunizationGateway
+        end
+      end
+
       def self.for_patient(dfn)
-        ImmunizationGateway.for_patient(dfn)
+        gateway.for_patient(dfn)
       end
 
       def self.resource_class

--- a/app/models/lakeraven/ehr/location.rb
+++ b/app/models/lakeraven/ehr/location.rb
@@ -59,10 +59,20 @@ module Lakeraven
       validates :physical_type, inclusion: { in: PHYSICAL_TYPES.keys }, allow_blank: true
       validate :ien_valid_if_present
 
+      # -- Gateway DI -----------------------------------------------------------
+
+      class << self
+        attr_writer :gateway
+
+        def gateway
+          @gateway || LocationGateway
+        end
+      end
+
       def self.find_by_ien(ien)
         return nil unless ien.present? && ien.to_i > 0
 
-        attrs = LocationGateway.find(ien.to_i)
+        attrs = gateway.find(ien.to_i)
         attrs ? new(**attrs) : nil
       end
 

--- a/app/models/lakeraven/ehr/medication_request.rb
+++ b/app/models/lakeraven/ehr/medication_request.rb
@@ -33,8 +33,18 @@ module Lakeraven
       validates :status, inclusion: { in: VALID_STATUSES, allow_blank: true }
       validates :intent, inclusion: { in: VALID_INTENTS, allow_blank: true }
 
+      # -- Gateway DI -----------------------------------------------------------
+
+      class << self
+        attr_writer :gateway
+
+        def gateway
+          @gateway || MedicationRequestGateway
+        end
+      end
+
       def self.for_patient(dfn)
-        MedicationRequestGateway.for_patient(dfn)
+        gateway.for_patient(dfn)
       end
 
       def self.resource_class

--- a/app/models/lakeraven/ehr/observation.rb
+++ b/app/models/lakeraven/ehr/observation.rb
@@ -17,8 +17,18 @@ module Lakeraven
       attribute :status, :string
       attribute :effective_datetime, :datetime
 
+      # -- Gateway DI -----------------------------------------------------------
+
+      class << self
+        attr_writer :gateway
+
+        def gateway
+          @gateway || ObservationGateway
+        end
+      end
+
       def self.for_patient(dfn)
-        ObservationGateway.for_patient(dfn)
+        gateway.for_patient(dfn)
       end
 
       def vital_sign? = category == "vital-signs"

--- a/app/models/lakeraven/ehr/organization.rb
+++ b/app/models/lakeraven/ehr/organization.rb
@@ -42,6 +42,16 @@ module Lakeraven
       validates :npi, length: { is: 10 }, allow_blank: true
       validate :ien_valid_if_present
 
+      # -- Gateway DI -----------------------------------------------------------
+
+      class << self
+        attr_writer :gateway
+
+        def gateway
+          @gateway || OrganizationGateway
+        end
+      end
+
       # =============================================================================
       # FIND
       # =============================================================================
@@ -49,7 +59,7 @@ module Lakeraven
       def self.find_by_ien(ien)
         return nil unless ien.present? && ien.to_i > 0
 
-        attrs = OrganizationGateway.find(ien.to_i)
+        attrs = gateway.find(ien.to_i)
         attrs ? new(**attrs) : nil
       end
 

--- a/app/models/lakeraven/ehr/practitioner.rb
+++ b/app/models/lakeraven/ehr/practitioner.rb
@@ -21,16 +21,66 @@ module Lakeraven
       attribute :first_name, :string
       attribute :last_name, :string
 
+      class RecordNotFound < StandardError; end
+
+      # -- Gateway DI --------------------------------------------------------
+
+      class << self
+        attr_writer :gateway
+
+        def gateway
+          @gateway || PractitionerGateway
+        end
+      end
+
       # -- Class methods -----------------------------------------------------
+
+      def self.find(ien)
+        practitioner = find_by_ien(ien)
+        raise RecordNotFound, "Couldn't find Practitioner with 'ien'=#{ien}" unless practitioner
+
+        practitioner
+      end
 
       def self.find_by_ien(ien)
         return nil unless ien.present? && ien.to_i.positive?
 
-        PractitionerGateway.find(ien.to_i)
+        gateway.find(ien.to_i)
       end
 
       def self.search(name_pattern)
-        PractitionerGateway.search(name_pattern.to_s)
+        gateway.search(name_pattern.to_s)
+      end
+
+      def self.create(attributes = {})
+        new(attributes).tap(&:save)
+      end
+
+      def self.create!(attributes = {})
+        new(attributes).tap(&:save!)
+      end
+
+      # -- Persistence -------------------------------------------------------
+
+      def save
+        return false unless valid?
+
+        if persisted?
+          true
+        else
+          result = self.class.gateway.register(persistable_attributes)
+          if result[:success]
+            self.ien = result[:ien]
+            true
+          else
+            errors.add(:base, result[:error] || "Registration failed")
+            false
+          end
+        end
+      end
+
+      def save!
+        save || raise(ActiveModel::ValidationError.new(self))
       end
 
       # -- Initialize --------------------------------------------------------
@@ -113,7 +163,20 @@ module Lakeraven
         FHIR::PractitionerSerializer.call(self)
       end
 
+      # -- Validations (for save) ----------------------------------------------
+
+      validates :name, presence: true, if: -> { first_name.blank? && last_name.blank? }
+
       private
+
+      def persistable_attributes
+        {
+          name: name, first_name: first_name, last_name: last_name,
+          npi: npi, dea_number: dea_number, specialty: specialty,
+          provider_class: provider_class, title: title,
+          service_section: service_section, phone: phone
+        }.compact
+      end
 
       def sync_composite_fields
         self.name = "#{last_name},#{first_name}" if first_name.present? && last_name.present? && name.blank?

--- a/app/models/lakeraven/ehr/procedure.rb
+++ b/app/models/lakeraven/ehr/procedure.rb
@@ -29,8 +29,18 @@ module Lakeraven
       validates :display, presence: true
       validates :status, inclusion: { in: VALID_STATUSES, allow_blank: true }
 
+      # -- Gateway DI -----------------------------------------------------------
+
+      class << self
+        attr_writer :gateway
+
+        def gateway
+          @gateway || ProcedureGateway
+        end
+      end
+
       def self.for_patient(dfn)
-        ProcedureGateway.for_patient(dfn)
+        gateway.for_patient(dfn)
       end
 
       def self.resource_class

--- a/app/models/lakeraven/ehr/service_request.rb
+++ b/app/models/lakeraven/ehr/service_request.rb
@@ -34,6 +34,18 @@ module Lakeraven
       attribute :completed_on, :date
       attribute :notes, :string
 
+      class RecordNotFound < StandardError; end
+
+      # -- Gateway DI --------------------------------------------------------
+
+      class << self
+        attr_writer :gateway
+
+        def gateway
+          @gateway || ServiceRequestGateway
+        end
+      end
+
       def persisted?
         ien.present? && ien.to_i.positive?
       end
@@ -71,7 +83,38 @@ module Lakeraven
       end
 
       def self.for_patient(dfn)
-        ServiceRequestGateway.for_patient(dfn)
+        gateway.for_patient(dfn)
+      end
+
+      def self.create(attributes = {})
+        new(attributes).tap(&:save)
+      end
+
+      def self.create!(attributes = {})
+        new(attributes).tap(&:save!)
+      end
+
+      # -- Persistence -------------------------------------------------------
+
+      def save
+        return false unless valid?
+
+        if persisted?
+          true
+        else
+          result = self.class.gateway.register(persistable_attributes)
+          if result[:success]
+            self.ien = result[:ien]
+            true
+          else
+            errors.add(:base, result[:error] || "Registration failed")
+            false
+          end
+        end
+      end
+
+      def save!
+        save || raise(ActiveModel::ValidationError.new(self))
       end
 
       # -- Urgency predicates ------------------------------------------------
@@ -137,6 +180,18 @@ module Lakeraven
       end
 
       private
+
+      def persistable_attributes
+        {
+          patient_dfn: patient_dfn, requesting_provider_ien: requesting_provider_ien,
+          service_requested: service_requested, reason_for_referral: reason_for_referral,
+          urgency: urgency, status: status, referral_type: referral_type,
+          performer_name: performer_name, identifier: identifier,
+          estimated_cost: estimated_cost, diagnosis_codes: diagnosis_codes,
+          procedure_codes: procedure_codes, medical_priority_level: medical_priority_level,
+          appointment_on: appointment_on, completed_on: completed_on, notes: notes
+        }.compact
+      end
 
       def map_status_to_fhir
         if completed? then "completed"

--- a/test/models/lakeraven/ehr/allergy_intolerance_test.rb
+++ b/test/models/lakeraven/ehr/allergy_intolerance_test.rb
@@ -57,6 +57,34 @@ module Lakeraven
         assert_kind_of Array, results
       end
 
+      # -- Gateway DI ----------------------------------------------------------
+
+      test "gateway is configurable" do
+        assert AllergyIntolerance.respond_to?(:gateway)
+        assert AllergyIntolerance.respond_to?(:gateway=)
+      end
+
+      test "gateway defaults to AllergyIntoleranceGateway" do
+        assert_equal AllergyIntoleranceGateway, AllergyIntolerance.gateway
+      end
+
+      test "for_patient delegates to gateway" do
+        mock_gw = Object.new
+        def mock_gw.for_patient(_dfn)
+          [ Lakeraven::EHR::AllergyIntolerance.new(ien: "99", allergen: "MOCK") ]
+        end
+
+        original = AllergyIntolerance.gateway
+        begin
+          AllergyIntolerance.gateway = mock_gw
+          results = AllergyIntolerance.for_patient(1)
+          assert_equal 1, results.length
+          assert_equal "MOCK", results.first.allergen
+        ensure
+          AllergyIntolerance.gateway = original
+        end
+      end
+
       # -- FHIR serialization --------------------------------------------------
 
       test "to_fhir returns AllergyIntolerance resource" do

--- a/test/models/lakeraven/ehr/condition_test.rb
+++ b/test/models/lakeraven/ehr/condition_test.rb
@@ -74,6 +74,34 @@ module Lakeraven
         assert_kind_of Array, results
       end
 
+      # -- Gateway DI ----------------------------------------------------------
+
+      test "gateway is configurable" do
+        assert Condition.respond_to?(:gateway)
+        assert Condition.respond_to?(:gateway=)
+      end
+
+      test "gateway defaults to ConditionGateway" do
+        assert_equal ConditionGateway, Condition.gateway
+      end
+
+      test "for_patient delegates to gateway" do
+        mock_gw = Object.new
+        def mock_gw.for_patient(_dfn)
+          [ Lakeraven::EHR::Condition.new(ien: "99", patient_dfn: "1", display: "MOCK") ]
+        end
+
+        original = Condition.gateway
+        begin
+          Condition.gateway = mock_gw
+          results = Condition.for_patient(1)
+          assert_equal 1, results.length
+          assert_equal "MOCK", results.first.display
+        ensure
+          Condition.gateway = original
+        end
+      end
+
       # -- FHIR serialization --------------------------------------------------
 
       test "to_fhir returns Condition resource" do

--- a/test/models/lakeraven/ehr/encounter_test.rb
+++ b/test/models/lakeraven/ehr/encounter_test.rb
@@ -169,6 +169,36 @@ module Lakeraven
       end
 
       # =============================================================================
+      # GATEWAY DI
+      # =============================================================================
+
+      test "gateway is configurable" do
+        assert Encounter.respond_to?(:gateway)
+        assert Encounter.respond_to?(:gateway=)
+      end
+
+      test "gateway defaults to EncounterGateway" do
+        assert_equal EncounterGateway, Encounter.gateway
+      end
+
+      test "for_patient delegates to gateway" do
+        mock_gw = Object.new
+        def mock_gw.for_patient(_dfn)
+          [ Lakeraven::EHR::Encounter.new(status: "finished", class_code: "AMB") ]
+        end
+
+        original = Encounter.gateway
+        begin
+          Encounter.gateway = mock_gw
+          results = Encounter.for_patient(1)
+          assert_equal 1, results.length
+          assert results.first.finished?
+        ensure
+          Encounter.gateway = original
+        end
+      end
+
+      # =============================================================================
       # FHIR SERIALIZATION
       # =============================================================================
 

--- a/test/models/lakeraven/ehr/immunization_test.rb
+++ b/test/models/lakeraven/ehr/immunization_test.rb
@@ -70,6 +70,34 @@ module Lakeraven
         assert_kind_of Array, results
       end
 
+      # -- Gateway DI ----------------------------------------------------------
+
+      test "gateway is configurable" do
+        assert Immunization.respond_to?(:gateway)
+        assert Immunization.respond_to?(:gateway=)
+      end
+
+      test "gateway defaults to ImmunizationGateway" do
+        assert_equal ImmunizationGateway, Immunization.gateway
+      end
+
+      test "for_patient delegates to gateway" do
+        mock_gw = Object.new
+        def mock_gw.for_patient(_dfn)
+          [ Lakeraven::EHR::Immunization.new(ien: "99", patient_dfn: "1", vaccine_display: "MOCK") ]
+        end
+
+        original = Immunization.gateway
+        begin
+          Immunization.gateway = mock_gw
+          results = Immunization.for_patient(1)
+          assert_equal 1, results.length
+          assert_equal "MOCK", results.first.vaccine_display
+        ensure
+          Immunization.gateway = original
+        end
+      end
+
       # -- FHIR serialization --------------------------------------------------
 
       test "to_fhir returns Immunization resource" do

--- a/test/models/lakeraven/ehr/location_test.rb
+++ b/test/models/lakeraven/ehr/location_test.rb
@@ -86,6 +86,36 @@ module Lakeraven
       end
 
       # =============================================================================
+      # GATEWAY DI
+      # =============================================================================
+
+      test "gateway is configurable" do
+        assert Location.respond_to?(:gateway)
+        assert Location.respond_to?(:gateway=)
+      end
+
+      test "gateway defaults to LocationGateway" do
+        assert_equal LocationGateway, Location.gateway
+      end
+
+      test "find_by_ien delegates to gateway" do
+        mock_gw = Object.new
+        def mock_gw.find(ien)
+          { ien: ien, name: "MOCK CLINIC" }
+        end
+
+        original = Location.gateway
+        begin
+          Location.gateway = mock_gw
+          loc = Location.find_by_ien(42)
+          assert_equal "MOCK CLINIC", loc.name
+          assert_equal 42, loc.ien
+        ensure
+          Location.gateway = original
+        end
+      end
+
+      # =============================================================================
       # VALIDATION TESTS (ported from rpms_redux)
       # =============================================================================
 

--- a/test/models/lakeraven/ehr/medication_request_test.rb
+++ b/test/models/lakeraven/ehr/medication_request_test.rb
@@ -71,6 +71,34 @@ module Lakeraven
         assert_equal "Take 5mg daily", fhir[:dosageInstruction]&.first&.dig(:text)
       end
 
+      # -- Gateway DI ----------------------------------------------------------
+
+      test "gateway is configurable" do
+        assert MedicationRequest.respond_to?(:gateway)
+        assert MedicationRequest.respond_to?(:gateway=)
+      end
+
+      test "gateway defaults to MedicationRequestGateway" do
+        assert_equal MedicationRequestGateway, MedicationRequest.gateway
+      end
+
+      test "for_patient delegates to gateway" do
+        mock_gw = Object.new
+        def mock_gw.for_patient(_dfn)
+          [ Lakeraven::EHR::MedicationRequest.new(ien: "99", patient_dfn: "1", medication_display: "MOCK") ]
+        end
+
+        original = MedicationRequest.gateway
+        begin
+          MedicationRequest.gateway = mock_gw
+          results = MedicationRequest.for_patient(1)
+          assert_equal 1, results.length
+          assert_equal "MOCK", results.first.medication_display
+        ensure
+          MedicationRequest.gateway = original
+        end
+      end
+
       # -- validations -----------------------------------------------------------
 
       test "validates patient_dfn presence" do

--- a/test/models/lakeraven/ehr/observation_test.rb
+++ b/test/models/lakeraven/ehr/observation_test.rb
@@ -44,6 +44,34 @@ module Lakeraven
         assert_kind_of Array, results
       end
 
+      # -- Gateway DI ----------------------------------------------------------
+
+      test "gateway is configurable" do
+        assert Observation.respond_to?(:gateway)
+        assert Observation.respond_to?(:gateway=)
+      end
+
+      test "gateway defaults to ObservationGateway" do
+        assert_equal ObservationGateway, Observation.gateway
+      end
+
+      test "for_patient delegates to gateway" do
+        mock_gw = Object.new
+        def mock_gw.for_patient(_dfn)
+          [ Lakeraven::EHR::Observation.new(ien: "99", display: "MOCK BP") ]
+        end
+
+        original = Observation.gateway
+        begin
+          Observation.gateway = mock_gw
+          results = Observation.for_patient(1)
+          assert_equal 1, results.length
+          assert_equal "MOCK BP", results.first.display
+        ensure
+          Observation.gateway = original
+        end
+      end
+
       test "to_fhir returns Observation resource" do
         obs = Observation.new(ien: "42", patient_dfn: "100", status: "final")
         fhir = obs.to_fhir

--- a/test/models/lakeraven/ehr/organization_test.rb
+++ b/test/models/lakeraven/ehr/organization_test.rb
@@ -93,6 +93,36 @@ module Lakeraven
       end
 
       # =============================================================================
+      # GATEWAY DI
+      # =============================================================================
+
+      test "gateway is configurable" do
+        assert Organization.respond_to?(:gateway)
+        assert Organization.respond_to?(:gateway=)
+      end
+
+      test "gateway defaults to OrganizationGateway" do
+        assert_equal OrganizationGateway, Organization.gateway
+      end
+
+      test "find_by_ien delegates to gateway" do
+        mock_gw = Object.new
+        def mock_gw.find(ien)
+          { ien: ien, name: "MOCK ORG" }
+        end
+
+        original = Organization.gateway
+        begin
+          Organization.gateway = mock_gw
+          org = Organization.find_by_ien(42)
+          assert_equal "MOCK ORG", org.name
+          assert_equal 42, org.ien
+        ensure
+          Organization.gateway = original
+        end
+      end
+
+      # =============================================================================
       # FIND / PERSISTENCE TESTS (existing)
       # =============================================================================
 

--- a/test/models/lakeraven/ehr/practitioner_test.rb
+++ b/test/models/lakeraven/ehr/practitioner_test.rb
@@ -369,6 +369,153 @@ module Lakeraven
           "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
         )
       end
+      # =========================================================================
+      # DEPENDENCY INJECTION (gateway pattern)
+      # =========================================================================
+
+      test "gateway is configurable" do
+        assert Practitioner.respond_to?(:gateway)
+        assert Practitioner.respond_to?(:gateway=)
+      end
+
+      test "gateway defaults to PractitionerGateway" do
+        assert_equal PractitionerGateway, Practitioner.gateway
+      end
+
+      test "gateway can be swapped for testing" do
+        mock_gw = Object.new
+        def mock_gw.find(ien)
+          Lakeraven::EHR::Practitioner.new(ien: ien, name: "MOCK,DOCTOR", specialty: "Testing")
+        end
+
+        original = Practitioner.gateway
+        begin
+          Practitioner.gateway = mock_gw
+          prac = Practitioner.find_by_ien(42)
+          assert_equal "MOCK,DOCTOR", prac.name
+          assert_equal 42, prac.ien
+        ensure
+          Practitioner.gateway = original
+        end
+      end
+
+      test "search delegates to gateway" do
+        mock_gw = Object.new
+        def mock_gw.search(pattern)
+          [ Lakeraven::EHR::Practitioner.new(ien: 1, name: "DOE,JOHN") ]
+        end
+
+        original = Practitioner.gateway
+        begin
+          Practitioner.gateway = mock_gw
+          results = Practitioner.search("DOE")
+          assert_equal 1, results.length
+          assert_equal "DOE,JOHN", results.first.name
+        ensure
+          Practitioner.gateway = original
+        end
+      end
+
+      # =========================================================================
+      # PERSISTENCE VIA DI GATEWAY
+      # =========================================================================
+
+      class MockPractitionerGateway
+        attr_reader :registered
+
+        def initialize
+          @store = {}
+          @next_ien = 9000
+          @registered = []
+        end
+
+        def find(ien)
+          @store[ien]
+        end
+
+        def search(pattern)
+          @store.values.select { |p| p.name.to_s.upcase.include?(pattern.to_s.upcase) }
+        end
+
+        def register(attrs)
+          @next_ien += 1
+          prac = Lakeraven::EHR::Practitioner.new(**attrs.merge(ien: @next_ien))
+          @store[@next_ien] = prac
+          @registered << prac
+          { success: true, ien: @next_ien }
+        end
+      end
+
+      def with_mock_gateway
+        mock = MockPractitionerGateway.new
+        original = Practitioner.gateway
+        Practitioner.gateway = mock
+        yield mock
+      ensure
+        Practitioner.gateway = original
+      end
+
+      test "save persists a new practitioner via gateway" do
+        with_mock_gateway do |gw|
+          prac = Practitioner.new(first_name: "Sarah", last_name: "Martinez", specialty: "Cardiology")
+          assert prac.save
+          assert prac.persisted?
+          assert prac.ien.present?
+          assert_equal 1, gw.registered.length
+        end
+      end
+
+      test "save returns false for invalid practitioner" do
+        with_mock_gateway do |_gw|
+          prac = Practitioner.new # no name, no first/last
+          refute prac.save
+          refute prac.persisted?
+        end
+      end
+
+      test "save! raises on validation failure" do
+        with_mock_gateway do |_gw|
+          prac = Practitioner.new
+          assert_raises(ActiveModel::ValidationError) { prac.save! }
+        end
+      end
+
+      test "create returns persisted practitioner" do
+        with_mock_gateway do |_gw|
+          prac = Practitioner.create(first_name: "Jane", last_name: "Smith", specialty: "Radiology")
+          assert prac.is_a?(Practitioner)
+          assert prac.persisted?
+          assert_equal "Jane", prac.first_name
+        end
+      end
+
+      test "create! returns persisted practitioner" do
+        with_mock_gateway do |_gw|
+          prac = Practitioner.create!(first_name: "Bob", last_name: "Jones", specialty: "Oncology")
+          assert prac.persisted?
+          assert_equal "Bob", prac.first_name
+        end
+      end
+
+      test "create! raises on validation failure" do
+        with_mock_gateway do |_gw|
+          assert_raises(ActiveModel::ValidationError) { Practitioner.create! }
+        end
+      end
+
+      test "find via gateway returns practitioner" do
+        with_mock_gateway do |_gw|
+          created = Practitioner.create!(first_name: "Find", last_name: "Test", specialty: "GP")
+          found = Practitioner.find(created.ien)
+          assert_equal created.ien, found.ien
+        end
+      end
+
+      test "find via mock gateway raises RecordNotFound for unknown IEN" do
+        with_mock_gateway do |_gw|
+          assert_raises(Practitioner::RecordNotFound) { Practitioner.find(99999) }
+        end
+      end
     end
   end
 end

--- a/test/models/lakeraven/ehr/procedure_test.rb
+++ b/test/models/lakeraven/ehr/procedure_test.rb
@@ -58,6 +58,34 @@ module Lakeraven
         assert_equal "Total knee replacement", fhir.dig(:code, :text)
       end
 
+      # -- Gateway DI ----------------------------------------------------------
+
+      test "gateway is configurable" do
+        assert Procedure.respond_to?(:gateway)
+        assert Procedure.respond_to?(:gateway=)
+      end
+
+      test "gateway defaults to ProcedureGateway" do
+        assert_equal ProcedureGateway, Procedure.gateway
+      end
+
+      test "for_patient delegates to gateway" do
+        mock_gw = Object.new
+        def mock_gw.for_patient(_dfn)
+          [ Lakeraven::EHR::Procedure.new(ien: "99", patient_dfn: "1", display: "MOCK") ]
+        end
+
+        original = Procedure.gateway
+        begin
+          Procedure.gateway = mock_gw
+          results = Procedure.for_patient(1)
+          assert_equal 1, results.length
+          assert_equal "MOCK", results.first.display
+        ensure
+          Procedure.gateway = original
+        end
+      end
+
       # -- validations -----------------------------------------------------------
 
       test "validates patient_dfn presence" do

--- a/test/models/lakeraven/ehr/service_request_test.rb
+++ b/test/models/lakeraven/ehr/service_request_test.rb
@@ -435,6 +435,141 @@ module Lakeraven
         assert_kind_of Array, results
         assert_equal 0, results.length
       end
+
+      # =========================================================================
+      # DEPENDENCY INJECTION (gateway pattern)
+      # =========================================================================
+
+      test "gateway is configurable" do
+        assert ServiceRequest.respond_to?(:gateway)
+        assert ServiceRequest.respond_to?(:gateway=)
+      end
+
+      test "gateway defaults to ServiceRequestGateway" do
+        assert_equal ServiceRequestGateway, ServiceRequest.gateway
+      end
+
+      test "gateway can be swapped for testing" do
+        mock_gw = Object.new
+        def mock_gw.for_patient(dfn)
+          [ Lakeraven::EHR::ServiceRequest.new(ien: 1, patient_dfn: dfn, service_requested: "MOCK", requesting_provider_ien: 1) ]
+        end
+
+        original = ServiceRequest.gateway
+        begin
+          ServiceRequest.gateway = mock_gw
+          results = ServiceRequest.for_patient(42)
+          assert_equal 1, results.length
+          assert_equal 42, results.first.patient_dfn
+        ensure
+          ServiceRequest.gateway = original
+        end
+      end
+
+      # =========================================================================
+      # PERSISTENCE VIA DI GATEWAY
+      # =========================================================================
+
+      class MockServiceRequestGateway
+        attr_reader :registered
+
+        def initialize
+          @store = {}
+          @next_ien = 9000
+          @registered = []
+        end
+
+        def find(ien)
+          @store[ien]
+        end
+
+        def for_patient(dfn)
+          @store.values.select { |sr| sr.patient_dfn == dfn }
+        end
+
+        def register(attrs)
+          @next_ien += 1
+          sr = Lakeraven::EHR::ServiceRequest.new(**attrs.merge(ien: @next_ien))
+          @store[@next_ien] = sr
+          @registered << sr
+          { success: true, ien: @next_ien }
+        end
+      end
+
+      def with_mock_gateway
+        mock = MockServiceRequestGateway.new
+        original = ServiceRequest.gateway
+        ServiceRequest.gateway = mock
+        yield mock
+      ensure
+        ServiceRequest.gateway = original
+      end
+
+      test "save persists a new service request via gateway" do
+        with_mock_gateway do |gw|
+          sr = ServiceRequest.new(valid_sr_attributes)
+          assert sr.save
+          assert sr.persisted?
+          assert sr.ien.present?
+          assert_equal 1, gw.registered.length
+        end
+      end
+
+      test "save sets ien from gateway response" do
+        with_mock_gateway do |_gw|
+          sr = ServiceRequest.new(valid_sr_attributes)
+          sr.save
+          assert sr.ien > 0
+        end
+      end
+
+      test "save returns false for invalid service request" do
+        with_mock_gateway do |_gw|
+          sr = ServiceRequest.new(patient_dfn: nil, requesting_provider_ien: nil, service_requested: nil)
+          refute sr.save
+          refute sr.persisted?
+        end
+      end
+
+      test "save! raises on validation failure" do
+        with_mock_gateway do |_gw|
+          sr = ServiceRequest.new(patient_dfn: nil)
+          assert_raises(ActiveModel::ValidationError) { sr.save! }
+        end
+      end
+
+      test "create returns persisted service request" do
+        with_mock_gateway do |_gw|
+          sr = ServiceRequest.create(valid_sr_attributes)
+          assert sr.is_a?(ServiceRequest)
+          assert sr.persisted?
+          assert_equal "Cardiology consult", sr.service_requested
+        end
+      end
+
+      test "create! returns persisted service request" do
+        with_mock_gateway do |_gw|
+          sr = ServiceRequest.create!(valid_sr_attributes)
+          assert sr.persisted?
+        end
+      end
+
+      test "create! raises on validation failure" do
+        with_mock_gateway do |_gw|
+          assert_raises(ActiveModel::ValidationError) { ServiceRequest.create!(patient_dfn: nil) }
+        end
+      end
+
+      test "for_patient delegates to gateway via DI" do
+        with_mock_gateway do |_gw|
+          ServiceRequest.create!(valid_sr_attributes.merge(patient_dfn: 42))
+          ServiceRequest.create!(valid_sr_attributes.merge(patient_dfn: 42))
+          ServiceRequest.create!(valid_sr_attributes.merge(patient_dfn: 99))
+          results = ServiceRequest.for_patient(42)
+          assert_equal 2, results.length
+          assert(results.all? { |sr| sr.patient_dfn == 42 })
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

All 12 gateway-backed models now support dependency-injected gateways.

| Model | Gateway | Methods delegated |
|-------|---------|-------------------|
| Patient | PatientGateway | find, search, find_by_ssn, register |
| Practitioner | PractitionerGateway | find_by_ien, search, register |
| ServiceRequest | ServiceRequestGateway | for_patient, register |
| AllergyIntolerance | AllergyIntoleranceGateway | for_patient |
| Condition | ConditionGateway | for_patient |
| Encounter | EncounterGateway | for_patient |
| Immunization | ImmunizationGateway | for_patient |
| Location | LocationGateway | find_by_ien |
| MedicationRequest | MedicationRequestGateway | for_patient |
| Observation | ObservationGateway | for_patient |
| Organization | OrganizationGateway | find_by_ien |
| Procedure | ProcedureGateway | for_patient |

Patient, Practitioner, ServiceRequest also have save/create/create!.

963 minitest (+48 DI tests), 180 cucumber. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)