### PR TITLE
Create 6 missing models with TDD (+176 tests)

### DIFF
--- a/app/models/lakeraven/ehr/bulk_export.rb
+++ b/app/models/lakeraven/ehr/bulk_export.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # BulkExport Model - ActiveModel
+    # ONC Certification 170.315(g)(10) - Bulk Data Access
+    #
+    # Tracks the status of FHIR Bulk Data Export requests.
+    # Exports are asynchronous operations that generate NDJSON files
+    # for each resource type requested.
+    class BulkExport
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      # Export types
+      EXPORT_TYPE_SYSTEM = "system"
+      EXPORT_TYPE_PATIENT = "patient"
+      EXPORT_TYPE_GROUP = "group"
+
+      EXPORT_TYPES = [ EXPORT_TYPE_SYSTEM, EXPORT_TYPE_PATIENT, EXPORT_TYPE_GROUP ].freeze
+
+      # Export statuses
+      STATUS_PENDING = "pending"
+      STATUS_PROCESSING = "processing"
+      STATUS_COMPLETED = "completed"
+      STATUS_FAILED = "failed"
+      STATUS_EXPIRED = "expired"
+
+      STATUSES = [ STATUS_PENDING, STATUS_PROCESSING, STATUS_COMPLETED, STATUS_FAILED, STATUS_EXPIRED ].freeze
+
+      # US Core resource types for bulk export
+      SUPPORTED_RESOURCES = %w[
+        Patient AllergyIntolerance Condition Immunization Medication
+        MedicationRequest Observation Procedure DiagnosticReport
+        CarePlan CareTeam Goal Device Practitioner Organization
+        Location DocumentReference
+      ].freeze
+
+      # -- Attributes ----------------------------------------------------------
+
+      attribute :id, :string
+      attribute :export_type, :string
+      attribute :status, :string
+      attribute :request_url, :string
+      attribute :output_format, :string
+      attribute :group_id, :string
+      attribute :since_timestamp, :datetime
+      attribute :type_filters, :string
+      attribute :client_id, :string
+      attribute :started_at, :datetime
+      attribute :completed_at, :datetime
+
+      attr_accessor :requested_types, :output_files, :export_errors
+
+      def initialize(attributes = {})
+        types = attributes.delete(:requested_types)
+        files = attributes.delete(:output_files)
+        errors_list = attributes.delete(:export_errors)
+        super(attributes)
+        @requested_types = types || SUPPORTED_RESOURCES
+        @output_files = files || []
+        @export_errors = errors_list || []
+      end
+
+      # -- Validations ---------------------------------------------------------
+
+      validates :export_type, presence: true, inclusion: { in: EXPORT_TYPES }
+      validates :status, presence: true, inclusion: { in: STATUSES }
+      validates :request_url, presence: true
+      validates :output_format, presence: true
+
+      # -- Defaults ------------------------------------------------------------
+
+      def set_defaults!
+        self.status ||= STATUS_PENDING
+        self.output_format ||= "application/fhir+ndjson"
+        self.requested_types ||= SUPPORTED_RESOURCES
+        self.output_files ||= []
+        self.export_errors ||= []
+      end
+
+      # -- Normalize types -----------------------------------------------------
+
+      def self.normalize_types(types)
+        return SUPPORTED_RESOURCES if types.blank?
+        requested = types.is_a?(String) ? types.split(",").map(&:strip) : types
+        requested & SUPPORTED_RESOURCES
+      end
+
+      # -- Status transitions --------------------------------------------------
+
+      def start_processing!
+        self.status = STATUS_PROCESSING
+        self.started_at = Time.current
+      end
+
+      def complete!(files)
+        self.status = STATUS_COMPLETED
+        self.completed_at = Time.current
+        self.output_files = files
+      end
+
+      def fail!(error_message)
+        self.status = STATUS_FAILED
+        self.completed_at = Time.current
+        self.export_errors = [ { "type" => "transient", "message" => error_message } ]
+      end
+
+      # -- Status predicates ---------------------------------------------------
+
+      def completed?  = status == STATUS_COMPLETED
+      def processing? = status == STATUS_PROCESSING
+      def pending?    = status == STATUS_PENDING
+      def failed?     = status == STATUS_FAILED
+
+      # -- Status response -----------------------------------------------------
+
+      def status_response
+        case status
+        when STATUS_PENDING, STATUS_PROCESSING
+          {
+            status: 202,
+            headers: {
+              "X-Progress" => progress_message,
+              "Retry-After" => retry_after
+            }
+          }
+        when STATUS_COMPLETED
+          {
+            status: 200,
+            body: completion_body
+          }
+        when STATUS_FAILED
+          {
+            status: 500,
+            body: error_outcome
+          }
+        when STATUS_EXPIRED
+          {
+            status: 404,
+            body: not_found_outcome
+          }
+        end
+      end
+
+      private
+
+      def progress_message
+        case status
+        when STATUS_PENDING then "Export request queued"
+        when STATUS_PROCESSING then "Export in progress"
+        end
+      end
+
+      def retry_after
+        processing? ? "30" : "10"
+      end
+
+      def completion_body
+        {
+          transactionTime: completed_at&.iso8601,
+          request: request_url,
+          requiresAccessToken: true,
+          output: output_files_array,
+          error: export_errors.presence || []
+        }
+      end
+
+      def output_files_array
+        (output_files || []).map do |file|
+          { type: file["type"], url: file["url"], count: file["count"] }
+        end
+      end
+
+      def error_outcome
+        {
+          resourceType: "OperationOutcome",
+          issue: (export_errors || []).map do |error|
+            {
+              severity: "error",
+              code: error["type"] || "exception",
+              diagnostics: error["message"]
+            }
+          end
+        }
+      end
+
+      def not_found_outcome
+        {
+          resourceType: "OperationOutcome",
+          issue: [ {
+            severity: "error",
+            code: "not-found",
+            diagnostics: "Export request has expired or was not found"
+          } ]
+        }
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/care_team.rb
+++ b/app/models/lakeraven/ehr/care_team.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # FHIR CareTeam resource (Patient-specific from RPMS) - ActiveModel
+    # ONC 170.315(g)(10) - Required for patient care team access
+    # USCDI v3 Data Class: Care Team Member(s)
+    class CareTeam
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      US_CORE_PROFILE = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
+
+      VALID_STATUSES = %w[proposed active suspended inactive entered-in-error].freeze
+
+      attribute :ien, :string
+      attribute :patient_dfn, :string
+      attribute :name, :string
+      attribute :status, :string
+      attribute :category, :string
+      attribute :period_start, :date
+      attribute :period_end, :date
+      attribute :reason_code, :string
+      attribute :reason_display, :string
+      attribute :managing_organization, :string
+
+      # Participants stored as array of hashes
+      attr_accessor :participants
+
+      def initialize(attributes = {})
+        items = attributes.delete(:participants) || []
+        super(attributes)
+        @participants = items
+      end
+
+      validates :patient_dfn, presence: true
+      validates :status, inclusion: { in: VALID_STATUSES, allow_blank: true }
+
+      def id
+        ien
+      end
+
+      def persisted?
+        ien.present?
+      end
+
+      # -- FHIR serialization (hash-based) -------------------------------------
+
+      def to_fhir
+        resource = {
+          resourceType: "CareTeam",
+          id: "rpms-ct-#{ien}",
+          meta: { profile: [ US_CORE_PROFILE ] },
+          status: status || "active",
+          name: name,
+          category: build_categories,
+          subject: { reference: "Patient/rpms-#{patient_dfn}" },
+          period: build_period,
+          participant: build_participants,
+          reasonCode: build_reason_code,
+          managingOrganization: build_managing_organization
+        }
+        resource
+      end
+
+      def self.resource_class
+        "CareTeam"
+      end
+
+      def self.from_fhir_attributes(fhir_resource)
+        {
+          name: fhir_resource.name,
+          status: fhir_resource.status
+        }
+      end
+
+      private
+
+      def build_categories
+        [ {
+          coding: [ {
+            system: "http://loinc.org",
+            code: "LA27976-2",
+            display: "Encounter-focused care team"
+          } ]
+        } ]
+      end
+
+      def build_period
+        return nil if period_start.blank? && period_end.blank?
+        { start: period_start&.iso8601, end: period_end&.iso8601 }
+      end
+
+      def build_participants
+        return [] if participants.blank?
+
+        participants.map do |member|
+          {
+            role: build_participant_role(member["role"]),
+            member: {
+              reference: "Practitioner/rpms-#{member['duz']}",
+              display: member["name"]
+            },
+            period: member["start_date"].present? ? {
+              start: member["start_date"],
+              end: member["end_date"]
+            } : nil
+          }
+        end
+      end
+
+      def build_participant_role(role)
+        return nil if role.blank?
+        [ { coding: [], text: role } ]
+      end
+
+      def build_reason_code
+        return nil if reason_code.blank? && reason_display.blank?
+        [ {
+          coding: reason_code.present? ? [ { code: reason_code } ] : [],
+          text: reason_display
+        } ]
+      end
+
+      def build_managing_organization
+        return nil if managing_organization.blank?
+        [ { display: managing_organization } ]
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/communication.rb
+++ b/app/models/lakeraven/ehr/communication.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # FHIR Communication resource - ActiveModel (RPC-backed)
+    # Manages secure messages between care team members.
+    class Communication
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      # Communication status codes (FHIR R4)
+      STATUSES = {
+        "preparation" => "Preparation",
+        "in-progress" => "In Progress",
+        "not-done" => "Not Done",
+        "on-hold" => "On Hold",
+        "stopped" => "Stopped",
+        "completed" => "Completed",
+        "entered-in-error" => "Entered in Error",
+        "unknown" => "Unknown"
+      }.freeze
+
+      # Communication priority codes (FHIR R4)
+      PRIORITIES = {
+        "routine" => "Routine",
+        "urgent" => "Urgent",
+        "asap" => "ASAP",
+        "stat" => "Stat"
+      }.freeze
+
+      # Communication category codes
+      CATEGORIES = {
+        "alert" => "Alert",
+        "notification" => "Notification",
+        "reminder" => "Reminder",
+        "instruction" => "Instruction"
+      }.freeze
+
+      # -- Attributes ----------------------------------------------------------
+
+      attribute :ien, :string
+      attribute :subject_patient_dfn, :string
+      attribute :sender_type, :string
+      attribute :sender_id, :string
+      attribute :recipient_type, :string
+      attribute :recipient_id, :string
+      attribute :payload_content, :string
+      attribute :status, :string
+      attribute :priority, :string
+      attribute :category, :string
+      attribute :sent, :datetime
+      attribute :thread_id, :string
+      attribute :parent_message_id, :string
+      attribute :rpms_message_id, :string
+      attribute :rpms_parent_id, :string
+      attribute :about_service_request_ien, :string
+      attribute :encounter_id, :string
+
+      # -- Validations ---------------------------------------------------------
+
+      validates :subject_patient_dfn, presence: true
+      validates :sender_id, presence: true
+      validates :payload_content, presence: true
+      validates :status, inclusion: { in: STATUSES.keys }, allow_blank: true
+      validates :priority, inclusion: { in: PRIORITIES.keys }, allow_blank: true
+      validates :category, inclusion: { in: CATEGORIES.keys }, allow_blank: true
+
+      # -- Persistence ---------------------------------------------------------
+
+      def persisted?
+        ien.present?
+      end
+
+      # -- Status helpers ------------------------------------------------------
+
+      def draft?          = status == "preparation"
+      def in_progress?    = status == "in-progress"
+      def completed?      = status == "completed"
+      def on_hold?        = status == "on-hold"
+      def stopped?        = status == "stopped"
+      def status_display  = STATUSES[status] || "Unknown"
+
+      # -- Priority helpers ----------------------------------------------------
+
+      def routine?         = priority == "routine"
+      def urgent?          = priority == "urgent"
+      def asap?            = priority == "asap"
+      def stat?            = priority == "stat"
+      def priority_display = PRIORITIES[priority] || "Unknown"
+
+      # -- Category helpers ----------------------------------------------------
+
+      def category_display = CATEGORIES[category] || "Unknown"
+      def alert?           = category == "alert"
+      def notification?    = category == "notification"
+      def reminder?        = category == "reminder"
+      def instruction?     = category == "instruction"
+
+      # -- Threading helpers ---------------------------------------------------
+
+      def root_message?
+        parent_message_id.nil?
+      end
+
+      def reply?
+        parent_message_id.present?
+      end
+
+      # -- FHIR serialization (hash-based) -------------------------------------
+
+      def to_fhir
+        resource = {
+          resourceType: "Communication",
+          status: status,
+          priority: priority,
+          subject: subject_patient_dfn.present? ? { reference: "Patient/#{subject_patient_dfn}" } : nil,
+          sender: build_sender_reference,
+          recipient: build_recipient_references,
+          payload: build_fhir_payload,
+          category: build_fhir_category,
+          sent: sent&.iso8601
+        }
+        resource[:id] = ien.to_s if ien.present?
+        resource
+      end
+
+      def self.resource_class
+        "Communication"
+      end
+
+      def self.from_fhir(fhir_resource)
+        new(from_fhir_attributes(fhir_resource))
+      end
+
+      def self.from_fhir_attributes(fhir_resource)
+        attrs = { status: fhir_resource.status }
+
+        if fhir_resource.respond_to?(:subject) && fhir_resource.subject&.reference.present?
+          ref = fhir_resource.subject.reference
+          if ref.include?("Patient/")
+            dfn = ref.split("/").last.gsub(/\D/, "")
+            attrs[:subject_patient_dfn] = dfn if dfn.present?
+          end
+        end
+
+        if fhir_resource.respond_to?(:sender) && fhir_resource.sender&.reference.present?
+          ref = fhir_resource.sender.reference
+          if ref.include?("/")
+            parts = ref.split("/")
+            attrs[:sender_type] = parts[0]
+            attrs[:sender_id] = parts[1]
+          end
+        end
+
+        if fhir_resource.respond_to?(:payload) && fhir_resource.payload&.any?
+          attrs[:payload_content] = fhir_resource.payload.first.contentString
+        end
+
+        attrs
+      end
+
+      private
+
+      def build_sender_reference
+        return nil unless sender_type.present? && sender_id.present?
+        { reference: "#{sender_type}/#{sender_id}" }
+      end
+
+      def build_recipient_references
+        return [] unless recipient_type.present? && recipient_id.present?
+        [ { reference: "#{recipient_type}/#{recipient_id}" } ]
+      end
+
+      def build_fhir_payload
+        return [] if payload_content.blank?
+        [ { contentString: payload_content } ]
+      end
+
+      def build_fhir_category
+        return [] if category.blank?
+        [ {
+          coding: [ {
+            system: "http://terminology.hl7.org/CodeSystem/communication-category",
+            code: category,
+            display: category_display
+          } ]
+        } ]
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/consent.rb
+++ b/app/models/lakeraven/ehr/consent.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # FHIR Consent resource - ActiveModel (RPC-backed)
+    # Manages patient consent for proxy access and authorization.
+    class Consent
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      # Consent status codes
+      STATUSES = {
+        "draft" => "Draft",
+        "proposed" => "Proposed",
+        "active" => "Active",
+        "rejected" => "Rejected",
+        "inactive" => "Inactive",
+        "revoked" => "Revoked",
+        "expired" => "Expired",
+        "entered-in-error" => "Entered in Error"
+      }.freeze
+
+      # Consent scope codes (FHIR + legacy scopes)
+      SCOPES = {
+        "patient-privacy" => "Privacy Consent",
+        "treatment" => "Treatment",
+        "research" => "Research",
+        "adr" => "Advance Directive",
+        "hipaa-auth" => "HIPAA Authorization",
+        "view_referrals" => "View Referrals",
+        "view_records" => "View Records",
+        "upload_docs" => "Upload Documents",
+        "message" => "Message",
+        "full_access" => "Full Access"
+      }.freeze
+
+      # Provision types
+      PROVISION_TYPES = {
+        "permit" => "Permit",
+        "deny" => "Deny"
+      }.freeze
+
+      CATEGORY_CODE = "59284-0"
+      CATEGORY_DISPLAY = "Consent Document"
+
+      # -- Attributes ----------------------------------------------------------
+
+      attribute :id, :string
+      attribute :patient_dfn, :string
+      attribute :scope, :string
+      attribute :status, :string
+      attribute :provision_type, :string
+      attribute :period_start, :date
+      attribute :period_end, :date
+      attribute :date_time, :date
+      attribute :performer_ien, :string
+      attribute :grantee_type, :string
+      attribute :grantee_id, :string
+      attribute :starts_at, :datetime
+      attribute :expires_at, :datetime
+      attribute :revoked_at, :datetime
+      attribute :revocation_reason, :string
+      attribute :provision_actor_related_person_id, :string
+      attribute :provision_actor_practitioner_ien, :string
+      attribute :provision_action, :string
+
+      # -- Validations ---------------------------------------------------------
+
+      validates :patient_dfn, presence: true
+      validates :scope, presence: true, inclusion: { in: SCOPES.keys }
+      validates :status, inclusion: { in: STATUSES.keys }, allow_blank: true
+      validates :provision_type, inclusion: { in: PROVISION_TYPES.keys }, allow_blank: true
+
+      # -- Persistence ---------------------------------------------------------
+
+      def persisted?
+        id.present?
+      end
+
+      # -- Status helpers ------------------------------------------------------
+
+      def active?       = status == "active"
+      def draft?        = status == "draft"
+      def proposed?     = status == "proposed"
+      def rejected?     = status == "rejected"
+      def inactive?     = status == "inactive"
+      def enforceable?  = active?
+      def status_display = STATUSES[status] || "Unknown"
+
+      # -- Scope helpers -------------------------------------------------------
+
+      def scope_display    = SCOPES[scope] || "Unknown"
+      def patient_privacy? = scope == "patient-privacy"
+      def treatment?       = scope == "treatment"
+      def research?        = scope == "research"
+
+      # -- Provision helpers ---------------------------------------------------
+
+      def permits?               = provision_type == "permit"
+      def denies?                = provision_type == "deny"
+      def provision_type_display = PROVISION_TYPES[provision_type] || "Unknown"
+
+      # -- Validity period -----------------------------------------------------
+
+      def within_period?
+        today = Date.current
+        start_ok = period_start.nil? || period_start <= today
+        end_ok = period_end.nil? || period_end >= today
+        start_ok && end_ok
+      end
+
+      # -- Authorization -------------------------------------------------------
+
+      def authorizes_access?
+        enforceable? && permits? && within_period?
+      end
+
+      def allows?(permission)
+        return false unless active?
+        scope == "full_access" || scope == permission.to_s
+      end
+
+      def expired?
+        expires_at.present? && expires_at <= Time.current
+      end
+
+      # -- FHIR serialization (hash-based) -------------------------------------
+
+      def to_fhir
+        resource = {
+          resourceType: "Consent",
+          status: status,
+          patient: patient_dfn.present? ? { reference: "Patient/#{patient_dfn}" } : nil,
+          scope: build_fhir_scope,
+          category: build_fhir_category,
+          dateTime: date_time&.iso8601,
+          performer: build_fhir_performer,
+          provision: build_fhir_provision
+        }
+        resource[:id] = id.to_s if id.present?
+        resource
+      end
+
+      def self.resource_class
+        "Consent"
+      end
+
+      def self.from_fhir(fhir_resource)
+        new(from_fhir_attributes(fhir_resource))
+      end
+
+      def self.from_fhir_attributes(fhir_resource)
+        attrs = { status: fhir_resource.status }
+
+        if fhir_resource.respond_to?(:scope) && fhir_resource.scope&.coding&.any?
+          attrs[:scope] = fhir_resource.scope.coding.first.code
+        end
+
+        if fhir_resource.respond_to?(:patient) && fhir_resource.patient&.reference.present?
+          ref = fhir_resource.patient.reference
+          if ref.include?("Patient/")
+            dfn = ref.split("/").last.gsub(/\D/, "")
+            attrs[:patient_dfn] = dfn if dfn.present?
+          end
+        end
+
+        if fhir_resource.respond_to?(:dateTime) && fhir_resource.dateTime.present?
+          attrs[:date_time] = Date.parse(fhir_resource.dateTime)
+        end
+
+        attrs
+      end
+
+      private
+
+      def build_fhir_scope
+        return nil if scope.blank?
+        {
+          coding: [ {
+            system: "http://terminology.hl7.org/CodeSystem/consentscope",
+            code: scope,
+            display: scope_display
+          } ]
+        }
+      end
+
+      def build_fhir_category
+        [ {
+          coding: [ {
+            system: "http://loinc.org",
+            code: CATEGORY_CODE,
+            display: CATEGORY_DISPLAY
+          } ]
+        } ]
+      end
+
+      def build_fhir_performer
+        return [] unless performer_ien.present?
+        [ { reference: "Practitioner/rpms-practitioner-#{performer_ien}" } ]
+      end
+
+      def build_fhir_provision
+        return nil if provision_type.blank?
+        {
+          type: provision_type,
+          actor: build_provision_actors,
+          action: build_provision_actions,
+          period: build_provision_period
+        }
+      end
+
+      def build_provision_actors
+        actors = []
+        if provision_actor_related_person_id.present?
+          actors << {
+            role: { coding: [ { code: "DPOWATT", display: "Durable Power of Attorney" } ] },
+            reference: { reference: "RelatedPerson/#{provision_actor_related_person_id}" }
+          }
+        end
+        if provision_actor_practitioner_ien.present?
+          actors << {
+            role: { coding: [ { code: "CST", display: "Custodian" } ] },
+            reference: { reference: "Practitioner/rpms-practitioner-#{provision_actor_practitioner_ien}" }
+          }
+        end
+        actors
+      end
+
+      def build_provision_actions
+        return nil if provision_action.blank?
+        [ { coding: [ { system: "http://terminology.hl7.org/CodeSystem/consentaction", code: provision_action } ] } ]
+      end
+
+      def build_provision_period
+        return nil if period_start.blank? && period_end.blank?
+        { start: period_start&.iso8601, end: period_end&.iso8601 }
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/detected_issue.rb
+++ b/app/models/lakeraven/ehr/detected_issue.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # FHIR DetectedIssue resource - ActiveModel
+    # Represents a clinical issue detected during drug interaction checking.
+    # Maps to FHIR R4 DetectedIssue per ONC 170.315(a)(4).
+    class DetectedIssue
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      US_CORE_PROFILE = "http://hl7.org/fhir/StructureDefinition/DetectedIssue"
+
+      VALID_STATUSES = %w[preliminary final amended corrected cancelled entered-in-error].freeze
+      VALID_SEVERITIES = %w[high moderate low].freeze
+      VALID_CODES = %w[drug-drug drug-allergy].freeze
+
+      attribute :status, :string
+      attribute :severity, :string
+      attribute :code, :string
+      attribute :detail, :string
+
+      attr_accessor :implicated_items
+
+      def initialize(attributes = {})
+        items = attributes.delete(:implicated_items) || []
+        super(attributes)
+        @implicated_items = items
+      end
+
+      validates :status, presence: true, inclusion: { in: VALID_STATUSES }
+      validates :severity, inclusion: { in: VALID_SEVERITIES, allow_blank: true }
+      validates :code, presence: true, inclusion: { in: VALID_CODES }
+
+      # Build from an InteractionAlert value object
+      def self.from_interaction_alert(alert)
+        new(
+          status: "final",
+          severity: alert.severity.to_s,
+          code: alert.interaction_type == :drug_allergy ? "drug-allergy" : "drug-drug",
+          detail: "#{alert.drug_a} + #{alert.drug_b}: #{alert.description}",
+          implicated_items: [
+            { display: alert.drug_a, reference: nil },
+            { display: alert.drug_b, reference: nil }
+          ]
+        )
+      end
+
+      def to_fhir
+        {
+          resourceType: "DetectedIssue",
+          meta: { profile: [ US_CORE_PROFILE ] },
+          status: status,
+          severity: severity,
+          code: build_code,
+          detail: detail,
+          implicated: build_implicated
+        }
+      end
+
+      def self.resource_class
+        "DetectedIssue"
+      end
+
+      def self.from_fhir_attributes(fhir_resource)
+        {
+          status: fhir_resource.status,
+          severity: fhir_resource.severity,
+          code: fhir_resource.code&.coding&.first&.code,
+          detail: fhir_resource.detail
+        }
+      end
+
+      private
+
+      def build_code
+        display = case code
+        when "drug-drug" then "Drug-drug interaction"
+        when "drug-allergy" then "Drug-allergy interaction"
+        else code
+        end
+
+        {
+          coding: [ {
+            system: "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+            code: code,
+            display: display
+          } ]
+        }
+      end
+
+      def build_implicated
+        return [] unless implicated_items.is_a?(Array)
+        implicated_items.map do |item|
+          { display: item[:display], reference: item[:reference] }
+        end
+      end
+    end
+  end
+end

--- a/app/models/lakeraven/ehr/related_person.rb
+++ b/app/models/lakeraven/ehr/related_person.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # FHIR RelatedPerson resource - ActiveModel (RPC-backed)
+    # Represents patient advocates, family caregivers, and authorized representatives.
+    class RelatedPerson
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      # Relationship codes (based on HL7 v2-0131)
+      RELATIONSHIPS = {
+        "parent" => "Parent",
+        "spouse" => "Spouse",
+        "child" => "Child",
+        "sibling" => "Sibling",
+        "guardian" => "Guardian",
+        "friend" => "Friend",
+        "caregiver" => "Caregiver",
+        "advocate" => "Patient Advocate",
+        "emergency" => "Emergency Contact",
+        "other" => "Other"
+      }.freeze
+
+      # -- Attributes ----------------------------------------------------------
+
+      attribute :id, :string
+      attribute :patient_dfn, :string
+      attribute :name, :string
+      attribute :relationship, :string
+      attribute :active, :boolean
+      attribute :phone, :string
+      attribute :email, :string
+      attribute :period_start, :date
+      attribute :period_end, :date
+
+      # -- Validations ---------------------------------------------------------
+
+      validates :patient_dfn, presence: true
+      validates :name, presence: true
+      validates :relationship, presence: true, inclusion: { in: RELATIONSHIPS.keys }
+
+      # -- Persistence ---------------------------------------------------------
+
+      def persisted?
+        id.present?
+      end
+
+      # -- Status helpers ------------------------------------------------------
+
+      def active?
+        active == true
+      end
+
+      def within_period?
+        today = Date.current
+        start_ok = period_start.nil? || period_start <= today
+        end_ok = period_end.nil? || period_end >= today
+        start_ok && end_ok
+      end
+
+      def valid_for_authorization?
+        active? && within_period?
+      end
+
+      # -- Relationship helpers ------------------------------------------------
+
+      def relationship_display = RELATIONSHIPS[relationship] || "Unknown"
+      def guardian?            = relationship == "guardian"
+      def caregiver?           = relationship == "caregiver"
+
+      def family_member?
+        %w[parent spouse child sibling].include?(relationship)
+      end
+
+      # -- FHIR serialization (hash-based) -------------------------------------
+
+      def to_fhir
+        resource = {
+          resourceType: "RelatedPerson",
+          active: active,
+          patient: patient_dfn.present? ? { reference: "Patient/#{patient_dfn}" } : nil,
+          relationship: build_fhir_relationship,
+          name: build_fhir_name,
+          telecom: build_fhir_telecom,
+          period: build_fhir_period
+        }
+        resource[:id] = id.to_s if id.present?
+        resource
+      end
+
+      def self.resource_class
+        "RelatedPerson"
+      end
+
+      def self.from_fhir(fhir_resource)
+        new(from_fhir_attributes(fhir_resource))
+      end
+
+      def self.from_fhir_attributes(fhir_resource)
+        attrs = { active: fhir_resource.active }
+
+        if fhir_resource.respond_to?(:patient) && fhir_resource.patient&.reference.present?
+          ref = fhir_resource.patient.reference
+          if ref.include?("Patient/")
+            dfn = ref.split("/").last.gsub(/\D/, "")
+            attrs[:patient_dfn] = dfn if dfn.present?
+          end
+        end
+
+        if fhir_resource.respond_to?(:relationship) && fhir_resource.relationship&.any?
+          rel = fhir_resource.relationship.first
+          attrs[:relationship] = rel.coding.first.code if rel.coding&.any?
+        end
+
+        if fhir_resource.respond_to?(:name) && fhir_resource.name&.any?
+          n = fhir_resource.name.first
+          attrs[:name] = n.text || "#{n.given&.join(' ')} #{n.family}".strip
+        end
+
+        attrs
+      end
+
+      private
+
+      def build_fhir_relationship
+        return [] if relationship.blank?
+        [ {
+          coding: [ {
+            system: "http://terminology.hl7.org/CodeSystem/v2-0131",
+            code: relationship,
+            display: relationship_display
+          } ]
+        } ]
+      end
+
+      def build_fhir_name
+        return [] if name.blank?
+        [ { text: name } ]
+      end
+
+      def build_fhir_telecom
+        telecoms = []
+        telecoms << { system: "phone", value: phone } if phone.present?
+        telecoms << { system: "email", value: email } if email.present?
+        telecoms
+      end
+
+      def build_fhir_period
+        return nil if period_start.blank? && period_end.blank?
+        { start: period_start&.iso8601, end: period_end&.iso8601 }
+      end
+    end
+  end
+end

--- a/test/models/lakeraven/ehr/bulk_export_test.rb
+++ b/test/models/lakeraven/ehr/bulk_export_test.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class BulkExportTest < ActiveSupport::TestCase
+      # =============================================================================
+      # CREATION AND DEFAULTS
+      # =============================================================================
+
+      test "creates export with default values" do
+        export = BulkExport.new(
+          request_url: "http://example.com/fhir/$export",
+          export_type: BulkExport::EXPORT_TYPE_SYSTEM
+        )
+        export.set_defaults!
+
+        assert_equal BulkExport::STATUS_PENDING, export.status
+        assert_equal "application/fhir+ndjson", export.output_format
+        assert_equal BulkExport::SUPPORTED_RESOURCES, export.requested_types
+      end
+
+      test "validates export_type presence" do
+        export = BulkExport.new(request_url: "http://example.com")
+        assert_not export.valid?
+        assert_includes export.errors[:export_type], "can't be blank"
+      end
+
+      test "validates export_type inclusion" do
+        export = BulkExport.new(request_url: "http://example.com", export_type: "invalid")
+        assert_not export.valid?
+        assert_includes export.errors[:export_type], "is not included in the list"
+      end
+
+      test "validates status presence" do
+        export = BulkExport.new(
+          request_url: "http://example.com",
+          export_type: BulkExport::EXPORT_TYPE_SYSTEM,
+          status: nil
+        )
+        assert_not export.valid?
+        assert_includes export.errors[:status], "can't be blank"
+      end
+
+      test "validates request_url presence" do
+        export = BulkExport.new(
+          export_type: BulkExport::EXPORT_TYPE_SYSTEM,
+          status: BulkExport::STATUS_PENDING
+        )
+        assert_not export.valid?
+        assert_includes export.errors[:request_url], "can't be blank"
+      end
+
+      test "validates output_format presence" do
+        export = BulkExport.new(
+          request_url: "http://example.com",
+          export_type: BulkExport::EXPORT_TYPE_SYSTEM,
+          status: BulkExport::STATUS_PENDING,
+          output_format: nil
+        )
+        assert_not export.valid?
+        assert_includes export.errors[:output_format], "can't be blank"
+      end
+
+      # =============================================================================
+      # STATUS TRANSITIONS
+      # =============================================================================
+
+      test "start_processing updates status" do
+        export = build_export
+        export.start_processing!
+
+        assert_equal BulkExport::STATUS_PROCESSING, export.status
+        assert_not_nil export.started_at
+      end
+
+      test "complete updates status and output_files" do
+        export = build_export
+        export.start_processing!
+
+        files = [ { "type" => "Patient", "url" => "http://example.com/file.ndjson", "count" => 10 } ]
+        export.complete!(files)
+
+        assert_equal BulkExport::STATUS_COMPLETED, export.status
+        assert_not_nil export.completed_at
+        assert_equal files, export.output_files
+      end
+
+      test "fail updates status and errors" do
+        export = build_export
+        export.start_processing!
+        export.fail!("Test error")
+
+        assert_equal BulkExport::STATUS_FAILED, export.status
+        assert_equal [ { "type" => "transient", "message" => "Test error" } ], export.export_errors
+      end
+
+      # =============================================================================
+      # NORMALIZE TYPES
+      # =============================================================================
+
+      test "normalize_types filters unsupported resources" do
+        types = BulkExport.normalize_types("Patient,Invalid,Condition,Fake")
+        assert_equal %w[Patient Condition], types
+      end
+
+      test "normalize_types returns all supported when blank" do
+        types = BulkExport.normalize_types(nil)
+        assert_equal BulkExport::SUPPORTED_RESOURCES, types
+
+        types = BulkExport.normalize_types("")
+        assert_equal BulkExport::SUPPORTED_RESOURCES, types
+      end
+
+      # =============================================================================
+      # STATUS PREDICATES
+      # =============================================================================
+
+      test "status predicates work correctly" do
+        export = build_export
+
+        assert export.pending?
+        assert_not export.processing?
+        assert_not export.completed?
+        assert_not export.failed?
+
+        export.start_processing!
+        assert_not export.pending?
+        assert export.processing?
+
+        export.complete!([])
+        assert export.completed?
+        assert_not export.processing?
+      end
+
+      # =============================================================================
+      # STATUS RESPONSE
+      # =============================================================================
+
+      test "status_response returns 202 for pending" do
+        export = build_export
+        response = export.status_response
+
+        assert_equal 202, response[:status]
+        assert_includes response[:headers]["X-Progress"], "queued"
+      end
+
+      test "status_response returns 200 for completed" do
+        export = build_export
+        export.start_processing!
+        export.complete!([])
+
+        response = export.status_response
+
+        assert_equal 200, response[:status]
+        assert_equal "http://example.com/fhir/$export", response[:body][:request]
+      end
+
+      test "status_response returns 500 for failed" do
+        export = build_export
+        export.start_processing!
+        export.fail!("Something broke")
+
+        response = export.status_response
+        assert_equal 500, response[:status]
+        assert_equal "OperationOutcome", response[:body][:resourceType]
+      end
+
+      private
+
+      def build_export(overrides = {})
+        defaults = {
+          request_url: "http://example.com/fhir/$export",
+          export_type: BulkExport::EXPORT_TYPE_SYSTEM,
+          status: BulkExport::STATUS_PENDING,
+          output_format: "application/fhir+ndjson",
+          requested_types: BulkExport::SUPPORTED_RESOURCES,
+          output_files: [],
+          export_errors: []
+        }
+        BulkExport.new(defaults.merge(overrides))
+      end
+    end
+  end
+end

--- a/test/models/lakeraven/ehr/care_team_test.rb
+++ b/test/models/lakeraven/ehr/care_team_test.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "ostruct"
+
+module Lakeraven
+  module EHR
+    class CareTeamTest < ActiveSupport::TestCase
+      # =============================================================================
+      # MODEL ATTRIBUTES
+      # =============================================================================
+
+      test "has required attributes" do
+        team = CareTeam.new(
+          ien: "123",
+          patient_dfn: "456",
+          name: "Diabetes Care Team",
+          status: "active"
+        )
+
+        assert_equal "123", team.ien
+        assert_equal "456", team.patient_dfn
+        assert_equal "Diabetes Care Team", team.name
+        assert_equal "active", team.status
+      end
+
+      test "validates patient_dfn presence" do
+        team = CareTeam.new(name: "Care Team")
+        assert_not team.valid?
+        assert_includes team.errors[:patient_dfn], "can't be blank"
+      end
+
+      test "validates status values" do
+        team = CareTeam.new(patient_dfn: "123", status: "invalid")
+        assert_not team.valid?
+        assert_includes team.errors[:status], "is not included in the list"
+      end
+
+      test "allows valid status values" do
+        %w[proposed active suspended inactive entered-in-error].each do |status|
+          team = CareTeam.new(patient_dfn: "123", status: status)
+          assert team.valid?, "Expected #{status} to be valid"
+        end
+      end
+
+      test "allows blank status" do
+        team = CareTeam.new(patient_dfn: "123")
+        assert team.valid?
+      end
+
+      test "accepts participants array" do
+        participants = [
+          { "duz" => "123", "name" => "Dr. Smith", "role" => "Primary Care" },
+          { "duz" => "456", "name" => "Nurse Jones", "role" => "Care Manager" }
+        ]
+
+        team = CareTeam.new(patient_dfn: "123", participants: participants)
+
+        assert_equal 2, team.participants.length
+        assert_equal "Dr. Smith", team.participants.first["name"]
+      end
+
+      # =============================================================================
+      # FHIR SERIALIZATION
+      # =============================================================================
+
+      test "to_fhir returns valid FHIR structure" do
+        team = CareTeam.new(
+          ien: "123",
+          patient_dfn: "456",
+          name: "Diabetes Care Team",
+          status: "active"
+        )
+
+        fhir = team.to_fhir
+
+        assert_equal "CareTeam", fhir[:resourceType]
+        assert_equal "rpms-ct-123", fhir[:id]
+        assert_includes fhir[:meta][:profile], "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
+      end
+
+      test "to_fhir includes status and name" do
+        team = CareTeam.new(
+          ien: "123", patient_dfn: "456",
+          name: "Primary Care Team", status: "active"
+        )
+
+        fhir = team.to_fhir
+
+        assert_equal "active", fhir[:status]
+        assert_equal "Primary Care Team", fhir[:name]
+      end
+
+      test "to_fhir includes patient reference" do
+        team = CareTeam.new(ien: "123", patient_dfn: "456")
+
+        fhir = team.to_fhir
+
+        assert_equal "Patient/rpms-456", fhir[:subject][:reference]
+      end
+
+      test "to_fhir includes participants" do
+        participants = [
+          { "duz" => "789", "name" => "Dr. Smith", "role" => "Primary Care Provider" }
+        ]
+
+        team = CareTeam.new(ien: "123", patient_dfn: "456", participants: participants)
+
+        fhir = team.to_fhir
+
+        assert_equal 1, fhir[:participant].length
+        assert_equal "Practitioner/rpms-789", fhir[:participant].first[:member][:reference]
+        assert_equal "Dr. Smith", fhir[:participant].first[:member][:display]
+      end
+
+      test "to_fhir includes category" do
+        team = CareTeam.new(ien: "123", patient_dfn: "456")
+
+        fhir = team.to_fhir
+
+        assert_equal 1, fhir[:category].length
+        coding = fhir[:category].first[:coding].first
+        assert_equal "LA27976-2", coding[:code]
+        assert_equal "http://loinc.org", coding[:system]
+      end
+
+      test "to_fhir includes period" do
+        team = CareTeam.new(
+          ien: "123", patient_dfn: "456",
+          period_start: Date.new(2026, 1, 1),
+          period_end: Date.new(2026, 12, 31)
+        )
+
+        fhir = team.to_fhir
+
+        assert_equal "2026-01-01", fhir[:period][:start]
+        assert_equal "2026-12-31", fhir[:period][:end]
+      end
+
+      test "to_fhir omits period when no dates" do
+        team = CareTeam.new(ien: "123", patient_dfn: "456")
+        fhir = team.to_fhir
+        assert_nil fhir[:period]
+      end
+
+      test "to_fhir includes reason code" do
+        team = CareTeam.new(
+          ien: "123", patient_dfn: "456",
+          reason_code: "E11.9", reason_display: "Diabetes mellitus"
+        )
+        fhir = team.to_fhir
+
+        assert_not_nil fhir[:reasonCode]
+        assert_equal "Diabetes mellitus", fhir[:reasonCode].first[:text]
+      end
+
+      test "to_fhir includes managing organization" do
+        team = CareTeam.new(
+          ien: "123", patient_dfn: "456",
+          managing_organization: "Alaska Native Medical Center"
+        )
+        fhir = team.to_fhir
+
+        assert_not_nil fhir[:managingOrganization]
+        assert_equal "Alaska Native Medical Center", fhir[:managingOrganization].first[:display]
+      end
+
+      # =============================================================================
+      # RESOURCE CLASS & PERSISTENCE
+      # =============================================================================
+
+      test "resource_class returns CareTeam" do
+        assert_equal "CareTeam", CareTeam.resource_class
+      end
+
+      test "persisted? returns true when ien present" do
+        team = CareTeam.new(ien: "123", patient_dfn: "456")
+        assert team.persisted?
+      end
+
+      test "persisted? returns false when ien blank" do
+        team = CareTeam.new(patient_dfn: "456")
+        assert_not team.persisted?
+      end
+
+      test "id returns ien" do
+        team = CareTeam.new(ien: "123", patient_dfn: "456")
+        assert_equal "123", team.id
+      end
+
+      test "from_fhir_attributes extracts name and status" do
+        fhir = OpenStruct.new(name: "Test Team", status: "active")
+        attrs = CareTeam.from_fhir_attributes(fhir)
+        assert_equal "Test Team", attrs[:name]
+        assert_equal "active", attrs[:status]
+      end
+    end
+  end
+end

--- a/test/models/lakeraven/ehr/communication_test.rb
+++ b/test/models/lakeraven/ehr/communication_test.rb
@@ -1,0 +1,423 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "ostruct"
+
+module Lakeraven
+  module EHR
+    class CommunicationTest < ActiveSupport::TestCase
+      # =============================================================================
+      # VALIDATION TESTS
+      # =============================================================================
+
+      test "should be valid with required attributes" do
+        communication = Communication.new(
+          subject_patient_dfn: "12345",
+          sender_type: "Practitioner",
+          sender_id: "101",
+          payload_content: "Test message"
+        )
+        assert communication.valid?, "Communication should be valid with required attributes"
+      end
+
+      test "should require subject_patient_dfn" do
+        communication = Communication.new(
+          sender_type: "Practitioner",
+          sender_id: "101",
+          payload_content: "Test message"
+        )
+        refute communication.valid?
+        assert communication.errors[:subject_patient_dfn].any?
+      end
+
+      test "should require sender_id" do
+        communication = Communication.new(
+          subject_patient_dfn: "12345",
+          sender_type: "Practitioner",
+          payload_content: "Test message"
+        )
+        refute communication.valid?
+        assert communication.errors[:sender_id].any?
+      end
+
+      test "should require payload_content" do
+        communication = Communication.new(
+          subject_patient_dfn: "12345",
+          sender_type: "Practitioner",
+          sender_id: "101"
+        )
+        refute communication.valid?
+        assert communication.errors[:payload_content].any?
+      end
+
+      test "should validate status is in allowed list" do
+        communication = Communication.new(
+          subject_patient_dfn: "12345",
+          sender_type: "Practitioner",
+          sender_id: "101",
+          payload_content: "Test",
+          status: "invalid"
+        )
+        refute communication.valid?
+        assert_includes communication.errors[:status], "is not included in the list"
+      end
+
+      test "should validate priority is in allowed list" do
+        communication = Communication.new(
+          subject_patient_dfn: "12345",
+          sender_type: "Practitioner",
+          sender_id: "101",
+          payload_content: "Test",
+          priority: "invalid"
+        )
+        refute communication.valid?
+        assert_includes communication.errors[:priority], "is not included in the list"
+      end
+
+      test "should validate category is in allowed list" do
+        communication = Communication.new(
+          subject_patient_dfn: "12345",
+          sender_type: "Practitioner",
+          sender_id: "101",
+          payload_content: "Test",
+          category: "invalid"
+        )
+        refute communication.valid?
+        assert_includes communication.errors[:category], "is not included in the list"
+      end
+
+      # =============================================================================
+      # STATUS HELPER TESTS
+      # =============================================================================
+
+      test "draft? returns true for preparation status" do
+        communication = Communication.new(status: "preparation")
+        assert communication.draft?
+      end
+
+      test "in_progress? returns true for in-progress status" do
+        communication = Communication.new(status: "in-progress")
+        assert communication.in_progress?
+      end
+
+      test "completed? returns true for completed status" do
+        communication = Communication.new(status: "completed")
+        assert communication.completed?
+      end
+
+      test "on_hold? returns true for on-hold status" do
+        communication = Communication.new(status: "on-hold")
+        assert communication.on_hold?
+      end
+
+      test "stopped? returns true for stopped status" do
+        communication = Communication.new(status: "stopped")
+        assert communication.stopped?
+      end
+
+      test "status_display returns human-readable status" do
+        communication = Communication.new(status: "completed")
+        assert_equal "Completed", communication.status_display
+
+        communication.status = "in-progress"
+        assert_equal "In Progress", communication.status_display
+      end
+
+      test "status_display returns Unknown for nil status" do
+        communication = Communication.new(status: nil)
+        assert_equal "Unknown", communication.status_display
+      end
+
+      # =============================================================================
+      # PRIORITY HELPER TESTS
+      # =============================================================================
+
+      test "routine? returns true for routine priority" do
+        communication = Communication.new(priority: "routine")
+        assert communication.routine?
+      end
+
+      test "urgent? returns true for urgent priority" do
+        communication = Communication.new(priority: "urgent")
+        assert communication.urgent?
+      end
+
+      test "asap? returns true for asap priority" do
+        communication = Communication.new(priority: "asap")
+        assert communication.asap?
+      end
+
+      test "stat? returns true for stat priority" do
+        communication = Communication.new(priority: "stat")
+        assert communication.stat?
+      end
+
+      test "priority_display returns human-readable priority" do
+        communication = Communication.new(priority: "stat")
+        assert_equal "Stat", communication.priority_display
+      end
+
+      test "priority_display returns Unknown for nil priority" do
+        communication = Communication.new(priority: nil)
+        assert_equal "Unknown", communication.priority_display
+      end
+
+      # =============================================================================
+      # CATEGORY HELPER TESTS
+      # =============================================================================
+
+      test "category_display returns human-readable category" do
+        communication = Communication.new(category: "alert")
+        assert_equal "Alert", communication.category_display
+
+        communication.category = "notification"
+        assert_equal "Notification", communication.category_display
+      end
+
+      test "alert? returns true for alert category" do
+        assert Communication.new(category: "alert").alert?
+      end
+
+      test "notification? returns true for notification category" do
+        assert Communication.new(category: "notification").notification?
+      end
+
+      test "reminder? returns true for reminder category" do
+        assert Communication.new(category: "reminder").reminder?
+      end
+
+      test "instruction? returns true for instruction category" do
+        assert Communication.new(category: "instruction").instruction?
+      end
+
+      # =============================================================================
+      # THREADING HELPERS
+      # =============================================================================
+
+      test "root_message? returns true when no parent_message_id" do
+        communication = Communication.new(parent_message_id: nil)
+        assert communication.root_message?
+      end
+
+      test "root_message? returns false when parent_message_id present" do
+        communication = Communication.new(parent_message_id: "abc-123")
+        refute communication.root_message?
+      end
+
+      test "reply? returns true when parent_message_id present" do
+        communication = Communication.new(parent_message_id: "abc-123")
+        assert communication.reply?
+      end
+
+      test "reply? returns false when no parent_message_id" do
+        communication = Communication.new(parent_message_id: nil)
+        refute communication.reply?
+      end
+
+      # =============================================================================
+      # PERSISTENCE TESTS
+      # =============================================================================
+
+      test "persisted? returns false for new communication without ien" do
+        communication = Communication.new(subject_patient_dfn: "12345", payload_content: "Test")
+        refute communication.persisted?
+      end
+
+      test "persisted? returns true when ien present" do
+        communication = Communication.new(ien: "999")
+        assert communication.persisted?
+      end
+
+      # =============================================================================
+      # FHIR SERIALIZATION TESTS
+      # =============================================================================
+
+      test "to_fhir returns valid FHIR Communication resource" do
+        communication = Communication.new(
+          ien: "42",
+          subject_patient_dfn: "12345",
+          sender_type: "Practitioner",
+          sender_id: "101",
+          status: "completed",
+          payload_content: "Test message"
+        )
+        fhir = communication.to_fhir
+
+        assert_equal "Communication", fhir[:resourceType]
+        assert_equal "42", fhir[:id]
+        assert_equal "completed", fhir[:status]
+      end
+
+      test "to_fhir includes subject reference" do
+        communication = Communication.new(
+          subject_patient_dfn: "12345",
+          sender_type: "Practitioner",
+          sender_id: "101",
+          payload_content: "Test"
+        )
+        fhir = communication.to_fhir
+
+        assert_not_nil fhir[:subject]
+        assert_equal "Patient/12345", fhir[:subject][:reference]
+      end
+
+      test "to_fhir includes sender reference" do
+        communication = Communication.new(
+          subject_patient_dfn: "12345",
+          sender_type: "Practitioner",
+          sender_id: "101",
+          payload_content: "Test"
+        )
+        fhir = communication.to_fhir
+
+        assert_not_nil fhir[:sender]
+        assert fhir[:sender][:reference].include?("Practitioner")
+      end
+
+      test "to_fhir includes recipient reference" do
+        communication = Communication.new(
+          subject_patient_dfn: "12345",
+          sender_type: "Practitioner",
+          sender_id: "101",
+          recipient_type: "Patient",
+          recipient_id: "12345",
+          payload_content: "Test"
+        )
+        fhir = communication.to_fhir
+
+        assert fhir[:recipient].any?
+        assert fhir[:recipient].first[:reference].include?("Patient")
+      end
+
+      test "to_fhir includes payload" do
+        communication = Communication.new(
+          subject_patient_dfn: "12345",
+          sender_type: "Practitioner",
+          sender_id: "101",
+          payload_content: "Important message"
+        )
+        fhir = communication.to_fhir
+
+        assert fhir[:payload].any?
+        assert_equal "Important message", fhir[:payload].first[:contentString]
+      end
+
+      test "to_fhir includes sent timestamp" do
+        communication = Communication.new(
+          subject_patient_dfn: "12345",
+          sender_type: "Practitioner",
+          sender_id: "101",
+          payload_content: "Test",
+          sent: DateTime.parse("2024-06-15T10:30:00")
+        )
+        fhir = communication.to_fhir
+
+        assert_not_nil fhir[:sent]
+        assert fhir[:sent].include?("2024-06-15")
+      end
+
+      test "to_fhir includes category" do
+        communication = Communication.new(
+          subject_patient_dfn: "12345",
+          sender_type: "Practitioner",
+          sender_id: "101",
+          payload_content: "Test",
+          category: "alert"
+        )
+        fhir = communication.to_fhir
+
+        assert fhir[:category].any?
+        assert_equal "alert", fhir[:category].first[:coding].first[:code]
+      end
+
+      test "to_fhir includes priority" do
+        communication = Communication.new(
+          subject_patient_dfn: "12345",
+          sender_type: "Practitioner",
+          sender_id: "101",
+          payload_content: "Test",
+          priority: "urgent"
+        )
+        fhir = communication.to_fhir
+
+        assert_equal "urgent", fhir[:priority]
+      end
+
+      test "resource_class returns Communication" do
+        assert_equal "Communication", Communication.resource_class
+      end
+
+      test "from_fhir_attributes extracts attributes from OpenStruct" do
+        fhir_resource = OpenStruct.new(
+          status: "completed",
+          subject: OpenStruct.new(reference: "Patient/12345"),
+          sender: OpenStruct.new(reference: "Practitioner/101"),
+          payload: [ OpenStruct.new(contentString: "Test message") ]
+        )
+
+        attrs = Communication.from_fhir_attributes(fhir_resource)
+        assert_equal "completed", attrs[:status]
+        assert_equal "12345", attrs[:subject_patient_dfn]
+        assert_equal "Test message", attrs[:payload_content]
+      end
+
+      test "from_fhir creates communication from FHIR resource" do
+        fhir_resource = OpenStruct.new(
+          status: "completed",
+          subject: OpenStruct.new(reference: "Patient/12345"),
+          sender: OpenStruct.new(reference: "Practitioner/101"),
+          payload: [ OpenStruct.new(contentString: "Test message") ]
+        )
+
+        communication = Communication.from_fhir(fhir_resource)
+        assert communication.is_a?(Communication)
+        assert_equal "completed", communication.status
+        assert_equal "12345", communication.subject_patient_dfn
+      end
+
+      # =============================================================================
+      # EDGE CASE TESTS
+      # =============================================================================
+
+      test "handles nil recipient in FHIR" do
+        communication = Communication.new(
+          subject_patient_dfn: "12345",
+          sender_type: "Practitioner",
+          sender_id: "101",
+          payload_content: "Test",
+          recipient_type: nil,
+          recipient_id: nil
+        )
+        fhir = communication.to_fhir
+
+        assert_equal [], fhir[:recipient]
+      end
+
+      test "handles nil sent timestamp in FHIR" do
+        communication = Communication.new(
+          subject_patient_dfn: "12345",
+          sender_type: "Practitioner",
+          sender_id: "101",
+          payload_content: "Test",
+          sent: nil
+        )
+        fhir = communication.to_fhir
+
+        assert_nil fhir[:sent]
+      end
+
+      test "handles nil category in FHIR" do
+        communication = Communication.new(
+          subject_patient_dfn: "12345",
+          sender_type: "Practitioner",
+          sender_id: "101",
+          payload_content: "Test",
+          category: nil
+        )
+        fhir = communication.to_fhir
+
+        assert_equal [], fhir[:category]
+      end
+    end
+  end
+end

--- a/test/models/lakeraven/ehr/consent_test.rb
+++ b/test/models/lakeraven/ehr/consent_test.rb
@@ -1,0 +1,448 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "ostruct"
+
+module Lakeraven
+  module EHR
+    class ConsentTest < ActiveSupport::TestCase
+      # =============================================================================
+      # VALIDATION TESTS
+      # =============================================================================
+
+      test "should be valid with required attributes" do
+        consent = Consent.new(patient_dfn: "12345", scope: "patient-privacy")
+        assert consent.valid?, "Consent should be valid with patient and scope"
+      end
+
+      test "should require patient_dfn" do
+        consent = Consent.new(scope: "patient-privacy")
+        refute consent.valid?
+        assert consent.errors[:patient_dfn].any?
+      end
+
+      test "should require scope" do
+        consent = Consent.new(patient_dfn: "12345")
+        refute consent.valid?
+        assert consent.errors[:scope].any?
+      end
+
+      test "should validate scope is in allowed list" do
+        consent = Consent.new(patient_dfn: "12345", scope: "invalid-scope")
+        refute consent.valid?
+        assert_includes consent.errors[:scope], "is not included in the list"
+      end
+
+      test "should validate status if present" do
+        consent = Consent.new(patient_dfn: "12345", scope: "patient-privacy", status: "invalid")
+        refute consent.valid?
+        assert_includes consent.errors[:status], "is not included in the list"
+      end
+
+      test "should validate provision_type if present" do
+        consent = Consent.new(patient_dfn: "12345", scope: "patient-privacy", provision_type: "invalid")
+        refute consent.valid?
+        assert_includes consent.errors[:provision_type], "is not included in the list"
+      end
+
+      # =============================================================================
+      # STATUS HELPER TESTS
+      # =============================================================================
+
+      test "active? returns true for active status" do
+        assert Consent.new(status: "active").active?
+      end
+
+      test "draft? returns true for draft status" do
+        assert Consent.new(status: "draft").draft?
+      end
+
+      test "proposed? returns true for proposed status" do
+        assert Consent.new(status: "proposed").proposed?
+      end
+
+      test "rejected? returns true for rejected status" do
+        assert Consent.new(status: "rejected").rejected?
+      end
+
+      test "inactive? returns true for inactive status" do
+        assert Consent.new(status: "inactive").inactive?
+      end
+
+      test "enforceable? returns true only for active status" do
+        assert Consent.new(status: "active").enforceable?
+        refute Consent.new(status: "draft").enforceable?
+        refute Consent.new(status: "proposed").enforceable?
+        refute Consent.new(status: "rejected").enforceable?
+        refute Consent.new(status: "inactive").enforceable?
+      end
+
+      test "status_display returns human-readable status" do
+        consent = Consent.new(status: "active")
+        assert_equal "Active", consent.status_display
+
+        consent.status = "draft"
+        assert_equal "Draft", consent.status_display
+
+        consent.status = nil
+        assert_equal "Unknown", consent.status_display
+      end
+
+      # =============================================================================
+      # SCOPE HELPER TESTS
+      # =============================================================================
+
+      test "scope_display returns human-readable scope" do
+        consent = Consent.new(scope: "patient-privacy")
+        assert_equal "Privacy Consent", consent.scope_display
+
+        consent.scope = "treatment"
+        assert_equal "Treatment", consent.scope_display
+
+        consent.scope = "research"
+        assert_equal "Research", consent.scope_display
+
+        consent.scope = nil
+        assert_equal "Unknown", consent.scope_display
+      end
+
+      test "patient_privacy? returns true for patient-privacy scope" do
+        assert Consent.new(scope: "patient-privacy").patient_privacy?
+      end
+
+      test "treatment? returns true for treatment scope" do
+        assert Consent.new(scope: "treatment").treatment?
+      end
+
+      test "research? returns true for research scope" do
+        assert Consent.new(scope: "research").research?
+      end
+
+      # =============================================================================
+      # PROVISION HELPER TESTS
+      # =============================================================================
+
+      test "permits? returns true for permit provision" do
+        assert Consent.new(provision_type: "permit").permits?
+      end
+
+      test "denies? returns true for deny provision" do
+        assert Consent.new(provision_type: "deny").denies?
+      end
+
+      test "provision_type_display returns human-readable provision type" do
+        consent = Consent.new(provision_type: "permit")
+        assert_equal "Permit", consent.provision_type_display
+
+        consent.provision_type = "deny"
+        assert_equal "Deny", consent.provision_type_display
+      end
+
+      # =============================================================================
+      # VALIDITY PERIOD TESTS
+      # =============================================================================
+
+      test "within_period? returns true when no period set" do
+        consent = Consent.new(patient_dfn: "12345", scope: "patient-privacy")
+        assert consent.within_period?
+      end
+
+      test "within_period? returns true when within period" do
+        consent = Consent.new(
+          patient_dfn: "12345",
+          scope: "patient-privacy",
+          period_start: Date.current - 1.year,
+          period_end: Date.current + 1.year
+        )
+        assert consent.within_period?
+      end
+
+      test "within_period? returns false when before period" do
+        consent = Consent.new(
+          patient_dfn: "12345",
+          scope: "patient-privacy",
+          period_start: Date.current + 1.month
+        )
+        refute consent.within_period?
+      end
+
+      test "within_period? returns false when after period" do
+        consent = Consent.new(
+          patient_dfn: "12345",
+          scope: "patient-privacy",
+          period_end: Date.current - 1.month
+        )
+        refute consent.within_period?
+      end
+
+      # =============================================================================
+      # AUTHORIZATION TESTS
+      # =============================================================================
+
+      test "authorizes_access? returns true when enforceable and permits" do
+        consent = Consent.new(
+          patient_dfn: "12345",
+          scope: "patient-privacy",
+          status: "active",
+          provision_type: "permit"
+        )
+        assert consent.authorizes_access?
+      end
+
+      test "authorizes_access? returns false when not active" do
+        consent = Consent.new(
+          patient_dfn: "12345",
+          scope: "patient-privacy",
+          status: "inactive",
+          provision_type: "permit"
+        )
+        refute consent.authorizes_access?
+      end
+
+      test "authorizes_access? returns false when denies" do
+        consent = Consent.new(
+          patient_dfn: "12345",
+          scope: "patient-privacy",
+          status: "active",
+          provision_type: "deny"
+        )
+        refute consent.authorizes_access?
+      end
+
+      test "authorizes_access? returns false when outside period" do
+        consent = Consent.new(
+          patient_dfn: "12345",
+          scope: "patient-privacy",
+          status: "active",
+          provision_type: "permit",
+          period_end: Date.current - 1.month
+        )
+        refute consent.authorizes_access?
+      end
+
+      # =============================================================================
+      # ALLOWS PERMISSION
+      # =============================================================================
+
+      test "allows? returns true for matching scope" do
+        consent = Consent.new(status: "active", scope: "view_referrals")
+        assert consent.allows?(:view_referrals)
+      end
+
+      test "allows? returns true for full_access" do
+        consent = Consent.new(status: "active", scope: "full_access")
+        assert consent.allows?(:view_referrals)
+      end
+
+      test "allows? returns false for non-matching scope" do
+        consent = Consent.new(status: "active", scope: "view_referrals")
+        refute consent.allows?(:upload_docs)
+      end
+
+      test "allows? returns false when not active" do
+        consent = Consent.new(status: "draft", scope: "full_access")
+        refute consent.allows?(:view_referrals)
+      end
+
+      # =============================================================================
+      # EXPIRED
+      # =============================================================================
+
+      test "expired? returns true when expires_at is past" do
+        consent = Consent.new(expires_at: 1.day.ago)
+        assert consent.expired?
+      end
+
+      test "expired? returns false when expires_at is future" do
+        consent = Consent.new(expires_at: 1.day.from_now)
+        refute consent.expired?
+      end
+
+      test "expired? returns false when expires_at is nil" do
+        consent = Consent.new(expires_at: nil)
+        refute consent.expired?
+      end
+
+      # =============================================================================
+      # PERSISTENCE TESTS
+      # =============================================================================
+
+      test "persisted? returns false for new consent without id" do
+        consent = Consent.new(patient_dfn: "12345", scope: "patient-privacy")
+        refute consent.persisted?
+      end
+
+      test "persisted? returns true when id present" do
+        consent = Consent.new(id: "42")
+        assert consent.persisted?
+      end
+
+      # =============================================================================
+      # FHIR SERIALIZATION TESTS
+      # =============================================================================
+
+      test "to_fhir returns valid FHIR Consent resource" do
+        consent = Consent.new(
+          id: "42",
+          patient_dfn: "12345",
+          scope: "patient-privacy",
+          status: "active"
+        )
+        fhir = consent.to_fhir
+
+        assert_equal "Consent", fhir[:resourceType]
+        assert_equal "42", fhir[:id]
+        assert_equal "active", fhir[:status]
+      end
+
+      test "to_fhir includes patient reference" do
+        consent = Consent.new(patient_dfn: "12345", scope: "patient-privacy")
+        fhir = consent.to_fhir
+
+        assert_not_nil fhir[:patient]
+        assert_equal "Patient/12345", fhir[:patient][:reference]
+      end
+
+      test "to_fhir includes scope coding" do
+        consent = Consent.new(patient_dfn: "12345", scope: "patient-privacy")
+        fhir = consent.to_fhir
+
+        assert_not_nil fhir[:scope]
+        coding = fhir[:scope][:coding].first
+        assert_equal "patient-privacy", coding[:code]
+        assert_equal "Privacy Consent", coding[:display]
+      end
+
+      test "to_fhir includes category" do
+        consent = Consent.new(patient_dfn: "12345", scope: "patient-privacy")
+        fhir = consent.to_fhir
+
+        assert fhir[:category].any?
+        coding = fhir[:category].first[:coding].first
+        assert_equal "59284-0", coding[:code]
+        assert_equal "Consent Document", coding[:display]
+      end
+
+      test "to_fhir includes dateTime" do
+        consent = Consent.new(
+          patient_dfn: "12345",
+          scope: "patient-privacy",
+          date_time: Date.parse("2024-06-15")
+        )
+        fhir = consent.to_fhir
+
+        assert_equal "2024-06-15", fhir[:dateTime]
+      end
+
+      test "to_fhir includes performer" do
+        consent = Consent.new(
+          patient_dfn: "12345",
+          scope: "patient-privacy",
+          performer_ien: "101"
+        )
+        fhir = consent.to_fhir
+
+        assert fhir[:performer].any?
+        performer = fhir[:performer].first
+        assert performer[:reference].include?("Practitioner")
+        assert performer[:reference].include?("101")
+      end
+
+      test "to_fhir includes provision" do
+        consent = Consent.new(
+          patient_dfn: "12345",
+          scope: "patient-privacy",
+          provision_type: "permit"
+        )
+        fhir = consent.to_fhir
+
+        assert_not_nil fhir[:provision]
+        assert_equal "permit", fhir[:provision][:type]
+      end
+
+      test "to_fhir includes provision actor for related person" do
+        consent = Consent.new(
+          patient_dfn: "12345",
+          scope: "patient-privacy",
+          provision_type: "permit",
+          provision_actor_related_person_id: "rp-123"
+        )
+        fhir = consent.to_fhir
+
+        assert fhir[:provision][:actor].any?
+        actor = fhir[:provision][:actor].first
+        assert actor[:reference][:reference].include?("RelatedPerson")
+      end
+
+      test "resource_class returns Consent" do
+        assert_equal "Consent", Consent.resource_class
+      end
+
+      test "from_fhir_attributes extracts attributes" do
+        fhir_resource = OpenStruct.new(
+          status: "active",
+          scope: OpenStruct.new(coding: [ OpenStruct.new(code: "patient-privacy") ]),
+          patient: OpenStruct.new(reference: "Patient/12345"),
+          dateTime: "2024-06-15"
+        )
+
+        attrs = Consent.from_fhir_attributes(fhir_resource)
+        assert_equal "active", attrs[:status]
+        assert_equal "patient-privacy", attrs[:scope]
+        assert_equal "12345", attrs[:patient_dfn]
+        assert_equal Date.parse("2024-06-15"), attrs[:date_time]
+      end
+
+      test "from_fhir creates consent from FHIR resource" do
+        fhir_resource = OpenStruct.new(
+          status: "active",
+          scope: OpenStruct.new(coding: [ OpenStruct.new(code: "patient-privacy") ]),
+          patient: OpenStruct.new(reference: "Patient/12345")
+        )
+
+        consent = Consent.from_fhir(fhir_resource)
+        assert consent.is_a?(Consent)
+        assert_equal "active", consent.status
+        assert_equal "patient-privacy", consent.scope
+        assert_equal "12345", consent.patient_dfn
+      end
+
+      # =============================================================================
+      # EDGE CASE TESTS
+      # =============================================================================
+
+      test "handles nil performer in FHIR" do
+        consent = Consent.new(
+          patient_dfn: "12345",
+          scope: "patient-privacy",
+          performer_ien: nil
+        )
+        fhir = consent.to_fhir
+
+        assert_equal [], fhir[:performer]
+      end
+
+      test "handles nil provision in FHIR" do
+        consent = Consent.new(
+          patient_dfn: "12345",
+          scope: "patient-privacy",
+          provision_type: nil
+        )
+        fhir = consent.to_fhir
+
+        assert_nil fhir[:provision]
+      end
+
+      test "handles nil dateTime in FHIR" do
+        consent = Consent.new(
+          patient_dfn: "12345",
+          scope: "patient-privacy",
+          date_time: nil
+        )
+        fhir = consent.to_fhir
+
+        assert_nil fhir[:dateTime]
+      end
+    end
+  end
+end

--- a/test/models/lakeraven/ehr/detected_issue_test.rb
+++ b/test/models/lakeraven/ehr/detected_issue_test.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class DetectedIssueTest < ActiveSupport::TestCase
+      # =============================================================================
+      # VALIDATIONS
+      # =============================================================================
+
+      test "valid with all required attributes" do
+        issue = build_detected_issue
+        assert issue.valid?
+      end
+
+      test "requires status" do
+        issue = build_detected_issue(status: nil)
+        assert_not issue.valid?
+        assert_includes issue.errors[:status], "can't be blank"
+      end
+
+      test "requires code" do
+        issue = build_detected_issue(code: nil)
+        assert_not issue.valid?
+        assert_includes issue.errors[:code], "can't be blank"
+      end
+
+      test "validates status inclusion" do
+        issue = build_detected_issue(status: "invalid")
+        assert_not issue.valid?
+      end
+
+      test "validates severity inclusion" do
+        issue = build_detected_issue(severity: "invalid")
+        assert_not issue.valid?
+      end
+
+      test "validates code inclusion" do
+        issue = build_detected_issue(code: "invalid")
+        assert_not issue.valid?
+      end
+
+      # =============================================================================
+      # FHIR SERIALIZATION
+      # =============================================================================
+
+      test "to_fhir returns DetectedIssue resourceType" do
+        issue = build_detected_issue
+        fhir = issue.to_fhir
+
+        assert_equal "DetectedIssue", fhir[:resourceType]
+      end
+
+      test "to_fhir includes status" do
+        issue = build_detected_issue(status: "final")
+        fhir = issue.to_fhir
+
+        assert_equal "final", fhir[:status]
+      end
+
+      test "to_fhir includes severity" do
+        issue = build_detected_issue(severity: "high")
+        fhir = issue.to_fhir
+
+        assert_equal "high", fhir[:severity]
+      end
+
+      test "to_fhir includes code as CodeableConcept" do
+        issue = build_detected_issue(code: "drug-drug")
+        fhir = issue.to_fhir
+
+        assert_not_nil fhir[:code]
+        coding = fhir[:code][:coding].first
+        assert_equal "drug-drug", coding[:code]
+      end
+
+      test "to_fhir includes detail text" do
+        issue = build_detected_issue(detail: "Warfarin + Aspirin: Increased bleeding risk")
+        fhir = issue.to_fhir
+
+        assert_equal "Warfarin + Aspirin: Increased bleeding risk", fhir[:detail]
+      end
+
+      test "to_fhir includes implicated items" do
+        issue = build_detected_issue(
+          implicated_items: [
+            { display: "warfarin", reference: "MedicationRequest/1" },
+            { display: "aspirin", reference: "MedicationRequest/2" }
+          ]
+        )
+        fhir = issue.to_fhir
+
+        assert_equal 2, fhir[:implicated].length
+        assert_equal "warfarin", fhir[:implicated].first[:display]
+      end
+
+      test "to_fhir includes meta profile" do
+        issue = build_detected_issue
+        fhir = issue.to_fhir
+
+        assert_not_nil fhir[:meta]
+      end
+
+      # =============================================================================
+      # FACTORY FROM INTERACTION ALERT
+      # =============================================================================
+
+      test "from_interaction_alert creates DetectedIssue for drug-drug" do
+        alert = InteractionAlert.new(
+          severity: :high,
+          drug_a: "warfarin",
+          drug_b: "aspirin",
+          description: "Increased bleeding risk",
+          source: "FDA",
+          interaction_type: :drug_drug
+        )
+
+        issue = DetectedIssue.from_interaction_alert(alert)
+
+        assert_kind_of DetectedIssue, issue
+        assert_equal "final", issue.status
+        assert_equal "high", issue.severity
+        assert_equal "drug-drug", issue.code
+        assert_includes issue.detail, "warfarin"
+        assert_includes issue.detail, "aspirin"
+        assert_equal 2, issue.implicated_items.length
+      end
+
+      test "from_interaction_alert creates DetectedIssue for drug-allergy" do
+        alert = InteractionAlert.new(
+          severity: :high,
+          drug_a: "amoxicillin",
+          drug_b: "penicillin allergy",
+          description: "Patient allergic to penicillin class",
+          interaction_type: :drug_allergy
+        )
+
+        issue = DetectedIssue.from_interaction_alert(alert)
+
+        assert_equal "drug-allergy", issue.code
+      end
+
+      test "from_interaction_alert maps severity symbols to strings" do
+        [ :high, :moderate, :low ].each do |severity|
+          alert = InteractionAlert.new(
+            severity: severity,
+            drug_a: "drug_a",
+            drug_b: "drug_b",
+            description: "test"
+          )
+
+          issue = DetectedIssue.from_interaction_alert(alert)
+          assert_equal severity.to_s, issue.severity
+        end
+      end
+
+      private
+
+      def build_detected_issue(overrides = {})
+        defaults = {
+          status: "final",
+          severity: "high",
+          code: "drug-drug",
+          detail: "Warfarin + Aspirin: Increased bleeding risk",
+          implicated_items: [
+            { display: "warfarin", reference: "MedicationRequest/1" },
+            { display: "aspirin", reference: "MedicationRequest/2" }
+          ]
+        }
+
+        DetectedIssue.new(defaults.merge(overrides))
+      end
+    end
+  end
+end

--- a/test/models/lakeraven/ehr/related_person_test.rb
+++ b/test/models/lakeraven/ehr/related_person_test.rb
@@ -1,0 +1,271 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "ostruct"
+
+module Lakeraven
+  module EHR
+    class RelatedPersonTest < ActiveSupport::TestCase
+      # =============================================================================
+      # VALIDATION TESTS
+      # =============================================================================
+
+      test "should be valid with required attributes" do
+        person = RelatedPerson.new(patient_dfn: "12345", name: "Jane Doe", relationship: "spouse")
+        assert person.valid?, "RelatedPerson should be valid with patient, name, and relationship"
+      end
+
+      test "should require patient_dfn" do
+        person = RelatedPerson.new(name: "Jane Doe", relationship: "spouse")
+        refute person.valid?
+        assert person.errors[:patient_dfn].any?
+      end
+
+      test "should require name" do
+        person = RelatedPerson.new(patient_dfn: "12345", relationship: "spouse")
+        refute person.valid?
+        assert person.errors[:name].any?
+      end
+
+      test "should require relationship" do
+        person = RelatedPerson.new(patient_dfn: "12345", name: "Jane Doe")
+        refute person.valid?
+        assert person.errors[:relationship].any?
+      end
+
+      test "should validate relationship is in allowed list" do
+        person = RelatedPerson.new(patient_dfn: "12345", name: "Jane Doe", relationship: "invalid")
+        refute person.valid?
+        assert_includes person.errors[:relationship], "is not included in the list"
+      end
+
+      # =============================================================================
+      # STATUS HELPER TESTS
+      # =============================================================================
+
+      test "active? returns true for active persons" do
+        person = RelatedPerson.new(patient_dfn: "12345", name: "Jane Doe", relationship: "spouse", active: true)
+        assert person.active?
+      end
+
+      test "active? returns false for inactive persons" do
+        person = RelatedPerson.new(patient_dfn: "12345", name: "Jane Doe", relationship: "spouse", active: false)
+        refute person.active?
+      end
+
+      test "within_period? returns true when no period set" do
+        person = RelatedPerson.new(patient_dfn: "12345", name: "Jane Doe", relationship: "spouse")
+        assert person.within_period?
+      end
+
+      test "within_period? returns true when within period" do
+        person = RelatedPerson.new(
+          patient_dfn: "12345", name: "Jane Doe", relationship: "spouse",
+          period_start: Date.current - 1.year, period_end: Date.current + 1.year
+        )
+        assert person.within_period?
+      end
+
+      test "within_period? returns false when before period" do
+        person = RelatedPerson.new(
+          patient_dfn: "12345", name: "Jane Doe", relationship: "spouse",
+          period_start: Date.current + 1.month
+        )
+        refute person.within_period?
+      end
+
+      test "within_period? returns false when after period" do
+        person = RelatedPerson.new(
+          patient_dfn: "12345", name: "Jane Doe", relationship: "spouse",
+          period_end: Date.current - 1.month
+        )
+        refute person.within_period?
+      end
+
+      test "valid_for_authorization? checks active and period" do
+        person = RelatedPerson.new(
+          patient_dfn: "12345", name: "Jane Doe", relationship: "spouse", active: true
+        )
+        assert person.valid_for_authorization?
+
+        person.active = false
+        refute person.valid_for_authorization?
+      end
+
+      # =============================================================================
+      # RELATIONSHIP HELPER TESTS
+      # =============================================================================
+
+      test "relationship_display returns human-readable relationship" do
+        person = RelatedPerson.new(relationship: "parent")
+        assert_equal "Parent", person.relationship_display
+
+        person.relationship = "spouse"
+        assert_equal "Spouse", person.relationship_display
+
+        person.relationship = "guardian"
+        assert_equal "Guardian", person.relationship_display
+
+        person.relationship = nil
+        assert_equal "Unknown", person.relationship_display
+      end
+
+      test "guardian? returns true for guardians" do
+        assert RelatedPerson.new(relationship: "guardian").guardian?
+      end
+
+      test "caregiver? returns true for caregivers" do
+        assert RelatedPerson.new(relationship: "caregiver").caregiver?
+      end
+
+      test "family_member? returns true for family relationships" do
+        assert RelatedPerson.new(relationship: "parent").family_member?
+        assert RelatedPerson.new(relationship: "spouse").family_member?
+        assert RelatedPerson.new(relationship: "child").family_member?
+        assert RelatedPerson.new(relationship: "sibling").family_member?
+        refute RelatedPerson.new(relationship: "friend").family_member?
+        refute RelatedPerson.new(relationship: "guardian").family_member?
+      end
+
+      # =============================================================================
+      # PERSISTENCE TESTS
+      # =============================================================================
+
+      test "persisted? returns false for new person without id" do
+        person = RelatedPerson.new(patient_dfn: "12345", name: "Jane Doe", relationship: "spouse")
+        refute person.persisted?
+      end
+
+      test "persisted? returns true when id present" do
+        person = RelatedPerson.new(id: "42")
+        assert person.persisted?
+      end
+
+      # =============================================================================
+      # FHIR SERIALIZATION TESTS
+      # =============================================================================
+
+      test "to_fhir returns valid FHIR RelatedPerson resource" do
+        person = RelatedPerson.new(
+          id: "42", patient_dfn: "12345", name: "Jane Doe",
+          relationship: "spouse", active: true
+        )
+        fhir = person.to_fhir
+
+        assert_equal "RelatedPerson", fhir[:resourceType]
+        assert_equal "42", fhir[:id]
+        assert_equal true, fhir[:active]
+      end
+
+      test "to_fhir includes patient reference" do
+        person = RelatedPerson.new(patient_dfn: "12345", name: "Jane Doe", relationship: "spouse")
+        fhir = person.to_fhir
+
+        assert_not_nil fhir[:patient]
+        assert_equal "Patient/12345", fhir[:patient][:reference]
+      end
+
+      test "to_fhir includes relationship coding" do
+        person = RelatedPerson.new(patient_dfn: "12345", name: "Jane Doe", relationship: "guardian")
+        fhir = person.to_fhir
+
+        assert fhir[:relationship].any?
+        relationship = fhir[:relationship].first
+        coding = relationship[:coding].first
+        assert_equal "guardian", coding[:code]
+        assert_equal "Guardian", coding[:display]
+      end
+
+      test "to_fhir includes name" do
+        person = RelatedPerson.new(patient_dfn: "12345", name: "Jane Doe", relationship: "spouse")
+        fhir = person.to_fhir
+
+        assert fhir[:name].any?
+        assert_equal "Jane Doe", fhir[:name].first[:text]
+      end
+
+      test "to_fhir includes telecom" do
+        person = RelatedPerson.new(
+          patient_dfn: "12345", name: "Jane Doe", relationship: "spouse",
+          phone: "555-1234", email: "jane@example.com"
+        )
+        fhir = person.to_fhir
+
+        assert_equal 2, fhir[:telecom].count
+        phone = fhir[:telecom].find { |t| t[:system] == "phone" }
+        email = fhir[:telecom].find { |t| t[:system] == "email" }
+        assert_equal "555-1234", phone[:value]
+        assert_equal "jane@example.com", email[:value]
+      end
+
+      test "to_fhir includes period" do
+        person = RelatedPerson.new(
+          patient_dfn: "12345", name: "Jane Doe", relationship: "spouse",
+          period_start: Date.parse("2024-01-01"), period_end: Date.parse("2024-12-31")
+        )
+        fhir = person.to_fhir
+
+        assert_not_nil fhir[:period]
+        assert_equal "2024-01-01", fhir[:period][:start]
+        assert_equal "2024-12-31", fhir[:period][:end]
+      end
+
+      test "resource_class returns RelatedPerson" do
+        assert_equal "RelatedPerson", RelatedPerson.resource_class
+      end
+
+      test "from_fhir_attributes extracts attributes" do
+        fhir_resource = OpenStruct.new(
+          active: true,
+          patient: OpenStruct.new(reference: "Patient/12345"),
+          relationship: [ OpenStruct.new(coding: [ OpenStruct.new(code: "guardian") ]) ],
+          name: [ OpenStruct.new(text: "Jane Guardian") ]
+        )
+
+        attrs = RelatedPerson.from_fhir_attributes(fhir_resource)
+        assert_equal true, attrs[:active]
+        assert_equal "12345", attrs[:patient_dfn]
+        assert_equal "guardian", attrs[:relationship]
+        assert_equal "Jane Guardian", attrs[:name]
+      end
+
+      test "from_fhir creates related person from FHIR resource" do
+        fhir_resource = OpenStruct.new(
+          active: true,
+          patient: OpenStruct.new(reference: "Patient/12345"),
+          relationship: [ OpenStruct.new(coding: [ OpenStruct.new(code: "spouse") ]) ],
+          name: [ OpenStruct.new(text: "Jane Spouse") ]
+        )
+
+        person = RelatedPerson.from_fhir(fhir_resource)
+        assert person.is_a?(RelatedPerson)
+        assert_equal "12345", person.patient_dfn
+        assert_equal "spouse", person.relationship
+      end
+
+      # =============================================================================
+      # EDGE CASE TESTS
+      # =============================================================================
+
+      test "handles nil period in FHIR" do
+        person = RelatedPerson.new(
+          patient_dfn: "12345", name: "Jane Doe", relationship: "spouse",
+          period_start: nil, period_end: nil
+        )
+        fhir = person.to_fhir
+
+        assert_nil fhir[:period]
+      end
+
+      test "handles empty telecom in FHIR" do
+        person = RelatedPerson.new(
+          patient_dfn: "12345", name: "Jane Doe", relationship: "spouse",
+          phone: nil, email: nil
+        )
+        fhir = person.to_fhir
+
+        assert_equal [], fhir[:telecom]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Communication, Consent, RelatedPerson, DetectedIssue, CareTeam, BulkExport.

All ActiveModel-based. Unblocks downstream services, controllers, and decorators that reference these models.

1506 minitest, 180 cucumber. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)