### PR TITLE
Drug interaction adapter + CQM calculation + IIS exchange (+38 tests)

### DIFF
--- a/app/services/lakeraven/ehr/cqm_calculation_service.rb
+++ b/app/services/lakeraven/ehr/cqm_calculation_service.rb
@@ -3,13 +3,14 @@
 module Lakeraven
   module EHR
     class CqmCalculationService
-      def initialize(conditions: [], observations: [])
+      def initialize(conditions: [], observations: [], measure_resolver: nil)
         @conditions = conditions
         @observations = observations
+        @measure_resolver = measure_resolver || ->(id) { Measure.find(id) }
       end
 
       def evaluate(measure_id, patient_dfn, period:)
-        measure = Measure.find(measure_id)
+        measure = @measure_resolver.call(measure_id)
         return nil unless measure
 
         patient_conditions = @conditions.select { |c| c.respond_to?(:dfn) ? c.dfn.to_s == patient_dfn.to_s : true }

--- a/app/services/lakeraven/ehr/drug_interaction/base_adapter.rb
+++ b/app/services/lakeraven/ehr/drug_interaction/base_adapter.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    module DrugInteraction
+      class BaseAdapter
+        # Check drug-drug interactions for a set of medications.
+        # Returns Array<InteractionAlert>
+        def check_interactions(medications)
+          raise NotImplementedError, "#{self.class}#check_interactions"
+        end
+
+        # Check drug-allergy cross-reactivity for a medication against known allergies.
+        # Returns Array<InteractionAlert>
+        def check_allergies(medication, allergies)
+          raise NotImplementedError, "#{self.class}#check_allergies"
+        end
+      end
+    end
+  end
+end

--- a/app/services/lakeraven/ehr/drug_interaction/mock_adapter.rb
+++ b/app/services/lakeraven/ehr/drug_interaction/mock_adapter.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+module Lakeraven
+  module EHR
+    module DrugInteraction
+      # YAML-based mock adapter for testing and development.
+      # Loads a static knowledge base of clinically significant interactions.
+      class MockAdapter < BaseAdapter
+        KNOWLEDGE_BASE_PATH = File.expand_path("../../../../../db/data/drug_interactions.yml", __dir__)
+
+        def initialize(knowledge_base_path: KNOWLEDGE_BASE_PATH)
+          kb = YAML.load_file(knowledge_base_path)
+          @class_members = kb["class_members"] || {}
+          @drug_drug_rules = kb["drug_drug"] || []
+          @drug_allergy_rules = kb["drug_allergy"] || []
+        end
+
+        def check_interactions(medications)
+          return [] if medications.length < 2
+
+          alerts = []
+          medications.combination(2).each do |med_a, med_b|
+            @drug_drug_rules.each do |rule|
+              if pair_matches?(med_a, med_b, rule)
+                alerts << InteractionAlert.new(
+                  severity: rule["severity"].to_sym,
+                  drug_a: med_a.medication_display,
+                  drug_b: med_b.medication_display,
+                  description: rule["description"],
+                  source: rule["source"]
+                )
+              end
+            end
+          end
+          alerts
+        end
+
+        def check_allergies(medication, allergies)
+          med_allergies = allergies.select { |a| a.category&.downcase == "medication" }
+          return [] if med_allergies.empty?
+
+          alerts = []
+          med_allergies.each do |allergy|
+            @drug_allergy_rules.each do |rule|
+              if allergy_matches?(medication, allergy, rule)
+                alerts << InteractionAlert.new(
+                  severity: rule["severity"].to_sym,
+                  drug_a: medication.medication_display,
+                  drug_b: "#{allergy.allergen} allergy",
+                  description: rule["description"],
+                  source: rule["source"],
+                  interaction_type: :drug_allergy
+                )
+              end
+            end
+          end
+          alerts
+        end
+
+        private
+
+        def pair_matches?(med_a, med_b, rule)
+          (med_in_class?(med_a, rule["drug_a_class"]) && med_in_class?(med_b, rule["drug_b_class"])) ||
+            (med_in_class?(med_a, rule["drug_b_class"]) && med_in_class?(med_b, rule["drug_a_class"]))
+        end
+
+        def allergy_matches?(medication, allergy, rule)
+          allergy_in_class?(allergy, rule["allergen_class"]) && med_in_class?(medication, rule["drug_class"])
+        end
+
+        def med_in_class?(medication, class_name)
+          members = @class_members[class_name]
+          return false unless members
+
+          codes = members["rxnorm"] || []
+          names = members["names"] || []
+
+          codes.include?(medication.medication_code.to_s) ||
+            names.any? { |n| medication.medication_display&.downcase&.include?(n.downcase) }
+        end
+
+        def allergy_in_class?(allergy, class_name)
+          members = @class_members[class_name]
+          return false unless members
+
+          codes = members["rxnorm"] || []
+          names = members["names"] || []
+
+          codes.include?(allergy.allergen_code.to_s) ||
+            names.any? { |n| allergy.allergen&.downcase&.include?(n.downcase) }
+        end
+      end
+    end
+  end
+end

--- a/app/services/lakeraven/ehr/drug_interaction_service.rb
+++ b/app/services/lakeraven/ehr/drug_interaction_service.rb
@@ -1,107 +1,30 @@
 # frozen_string_literal: true
 
-require "yaml"
-
 module Lakeraven
   module EHR
     # Orchestrates drug-drug and drug-allergy interaction checking.
     # ONC § 170.315(a)(4) compliance.
     #
-    # Uses a local YAML knowledge base by default. Pluggable adapter
-    # for RPMS pharmacy RPCs or external services.
+    # Accepts a pluggable adapter (default: YAML mock adapter).
+    # Production adapters: RPMS Pharmacy RPC, NLM DailyMed, FDB.
     class DrugInteractionService
-      KNOWLEDGE_BASE_PATH = File.expand_path("../../../../db/data/drug_interactions.yml", __dir__)
-
-      def initialize
-        kb = YAML.load_file(KNOWLEDGE_BASE_PATH)
-        @class_members = kb["class_members"] || {}
-        @drug_drug_rules = kb["drug_drug"] || []
-        @drug_allergy_rules = kb["drug_allergy"] || []
+      def initialize(adapter: nil)
+        @adapter = adapter || DrugInteraction::MockAdapter.new
       end
 
       def check(active_medications:, proposed_medication:, allergies:)
-        all_meds = active_medications + [ proposed_medication ]
+        all_meds = active_medications + [proposed_medication]
 
         interactions = []
-        interactions.concat(check_drug_drug(all_meds))
-        interactions.concat(check_drug_allergy(proposed_medication, allergies))
+        interactions.concat(@adapter.check_interactions(all_meds))
+        interactions.concat(@adapter.check_allergies(proposed_medication, allergies))
 
         DrugInteractionResult.new(interactions: interactions, decision_source: :local)
-      end
-
-      private
-
-      def check_drug_drug(medications)
-        return [] if medications.length < 2
-
-        alerts = []
-        medications.combination(2).each do |med_a, med_b|
-          @drug_drug_rules.each do |rule|
-            if pair_matches?(med_a, med_b, rule)
-              alerts << InteractionAlert.new(
-                severity: rule["severity"].to_sym,
-                drug_a: med_a.medication_display,
-                drug_b: med_b.medication_display,
-                description: rule["description"],
-                source: rule["source"]
-              )
-            end
-          end
-        end
-        alerts
-      end
-
-      def check_drug_allergy(medication, allergies)
-        med_allergies = allergies.select { |a| a.category&.downcase == "medication" }
-        return [] if med_allergies.empty?
-
-        alerts = []
-        med_allergies.each do |allergy|
-          @drug_allergy_rules.each do |rule|
-            if allergy_matches?(medication, allergy, rule)
-              alerts << InteractionAlert.new(
-                severity: rule["severity"].to_sym,
-                drug_a: medication.medication_display,
-                drug_b: "#{allergy.allergen} allergy",
-                description: rule["description"],
-                source: rule["source"],
-                interaction_type: :drug_allergy
-              )
-            end
-          end
-        end
-        alerts
-      end
-
-      def pair_matches?(med_a, med_b, rule)
-        (med_in_class?(med_a, rule["drug_a_class"]) && med_in_class?(med_b, rule["drug_b_class"])) ||
-          (med_in_class?(med_a, rule["drug_b_class"]) && med_in_class?(med_b, rule["drug_a_class"]))
-      end
-
-      def allergy_matches?(medication, allergy, rule)
-        allergy_in_class?(allergy, rule["allergen_class"]) && med_in_class?(medication, rule["drug_class"])
-      end
-
-      def med_in_class?(medication, class_name)
-        members = @class_members[class_name]
-        return false unless members
-
-        codes = members["rxnorm"] || []
-        names = members["names"] || []
-
-        codes.include?(medication.medication_code.to_s) ||
-          names.any? { |n| medication.medication_display&.downcase&.include?(n.downcase) }
-      end
-
-      def allergy_in_class?(allergy, class_name)
-        members = @class_members[class_name]
-        return false unless members
-
-        codes = members["rxnorm"] || []
-        names = members["names"] || []
-
-        codes.include?(allergy.allergen_code.to_s) ||
-          names.any? { |n| allergy.allergen&.downcase&.include?(n.downcase) }
+      rescue => e
+        DrugInteractionResult.new(
+          interactions: [], incomplete: true,
+          incomplete_reason: e.message, decision_source: :local
+        )
       end
     end
   end

--- a/app/services/lakeraven/ehr/drug_interaction_service.rb
+++ b/app/services/lakeraven/ehr/drug_interaction_service.rb
@@ -13,7 +13,7 @@ module Lakeraven
       end
 
       def check(active_medications:, proposed_medication:, allergies:)
-        all_meds = active_medications + [proposed_medication]
+        all_meds = active_medications + [ proposed_medication ]
 
         interactions = []
         interactions.concat(@adapter.check_interactions(all_meds))

--- a/test/services/lakeraven/ehr/cqm_calculation_service_test.rb
+++ b/test/services/lakeraven/ehr/cqm_calculation_service_test.rb
@@ -19,8 +19,8 @@ module Lakeraven
       test "evaluate returns MeasureReport for individual patient" do
         service = build_service(
           measure: @diabetes_measure,
-          conditions: [build_condition("pt_1", "2.16.840.1.113883.3.464.1003.103.12.1001")],
-          observations: [build_observation("pt_1", 8.5, Date.new(2026, 3, 1))]
+          conditions: [ build_condition("pt_1", "2.16.840.1.113883.3.464.1003.103.12.1001") ],
+          observations: [ build_observation("pt_1", 8.5, Date.new(2026, 3, 1)) ]
         )
 
         report = service.evaluate("CMS122v5", "pt_1", period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
@@ -34,8 +34,8 @@ module Lakeraven
       test "evaluate counts patient in numerator when threshold met" do
         service = build_service(
           measure: @diabetes_measure,
-          conditions: [build_condition("pt_1", "2.16.840.1.113883.3.464.1003.103.12.1001")],
-          observations: [build_observation("pt_1", 9.5, Date.new(2026, 6, 1))]
+          conditions: [ build_condition("pt_1", "2.16.840.1.113883.3.464.1003.103.12.1001") ],
+          observations: [ build_observation("pt_1", 9.5, Date.new(2026, 6, 1)) ]
         )
 
         report = service.evaluate("CMS122v5", "pt_1", period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
@@ -45,8 +45,8 @@ module Lakeraven
       test "evaluate excludes patient from numerator when threshold not met" do
         service = build_service(
           measure: @diabetes_measure,
-          conditions: [build_condition("pt_1", "2.16.840.1.113883.3.464.1003.103.12.1001")],
-          observations: [build_observation("pt_1", 7.0, Date.new(2026, 6, 1))]
+          conditions: [ build_condition("pt_1", "2.16.840.1.113883.3.464.1003.103.12.1001") ],
+          observations: [ build_observation("pt_1", 7.0, Date.new(2026, 6, 1)) ]
         )
 
         report = service.evaluate("CMS122v5", "pt_1", period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
@@ -56,8 +56,8 @@ module Lakeraven
       test "evaluate excludes patient without qualifying condition" do
         service = build_service(
           measure: @diabetes_measure,
-          conditions: [build_condition("pt_1", "other-valueset")],
-          observations: [build_observation("pt_1", 9.5, Date.new(2026, 6, 1))]
+          conditions: [ build_condition("pt_1", "other-valueset") ],
+          observations: [ build_observation("pt_1", 9.5, Date.new(2026, 6, 1)) ]
         )
 
         report = service.evaluate("CMS122v5", "pt_1", period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
@@ -67,8 +67,8 @@ module Lakeraven
       test "evaluate excludes observations outside measurement period" do
         service = build_service(
           measure: @diabetes_measure,
-          conditions: [build_condition("pt_1", "2.16.840.1.113883.3.464.1003.103.12.1001")],
-          observations: [build_observation("pt_1", 9.5, Date.new(2025, 6, 1))]
+          conditions: [ build_condition("pt_1", "2.16.840.1.113883.3.464.1003.103.12.1001") ],
+          observations: [ build_observation("pt_1", 9.5, Date.new(2025, 6, 1)) ]
         )
 
         report = service.evaluate("CMS122v5", "pt_1", period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
@@ -99,7 +99,7 @@ module Lakeraven
         service = build_service(
           measure: @screening_measure,
           conditions: [],
-          observations: [build_observation("pt_1", nil, Date.new(2026, 6, 1))]
+          observations: [ build_observation("pt_1", nil, Date.new(2026, 6, 1)) ]
         )
 
         report = service.evaluate("CMS130v5", "pt_1", period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))

--- a/test/services/lakeraven/ehr/cqm_calculation_service_test.rb
+++ b/test/services/lakeraven/ehr/cqm_calculation_service_test.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "ostruct"
+
+module Lakeraven
+  module EHR
+    class CqmCalculationServiceTest < ActiveSupport::TestCase
+      setup do
+        @diabetes_measure = Measure.new(id: "CMS122v5", title: "Diabetes: Hemoglobin A1c Poor Control")
+        @diabetes_measure.initial_population = { "resource_type" => "Condition", "valueset_id" => "2.16.840.1.113883.3.464.1003.103.12.1001" }
+        @diabetes_measure.numerator = { "value_threshold" => 9.0, "value_comparator" => ">" }
+
+        @screening_measure = Measure.new(id: "CMS130v5", title: "Colorectal Cancer Screening")
+        @screening_measure.initial_population = { "resource_type" => "Patient" }
+        @screening_measure.numerator = {}
+      end
+
+      test "evaluate returns MeasureReport for individual patient" do
+        service = build_service(
+          measure: @diabetes_measure,
+          conditions: [build_condition("pt_1", "2.16.840.1.113883.3.464.1003.103.12.1001")],
+          observations: [build_observation("pt_1", 8.5, Date.new(2026, 3, 1))]
+        )
+
+        report = service.evaluate("CMS122v5", "pt_1", period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
+
+        assert_kind_of MeasureReport, report
+        assert_equal "individual", report.report_type
+        assert_equal 1, report.initial_population_count
+        assert_equal 1, report.denominator_count
+      end
+
+      test "evaluate counts patient in numerator when threshold met" do
+        service = build_service(
+          measure: @diabetes_measure,
+          conditions: [build_condition("pt_1", "2.16.840.1.113883.3.464.1003.103.12.1001")],
+          observations: [build_observation("pt_1", 9.5, Date.new(2026, 6, 1))]
+        )
+
+        report = service.evaluate("CMS122v5", "pt_1", period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
+        assert_equal 1, report.numerator_count
+      end
+
+      test "evaluate excludes patient from numerator when threshold not met" do
+        service = build_service(
+          measure: @diabetes_measure,
+          conditions: [build_condition("pt_1", "2.16.840.1.113883.3.464.1003.103.12.1001")],
+          observations: [build_observation("pt_1", 7.0, Date.new(2026, 6, 1))]
+        )
+
+        report = service.evaluate("CMS122v5", "pt_1", period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
+        assert_equal 0, report.numerator_count
+      end
+
+      test "evaluate excludes patient without qualifying condition" do
+        service = build_service(
+          measure: @diabetes_measure,
+          conditions: [build_condition("pt_1", "other-valueset")],
+          observations: [build_observation("pt_1", 9.5, Date.new(2026, 6, 1))]
+        )
+
+        report = service.evaluate("CMS122v5", "pt_1", period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
+        assert_equal 0, report.initial_population_count
+      end
+
+      test "evaluate excludes observations outside measurement period" do
+        service = build_service(
+          measure: @diabetes_measure,
+          conditions: [build_condition("pt_1", "2.16.840.1.113883.3.464.1003.103.12.1001")],
+          observations: [build_observation("pt_1", 9.5, Date.new(2025, 6, 1))]
+        )
+
+        report = service.evaluate("CMS122v5", "pt_1", period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
+        assert_equal 0, report.numerator_count
+      end
+
+      test "evaluate_population aggregates across patients" do
+        service = build_service(
+          measure: @diabetes_measure,
+          conditions: [
+            build_condition("pt_1", "2.16.840.1.113883.3.464.1003.103.12.1001"),
+            build_condition("pt_2", "2.16.840.1.113883.3.464.1003.103.12.1001")
+          ],
+          observations: [
+            build_observation("pt_1", 9.5, Date.new(2026, 6, 1)),
+            build_observation("pt_2", 7.0, Date.new(2026, 6, 1))
+          ]
+        )
+
+        report = service.evaluate_population("CMS122v5", %w[pt_1 pt_2], period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
+
+        assert_equal "summary", report.report_type
+        assert_equal 2, report.initial_population_count
+        assert_equal 1, report.numerator_count
+      end
+
+      test "evaluate with presence-based numerator counts any observation" do
+        service = build_service(
+          measure: @screening_measure,
+          conditions: [],
+          observations: [build_observation("pt_1", nil, Date.new(2026, 6, 1))]
+        )
+
+        report = service.evaluate("CMS130v5", "pt_1", period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
+        assert_equal 1, report.numerator_count
+      end
+
+      private
+
+      def build_service(measure:, conditions: [], observations: [])
+        CqmCalculationService.new(
+          conditions: conditions,
+          observations: observations,
+          measure_resolver: ->(_id) { measure }
+        )
+      end
+
+      def build_condition(dfn, valueset_id)
+        ::OpenStruct.new(dfn: dfn, valueset_id: valueset_id)
+      end
+
+      def build_observation(dfn, value, effective_date)
+        ::OpenStruct.new(dfn: dfn, value: value, effective_date: effective_date)
+      end
+    end
+  end
+end

--- a/test/services/lakeraven/ehr/drug_interaction_service_test.rb
+++ b/test/services/lakeraven/ehr/drug_interaction_service_test.rb
@@ -62,19 +62,19 @@ module Lakeraven
 
       test "DrugInteractionResult#safe? returns false when interactions exist" do
         alert = InteractionAlert.new(severity: :moderate, drug_a: "a", drug_b: "b", description: "test")
-        result = DrugInteractionResult.new(interactions: [alert])
+        result = DrugInteractionResult.new(interactions: [ alert ])
         refute result.safe?
       end
 
       test "DrugInteractionResult#blocking? returns true for high-severity" do
         alert = InteractionAlert.new(severity: :high, drug_a: "warfarin", drug_b: "aspirin", description: "Bleeding")
-        result = DrugInteractionResult.new(interactions: [alert])
+        result = DrugInteractionResult.new(interactions: [ alert ])
         assert result.blocking?
       end
 
       test "DrugInteractionResult#blocking? returns false for moderate-only" do
         alert = InteractionAlert.new(severity: :moderate, drug_a: "a", drug_b: "b", description: "test")
-        result = DrugInteractionResult.new(interactions: [alert])
+        result = DrugInteractionResult.new(interactions: [ alert ])
         refute result.blocking?
       end
 
@@ -104,7 +104,7 @@ module Lakeraven
 
       test "DrugInteractionResult#to_fhir_detected_issues maps interactions" do
         alert = InteractionAlert.new(severity: :high, drug_a: "warfarin", drug_b: "aspirin", description: "Bleeding risk")
-        result = DrugInteractionResult.new(interactions: [alert])
+        result = DrugInteractionResult.new(interactions: [ alert ])
         issues = result.to_fhir_detected_issues
 
         assert_equal 1, issues.length
@@ -148,7 +148,7 @@ module Lakeraven
         service = DrugInteractionService.new
 
         result = service.check(
-          active_medications: [build_medication("warfarin", "11289")],
+          active_medications: [ build_medication("warfarin", "11289") ],
           proposed_medication: build_medication("aspirin", "1191"),
           allergies: []
         )
@@ -164,7 +164,7 @@ module Lakeraven
         result = service.check(
           active_medications: [],
           proposed_medication: build_medication("amoxicillin", "723"),
-          allergies: [build_allergy("penicillin", "7984")]
+          allergies: [ build_allergy("penicillin", "7984") ]
         )
 
         allergy_alerts = result.interactions.select { |a| a.interaction_type == :drug_allergy }
@@ -208,7 +208,7 @@ module Lakeraven
         service = DrugInteractionService.new(adapter: failing_adapter)
 
         result = service.check(
-          active_medications: [build_medication("warfarin", "11289")],
+          active_medications: [ build_medication("warfarin", "11289") ],
           proposed_medication: build_medication("aspirin", "1191"),
           allergies: []
         )
@@ -225,7 +225,7 @@ module Lakeraven
         service = DrugInteractionService.new(adapter: null_adapter)
 
         result = service.check(
-          active_medications: [build_medication("warfarin", "11289")],
+          active_medications: [ build_medication("warfarin", "11289") ],
           proposed_medication: build_medication("aspirin", "1191"),
           allergies: []
         )

--- a/test/services/lakeraven/ehr/drug_interaction_service_test.rb
+++ b/test/services/lakeraven/ehr/drug_interaction_service_test.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "ostruct"
+
+module Lakeraven
+  module EHR
+    class DrugInteractionServiceTest < ActiveSupport::TestCase
+      # =============================================================================
+      # INTERACTION ALERT VALUE OBJECT
+      # =============================================================================
+
+      test "InteractionAlert stores severity, drugs, and description" do
+        alert = InteractionAlert.new(
+          severity: :high, drug_a: "warfarin", drug_b: "aspirin",
+          description: "Increased bleeding risk", source: "FDA"
+        )
+
+        assert_equal :high, alert.severity
+        assert_equal "warfarin", alert.drug_a
+        assert_equal "aspirin", alert.drug_b
+        assert_equal "Increased bleeding risk", alert.description
+        assert_equal "FDA", alert.source
+      end
+
+      test "InteractionAlert#severe? returns true for high severity" do
+        alert = InteractionAlert.new(severity: :high, drug_a: "a", drug_b: "b", description: "test")
+        assert alert.severe?
+      end
+
+      test "InteractionAlert#severe? returns false for moderate severity" do
+        alert = InteractionAlert.new(severity: :moderate, drug_a: "a", drug_b: "b", description: "test")
+        refute alert.severe?
+      end
+
+      test "InteractionAlert#severe? returns false for low severity" do
+        alert = InteractionAlert.new(severity: :low, drug_a: "a", drug_b: "b", description: "test")
+        refute alert.severe?
+      end
+
+      test "InteractionAlert defaults interaction_type to drug_drug" do
+        alert = InteractionAlert.new(severity: :moderate, drug_a: "a", drug_b: "b", description: "test")
+        assert_equal :drug_drug, alert.interaction_type
+      end
+
+      test "InteractionAlert supports drug-allergy type" do
+        alert = InteractionAlert.new(
+          severity: :high, drug_a: "amoxicillin", drug_b: "penicillin allergy",
+          description: "Cross-reactivity risk", interaction_type: :drug_allergy
+        )
+        assert_equal :drug_allergy, alert.interaction_type
+      end
+
+      # =============================================================================
+      # DRUG INTERACTION RESULT VALUE OBJECT
+      # =============================================================================
+
+      test "DrugInteractionResult#safe? returns true when no interactions" do
+        result = DrugInteractionResult.new(interactions: [])
+        assert result.safe?
+      end
+
+      test "DrugInteractionResult#safe? returns false when interactions exist" do
+        alert = InteractionAlert.new(severity: :moderate, drug_a: "a", drug_b: "b", description: "test")
+        result = DrugInteractionResult.new(interactions: [alert])
+        refute result.safe?
+      end
+
+      test "DrugInteractionResult#blocking? returns true for high-severity" do
+        alert = InteractionAlert.new(severity: :high, drug_a: "warfarin", drug_b: "aspirin", description: "Bleeding")
+        result = DrugInteractionResult.new(interactions: [alert])
+        assert result.blocking?
+      end
+
+      test "DrugInteractionResult#blocking? returns false for moderate-only" do
+        alert = InteractionAlert.new(severity: :moderate, drug_a: "a", drug_b: "b", description: "test")
+        result = DrugInteractionResult.new(interactions: [alert])
+        refute result.blocking?
+      end
+
+      test "DrugInteractionResult#blocking? returns false when empty" do
+        result = DrugInteractionResult.new(interactions: [])
+        refute result.blocking?
+      end
+
+      test "DrugInteractionResult.success factory" do
+        result = DrugInteractionResult.success
+        assert result.safe?
+        refute result.blocking?
+        assert_empty result.interactions
+      end
+
+      test "DrugInteractionResult.failure factory" do
+        result = DrugInteractionResult.failure(message: "Adapter unavailable")
+        refute result.safe?
+        assert_equal "Adapter unavailable", result.message
+      end
+
+      test "DrugInteractionResult#incomplete? when flagged" do
+        result = DrugInteractionResult.new(interactions: [], incomplete: true, incomplete_reason: "Timeout")
+        assert result.incomplete?
+        refute result.safe?
+      end
+
+      test "DrugInteractionResult#to_fhir_detected_issues maps interactions" do
+        alert = InteractionAlert.new(severity: :high, drug_a: "warfarin", drug_b: "aspirin", description: "Bleeding risk")
+        result = DrugInteractionResult.new(interactions: [alert])
+        issues = result.to_fhir_detected_issues
+
+        assert_equal 1, issues.length
+        assert_equal "DetectedIssue", issues.first[:resourceType]
+        assert_equal "high", issues.first[:severity]
+        assert_equal "Bleeding risk", issues.first[:detail][:text]
+      end
+
+      # =============================================================================
+      # BASE ADAPTER INTERFACE
+      # =============================================================================
+
+      test "BaseAdapter#check_interactions raises NotImplementedError" do
+        adapter = DrugInteraction::BaseAdapter.new
+        assert_raises(NotImplementedError) { adapter.check_interactions([]) }
+      end
+
+      test "BaseAdapter#check_allergies raises NotImplementedError" do
+        adapter = DrugInteraction::BaseAdapter.new
+        assert_raises(NotImplementedError) { adapter.check_allergies("med", []) }
+      end
+
+      # =============================================================================
+      # SERVICE ORCHESTRATION (adapter-backed)
+      # =============================================================================
+
+      test "check returns safe result when no interactions" do
+        service = DrugInteractionService.new
+
+        result = service.check(
+          active_medications: [],
+          proposed_medication: build_medication("acetaminophen", "161"),
+          allergies: []
+        )
+
+        assert result.safe?
+        assert_empty result.interactions
+      end
+
+      test "check detects drug-drug interaction via mock adapter" do
+        service = DrugInteractionService.new
+
+        result = service.check(
+          active_medications: [build_medication("warfarin", "11289")],
+          proposed_medication: build_medication("aspirin", "1191"),
+          allergies: []
+        )
+
+        refute result.safe?
+        assert result.blocking?
+        assert result.interactions.any? { |a| a.drug_a.include?("warfarin") || a.drug_b.include?("warfarin") }
+      end
+
+      test "check detects drug-allergy interaction via mock adapter" do
+        service = DrugInteractionService.new
+
+        result = service.check(
+          active_medications: [],
+          proposed_medication: build_medication("amoxicillin", "723"),
+          allergies: [build_allergy("penicillin", "7984")]
+        )
+
+        allergy_alerts = result.interactions.select { |a| a.interaction_type == :drug_allergy }
+        assert allergy_alerts.any?
+        assert_includes allergy_alerts.first.drug_b.downcase, "penicillin"
+      end
+
+      test "check returns DrugInteractionResult" do
+        service = DrugInteractionService.new
+
+        result = service.check(
+          active_medications: [],
+          proposed_medication: build_medication("tylenol", "161"),
+          allergies: []
+        )
+
+        assert_kind_of DrugInteractionResult, result
+      end
+
+      test "check with multiple active meds checks all combinations" do
+        service = DrugInteractionService.new
+
+        result = service.check(
+          active_medications: [
+            build_medication("warfarin", "11289"),
+            build_medication("metformin", "6809")
+          ],
+          proposed_medication: build_medication("aspirin", "1191"),
+          allergies: []
+        )
+
+        assert_kind_of DrugInteractionResult, result
+        assert result.interactions.any?
+      end
+
+      test "check handles adapter failure gracefully" do
+        failing_adapter = ::OpenStruct.new
+        failing_adapter.define_singleton_method(:check_interactions) { |_| raise "Connection refused" }
+        failing_adapter.define_singleton_method(:check_allergies) { |_, _| [] }
+
+        service = DrugInteractionService.new(adapter: failing_adapter)
+
+        result = service.check(
+          active_medications: [build_medication("warfarin", "11289")],
+          proposed_medication: build_medication("aspirin", "1191"),
+          allergies: []
+        )
+
+        assert result.incomplete?
+        assert_includes result.incomplete_reason, "Connection refused"
+      end
+
+      test "check accepts custom adapter" do
+        null_adapter = ::OpenStruct.new
+        null_adapter.define_singleton_method(:check_interactions) { |_| [] }
+        null_adapter.define_singleton_method(:check_allergies) { |_, _| [] }
+
+        service = DrugInteractionService.new(adapter: null_adapter)
+
+        result = service.check(
+          active_medications: [build_medication("warfarin", "11289")],
+          proposed_medication: build_medication("aspirin", "1191"),
+          allergies: []
+        )
+
+        assert result.safe?
+      end
+
+      private
+
+      def build_medication(display, code)
+        ::OpenStruct.new(medication_display: display, medication_code: code)
+      end
+
+      def build_allergy(allergen, code)
+        ::OpenStruct.new(allergen: allergen, allergen_code: code, category: "medication")
+      end
+    end
+  end
+end

--- a/test/services/lakeraven/ehr/state_iis_exchange_service_test.rb
+++ b/test/services/lakeraven/ehr/state_iis_exchange_service_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class StateIisExchangeServiceTest < ActiveSupport::TestCase
+      test "send_immunizations succeeds with mock adapter" do
+        service = StateIisExchangeService.new
+        result = service.send_immunizations("pt_001")
+
+        assert result.success?
+      end
+
+      test "send_immunizations returns failure when disabled" do
+        service = StateIisExchangeService.new(enabled: false)
+        result = service.send_immunizations("pt_001")
+
+        assert result.failure?
+        assert_includes result.message, "disabled"
+      end
+
+      test "send_immunizations returns failure when facility code missing" do
+        service = StateIisExchangeService.new(facility_code: nil)
+        result = service.send_immunizations("pt_001")
+
+        assert result.failure?
+        assert_includes result.message, "facility code"
+      end
+
+      test "query_history succeeds with mock adapter" do
+        service = StateIisExchangeService.new
+        result = service.query_history("pt_001")
+
+        assert result.success?
+      end
+
+      test "query_history returns failure when disabled" do
+        service = StateIisExchangeService.new(enabled: false)
+        result = service.query_history("pt_001")
+
+        assert result.failure?
+      end
+
+      test "process_responses succeeds with mock adapter" do
+        service = StateIisExchangeService.new
+        result = service.process_responses
+
+        assert result.success?
+      end
+
+      test "sync_patient orchestrates query and process" do
+        service = StateIisExchangeService.new
+        result = service.sync_patient("pt_001")
+
+        assert result.success?
+        assert_equal "pt_001", result.data[:dfn]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Refactor DrugInteractionService to adapter pattern: `BaseAdapter` interface + `MockAdapter` (YAML knowledge base)
- Add CqmCalculationService tests (7): individual/population evaluation, threshold-based numerator, period filtering
- Add StateIisExchangeService tests (7): send/query/process/sync lifecycle, disabled/config error handling
- Add DrugInteractionService tests (24): value objects, adapter interface, orchestration, error handling

## Architecture

DrugInteractionService now accepts a pluggable adapter:
```ruby
service = DrugInteractionService.new(adapter: DrugInteraction::MockAdapter.new)
# Production: DrugInteraction::RpmsPharmacyAdapter, FdbAdapter, etc.
```

CqmCalculationService accepts `measure_resolver:` for testability without filesystem YAML fixtures.

## Test plan

- [x] `bundle exec rails test` — 2191 runs, 0 failures
- [x] `bundle exec cucumber` — 323 scenarios, 323 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)