### PR TITLE
ServiceRequestGateway: delete, cancel, deletable? (+10 tests)

### DIFF
--- a/app/gateways/lakeraven/ehr/service_request_gateway.rb
+++ b/app/gateways/lakeraven/ehr/service_request_gateway.rb
@@ -5,9 +5,63 @@ require "rpms_rpc/mappings"
 module Lakeraven
   module EHR
     class ServiceRequestGateway
+      DELETABLE_STATUSES = %w[draft pending submitted].freeze
+
       def self.for_patient(dfn)
         RpmsRpc::DataMapper.referral_search.fetch_many(dfn.to_s)
       end
+
+      def self.delete(ien, reason: nil)
+        referral = find_referral(ien)
+        return { success: false, error: "Referral not found", ien: ien } unless referral
+
+        status = referral[:status]&.downcase || "unknown"
+
+        unless DELETABLE_STATUSES.include?(status)
+          return { success: false, error: "Cannot delete #{status} referral", ien: ien }
+        end
+
+        if status != "draft" && reason.blank?
+          return { success: false, error: "Reason required for #{status} referral", ien: ien }
+        end
+
+        result = RpmsRpc::DataMapper.referral_delete.fetch_one(ien, reason)
+        if result && result[:success]
+          { success: true, message: "Referral deleted", ien: ien }
+        else
+          { success: false, error: result&.dig(:message) || "Delete failed", ien: ien }
+        end
+      rescue => e
+        { success: false, error: PhiSanitizer.sanitize_message(e.message), ien: ien }
+      end
+
+      def self.cancel(ien, reason: nil)
+        return { success: false, error: "Reason required for cancellation" } if reason.blank?
+
+        referral = find_referral(ien)
+        return { success: false, error: "Referral not found" } unless referral
+
+        result = RpmsRpc::DataMapper.referral_delete.fetch_one(ien, reason)
+        if result && result[:success]
+          { success: true, message: "Referral cancelled", ien: ien }
+        else
+          { success: false, error: result&.dig(:message) || "Cancellation failed", ien: ien }
+        end
+      rescue => e
+        { success: false, error: PhiSanitizer.sanitize_message(e.message), ien: ien }
+      end
+
+      def self.deletable?(ien)
+        referral = find_referral(ien)
+        return false unless referral
+
+        DELETABLE_STATUSES.include?(referral[:status]&.downcase)
+      end
+
+      def self.find_referral(ien)
+        RpmsRpc::DataMapper.referral_detail.fetch_one(ien.to_s)
+      end
+      private_class_method :find_referral
     end
   end
 end

--- a/test/gateways/lakeraven/ehr/service_request_gateway_delete_test.rb
+++ b/test/gateways/lakeraven/ehr/service_request_gateway_delete_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class ServiceRequestGatewayDeleteTest < ActiveSupport::TestCase
+      # =============================================================================
+      # DELETE DRAFT REFERRALS
+      # =============================================================================
+
+      test "delete removes draft referral" do
+        result = ServiceRequestGateway.delete("SR-DRAFT-001")
+
+        assert result[:success]
+      end
+
+      test "delete returns referral IEN on success" do
+        result = ServiceRequestGateway.delete("SR-DRAFT-001")
+
+        assert result[:success]
+        assert_equal "SR-DRAFT-001", result[:ien]
+      end
+
+      # =============================================================================
+      # DELETE PENDING REFERRALS
+      # =============================================================================
+
+      test "delete pending referral requires reason" do
+        result = ServiceRequestGateway.delete("SR-PENDING-001")
+
+        refute result[:success]
+        assert_includes result[:error].downcase, "reason"
+      end
+
+      test "delete pending referral with reason succeeds" do
+        result = ServiceRequestGateway.delete("SR-PENDING-001", reason: "Entered in error")
+
+        assert result[:success]
+      end
+
+      # =============================================================================
+      # CANNOT DELETE AUTHORIZED/COMPLETED
+      # =============================================================================
+
+      test "delete authorized referral fails" do
+        result = ServiceRequestGateway.delete("SR-AUTHORIZED-001")
+
+        refute result[:success]
+        assert_includes result[:error].downcase, "cannot delete"
+      end
+
+      # =============================================================================
+      # CANCEL
+      # =============================================================================
+
+      test "cancel authorized referral with reason succeeds" do
+        result = ServiceRequestGateway.cancel("SR-AUTHORIZED-001", reason: "Patient withdrew")
+
+        assert result[:success]
+      end
+
+      test "cancel requires reason" do
+        result = ServiceRequestGateway.cancel("SR-AUTHORIZED-001")
+
+        refute result[:success]
+        assert_includes result[:error].downcase, "reason"
+      end
+
+      # =============================================================================
+      # ERROR HANDLING
+      # =============================================================================
+
+      test "delete nonexistent referral fails" do
+        result = ServiceRequestGateway.delete("NONEXISTENT")
+
+        refute result[:success]
+      end
+
+      # =============================================================================
+      # DELETABLE STATUS CHECK
+      # =============================================================================
+
+      test "deletable? returns true for draft" do
+        assert ServiceRequestGateway.deletable?("SR-DRAFT-001")
+      end
+
+      test "deletable? returns false for authorized" do
+        refute ServiceRequestGateway.deletable?("SR-AUTHORIZED-001")
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -121,6 +121,17 @@ RpmsRpc.mock! do |m|
   m.seed_user("303", credentials: "testclerk;test123", name: "CLERK,TEST", role: :clerk)
   m.seed_user("304", credentials: "lindarodriguez;test123", name: "RODRIGUEZ,LINDA", role: :case_manager,
                      security_keys: [ :prc_supervisor, :cprs_gui_chart ])
+
+  # Referral details (for ServiceRequestGateway delete/cancel tests)
+  m.seed(:referral_detail, "SR-DRAFT-001", { ien: "SR-DRAFT-001", status: "draft", patient_dfn: "1",
+                                              service: "Cardiology", to_service: "Cardiology Clinic" })
+  m.seed(:referral_detail, "SR-PENDING-001", { ien: "SR-PENDING-001", status: "pending", patient_dfn: "1",
+                                                service: "Orthopedics", to_service: "Ortho Clinic" })
+  m.seed(:referral_detail, "SR-AUTHORIZED-001", { ien: "SR-AUTHORIZED-001", status: "authorized", patient_dfn: "1",
+                                                    service: "Neurology", to_service: "Neuro Clinic" })
+  m.seed(:referral_delete, "SR-DRAFT-001", { success: true, message: "Referral deleted" })
+  m.seed(:referral_delete, "SR-PENDING-001", { success: true, message: "Referral deleted" })
+  m.seed(:referral_delete, "SR-AUTHORIZED-001", { success: true, message: "Referral cancelled" })
 end
 
 # Shared auth helper for integration tests.


### PR DESCRIPTION
## Summary

Add referral deletion and cancellation to ServiceRequestGateway via BMCRPC DELREFRL RPC. Status-based guards enforce IHS rules:

- Draft: delete without reason
- Pending/submitted: delete requires reason  
- Authorized/completed/denied: cannot delete (use cancel with reason)

Also adds mock referral detail/delete data to test_helper for gateway testing.

Partial progress on #187 (21 of 231 gateway tests ported: 3 org + 3 loc + 5 sanitization + 10 delete).

## Test plan

- [x] `bundle exec rails test` — 2242 runs, 0 failures
- [x] `bundle exec cucumber` — 323 scenarios, 323 passed
- [x] `bundle exec rubocop` — 0 offenses
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)