### PR TITLE
Patient repository scaffold (Phase 2 of layer contract) (+14 tests)

### DIFF
--- a/app/models/lakeraven/ehr/patient.rb
+++ b/app/models/lakeraven/ehr/patient.rb
@@ -44,11 +44,40 @@ module Lakeraven
 
       class RecordNotFound < StandardError; end
 
+      # Provenance — set by repository at hydration time
+      attr_accessor :provenance
+
       # Validations
       validates :name, presence: true, if: -> { first_name.blank? && last_name.blank? }
       validates :sex, inclusion: { in: %w[M F U], allow_nil: true }
 
-      # -- Gateway DI -----------------------------------------------------------
+      # -- Public API (delegates to repository) --------------------------------
+
+      def self.find(dfn)
+        patient = PatientRepository.find(dfn)
+        raise RecordNotFound, "Couldn't find Patient with 'dfn'=#{dfn}" unless patient
+
+        patient
+      end
+
+      def self.find_by_dfn(dfn)
+        PatientRepository.find(dfn)
+      end
+
+      def self.search(name_pattern)
+        PatientRepository.search(name_pattern.to_s)
+      end
+
+      def self.search_by_ssn(ssn)
+        patient = find_by_ssn(ssn)
+        patient ? [ patient ] : []
+      end
+
+      def self.find_by_ssn(ssn)
+        PatientRepository.find_by_ssn(ssn)
+      end
+
+      # -- Write operations (remain on gateway for now) ------------------------
 
       class << self
         attr_writer :gateway
@@ -57,8 +86,6 @@ module Lakeraven
           @gateway || PatientGateway
         end
       end
-
-      # -- Persistence (ported from rpms_redux) --------------------------------
 
       def save
         return false unless valid?
@@ -87,34 +114,6 @@ module Lakeraven
 
       def self.create!(attributes = {})
         new(attributes).tap(&:save!)
-      end
-
-      def self.find(dfn)
-        patient = find_by_dfn(dfn)
-        raise RecordNotFound, "Couldn't find Patient with 'dfn'=#{dfn}" unless patient
-
-        patient
-      end
-
-      def self.find_by_dfn(dfn)
-        return nil unless dfn.present? && dfn.to_i.positive?
-
-        gateway.find(dfn.to_i)
-      end
-
-      def self.search(name_pattern)
-        gateway.search(name_pattern.to_s)
-      end
-
-      def self.search_by_ssn(ssn)
-        patient = find_by_ssn(ssn)
-        patient ? [ patient ] : []
-      end
-
-      def self.find_by_ssn(ssn)
-        return nil if ssn.blank?
-
-        gateway.find_by_ssn(ssn.to_s)
       end
 
       # -- Initialize with composite field sync ------------------------------

--- a/app/repositories/lakeraven/ehr/patient_repository.rb
+++ b/app/repositories/lakeraven/ehr/patient_repository.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    # Access layer: hydrates Patient domain objects from RPMS (via rpms-rpc)
+    # and PostgreSQL (via ActiveRecord). Hidden behind Patient class methods.
+    #
+    # Layer contract: only this class calls DataMapper/AR for patient data.
+    # Domain objects (Patient) are immutable after construction.
+    class PatientRepository
+      class << self
+        def find(dfn)
+          return nil if dfn.blank? || dfn.to_i <= 0
+
+          rpms_core = fetch_rpms_core(dfn.to_i)
+          return nil unless rpms_core
+
+          build_patient(rpms_core)
+        end
+
+        def search(name_pattern)
+          results = PatientGateway.search(name_pattern.to_s)
+          results.map { |p| attach_provenance(p) }
+        end
+
+        def find_by_ssn(ssn)
+          return nil if ssn.blank?
+
+          patient = PatientGateway.find_by_ssn(ssn)
+          return nil unless patient
+
+          attach_provenance(patient)
+        end
+
+        private
+
+        def fetch_rpms_core(dfn)
+          patient = PatientGateway.find(dfn)
+          return nil unless patient
+
+          patient
+        end
+
+        def build_patient(patient)
+          patient.provenance = build_provenance
+          patient
+        end
+
+        def attach_provenance(patient)
+          return nil unless patient
+
+          patient.provenance = build_provenance
+          patient
+        end
+
+        def build_provenance
+          {
+            rpms: { source: :rpc, fetched_at: Time.current, stale_after: 1.hour.from_now }
+          }
+        end
+      end
+    end
+  end
+end

--- a/test/models/lakeraven/ehr/patient_test.rb
+++ b/test/models/lakeraven/ehr/patient_test.rb
@@ -359,67 +359,42 @@ module Lakeraven
       end
 
       # =========================================================================
-      # DEPENDENCY INJECTION (Option B pilot)
+      # REPOSITORY DELEGATION
       # =========================================================================
 
-      test "gateway is configurable" do
+      test "find delegates to PatientRepository" do
+        patient = Patient.find(1)
+
+        assert_instance_of Patient, patient
+        assert_equal 1, patient.dfn
+        assert_equal "Anderson,Alice", patient.name
+      end
+
+      test "find_by_dfn delegates to PatientRepository" do
+        patient = Patient.find_by_dfn(1)
+
+        refute_nil patient
+        assert_equal 1, patient.dfn
+      end
+
+      test "search delegates to PatientRepository" do
+        results = Patient.search("Anderson")
+
+        assert results.any?
+        assert results.all? { |p| p.is_a?(Patient) }
+      end
+
+      test "find_by_ssn delegates to PatientRepository" do
+        patient = Patient.find_by_ssn("111-11-1111")
+
+        refute_nil patient
+        assert_instance_of Patient, patient
+      end
+
+      test "write gateway is still configurable" do
         assert Patient.respond_to?(:gateway)
         assert Patient.respond_to?(:gateway=)
-      end
-
-      test "gateway defaults to PatientGateway" do
         assert_equal PatientGateway, Patient.gateway
-      end
-
-      test "gateway can be swapped for testing" do
-        mock_gw = Object.new
-        def mock_gw.find(dfn)
-          Lakeraven::EHR::Patient.new(dfn: dfn, name: "MOCK,PATIENT", sex: "M")
-        end
-
-        original = Patient.gateway
-        begin
-          Patient.gateway = mock_gw
-          patient = Patient.find_by_dfn(42)
-          assert_equal "MOCK,PATIENT", patient.name
-          assert_equal 42, patient.dfn
-        ensure
-          Patient.gateway = original
-        end
-      end
-
-      test "search delegates to gateway" do
-        mock_gw = Object.new
-        def mock_gw.search(pattern)
-          [ Lakeraven::EHR::Patient.new(dfn: 1, name: "DOE,JOHN", sex: "M") ]
-        end
-
-        original = Patient.gateway
-        begin
-          Patient.gateway = mock_gw
-          results = Patient.search("DOE")
-          assert_equal 1, results.length
-          assert_equal "DOE,JOHN", results.first.name
-        ensure
-          Patient.gateway = original
-        end
-      end
-
-      test "find_by_ssn delegates to gateway" do
-        mock_gw = Object.new
-        def mock_gw.find_by_ssn(ssn)
-          Lakeraven::EHR::Patient.new(dfn: 1, name: "DOE,JOHN", sex: "M", ssn: ssn)
-        end
-
-        original = Patient.gateway
-        begin
-          Patient.gateway = mock_gw
-          patient = Patient.find_by_ssn("111-11-1111")
-          assert_equal "DOE,JOHN", patient.name
-          assert_equal "111-11-1111", patient.ssn
-        ensure
-          Patient.gateway = original
-        end
       end
 
       # =========================================================================
@@ -514,18 +489,14 @@ module Lakeraven
         end
       end
 
-      test "find via gateway returns patient" do
-        with_mock_gateway do |_gw|
-          created = Patient.create!(first_name: "Find", last_name: "Test", born_on: Date.parse("1970-01-01"), sex: "M")
-          found = Patient.find(created.dfn)
-          assert_equal created.dfn, found.dfn
-        end
+      test "find via repository returns patient" do
+        found = Patient.find(1)
+        assert_equal 1, found.dfn
+        assert_equal "Anderson,Alice", found.name
       end
 
-      test "find via mock gateway raises RecordNotFound for unknown DFN" do
-        with_mock_gateway do |_gw|
-          assert_raises(Patient::RecordNotFound) { Patient.find(99999) }
-        end
+      test "find raises RecordNotFound for unknown DFN via write gateway" do
+        assert_raises(Patient::RecordNotFound) { Patient.find(99999) }
       end
     end
   end

--- a/test/repositories/lakeraven/ehr/patient_repository_test.rb
+++ b/test/repositories/lakeraven/ehr/patient_repository_test.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class PatientRepositoryTest < ActiveSupport::TestCase
+      # =============================================================================
+      # FIND
+      # =============================================================================
+
+      test "find returns Patient for known DFN" do
+        patient = PatientRepository.find(1)
+
+        assert_instance_of Patient, patient
+        assert_equal 1, patient.dfn
+        assert_equal "Anderson,Alice", patient.name
+      end
+
+      test "find returns nil for unknown DFN" do
+        assert_nil PatientRepository.find(99999)
+      end
+
+      test "find returns nil for blank DFN" do
+        assert_nil PatientRepository.find(nil)
+        assert_nil PatientRepository.find("")
+      end
+
+      test "find merges extended demographics" do
+        patient = PatientRepository.find(1)
+
+        assert_equal "AMERICAN INDIAN", patient.race
+        assert_equal "123 Main St", patient.address_line1
+        assert_equal "Anchorage", patient.city
+      end
+
+      test "find includes tribal enrollment data" do
+        patient = PatientRepository.find(1)
+
+        assert_equal "ANLC-12345", patient.tribal_enrollment_number
+        assert_equal "Anchorage", patient.service_area
+      end
+
+      # =============================================================================
+      # FIND WITH PROVENANCE
+      # =============================================================================
+
+      test "find attaches provenance metadata" do
+        patient = PatientRepository.find(1)
+
+        refute_nil patient.provenance
+        assert_equal :rpc, patient.provenance[:rpms][:source]
+        refute_nil patient.provenance[:rpms][:fetched_at]
+      end
+
+      # =============================================================================
+      # SEARCH
+      # =============================================================================
+
+      test "search returns array of patients" do
+        patients = PatientRepository.search("Anderson")
+
+        assert patients.is_a?(Array)
+        assert patients.any?
+        assert patients.all? { |p| p.is_a?(Patient) }
+      end
+
+      test "search returns empty array for no matches" do
+        patients = PatientRepository.search("ZZZZZ")
+
+        assert_equal [], patients
+      end
+
+      # =============================================================================
+      # FIND BY SSN
+      # =============================================================================
+
+      test "find_by_ssn returns patient" do
+        patient = PatientRepository.find_by_ssn("111-11-1111")
+
+        refute_nil patient
+        assert_instance_of Patient, patient
+      end
+
+      test "find_by_ssn returns nil for unknown SSN" do
+        assert_nil PatientRepository.find_by_ssn("000-00-0000")
+      end
+
+      # =============================================================================
+      # IMMUTABILITY
+      # =============================================================================
+
+      test "returned patient has provenance" do
+        patient = PatientRepository.find(1)
+
+        refute_nil patient.provenance
+        assert_equal :rpc, patient.provenance[:rpms][:source]
+      end
+
+      # =============================================================================
+      # MODEL DELEGATION
+      # =============================================================================
+
+      test "Patient.find delegates to repository" do
+        patient = Patient.find(1)
+
+        assert_instance_of Patient, patient
+        assert_equal 1, patient.dfn
+      end
+
+      test "Patient.search delegates to repository" do
+        patients = Patient.search("Anderson")
+
+        assert patients.any?
+      end
+
+      test "Patient.find_by_dfn delegates to repository" do
+        patient = Patient.find_by_dfn(1)
+
+        refute_nil patient
+        assert_equal 1, patient.dfn
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Phase 2 of the ratified domain model architecture (layer contract).

Introduces PatientRepository as the Access layer between Patient (Domain) and PatientGateway (Data). Patient class methods now delegate to the repository instead of calling the gateway directly.

### Layer contract adherence

```
App (controllers) → Domain (Patient.find) → Access (PatientRepository) → Data (PatientGateway/DataMapper)
```

- **Patient** (Domain): class methods are pure delegation; instance methods have no I/O
- **PatientRepository** (Access): only caller of PatientGateway; attaches provenance metadata
- **PatientGateway** (Data): unchanged — still calls DataMapper directly (to be migrated per #197)

### Changes

- `app/repositories/lakeraven/ehr/patient_repository.rb` — new
- `app/models/lakeraven/ehr/patient.rb` — class methods delegate to repository; added `provenance` accessor
- `test/repositories/lakeraven/ehr/patient_repository_test.rb` — 14 new tests
- `test/models/lakeraven/ehr/patient_test.rb` — updated gateway DI tests to repository delegation tests

### Notes

- Immutability deferred — `freeze` was too aggressive for cucumber steps that modify patient attributes. Will revisit when constructor segments (`rpms_core:`, `pg_workflow:`) are implemented.
- Write path (save/create) remains on gateway directly — repository pattern applies to reads first.

## Test plan

- [x] `bundle exec rails test` — 2256 runs, 0 failures
- [x] `bundle exec cucumber` — 323 scenarios, 323 passed
- [x] `bundle exec rubocop` — 0 offenses
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)