### PR TITLE
Terminology decorators: ICD-10, SNOMED, LOINC, RxNorm, ATC, DIN (+20 tests)

### DIFF
--- a/app/terminology/lakeraven/ehr/terminology.rb
+++ b/app/terminology/lakeraven/ehr/terminology.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    module Terminology
+      # Base class for terminology decorators.
+      # Pure transform — no I/O, no RPC calls, no database queries.
+      # Projects a code value into a terminology system using in-memory data.
+      class Base
+        attr_reader :code
+
+        def initialize(code)
+          @code = code.to_s.strip.presence
+        end
+
+        def system
+          raise NotImplementedError, "#{self.class}#system"
+        end
+
+        def display
+          @code
+        end
+
+        def status
+          @code ? :mapped : :unmapped
+        end
+
+        def to_coding
+          return { code: nil, system: system, display: nil } if status == :unmapped
+
+          { code: code, system: system, display: display }.compact
+        end
+      end
+
+      # ICD-10 — diagnosis codes
+      # Editions: :cm (US), :se (Sweden), :ca (Canada), nil (international)
+      class ICD10 < Base
+        SYSTEMS = {
+          cm: "http://hl7.org/fhir/sid/icd-10-cm",
+          se: "http://hl7.org/fhir/sid/icd-10-se",
+          ca: "http://hl7.org/fhir/sid/icd-10-ca",
+          nil => "http://hl7.org/fhir/sid/icd-10"
+        }.freeze
+
+        def initialize(code, edition: :cm)
+          super(code)
+          @edition = edition
+        end
+
+        def system
+          SYSTEMS[@edition] || SYSTEMS[:cm]
+        end
+      end
+
+      # LOINC — observation/lab test identity (universal, no editions)
+      class LOINC < Base
+        def system
+          "http://loinc.org"
+        end
+      end
+
+      # RxNorm — US medication codes
+      class RxNorm < Base
+        def system
+          "http://www.nlm.nih.gov/research/umls/rxnorm"
+        end
+      end
+
+      # ATC — WHO Anatomical Therapeutic Chemical classification
+      # Used in Sweden, international markets
+      class ATC < Base
+        def system
+          "http://www.whocc.no/atc"
+        end
+      end
+
+      # DIN — Health Canada Drug Identification Number
+      class DIN < Base
+        def system
+          "https://health-products.canada.ca/dpd-bdpp"
+        end
+      end
+
+      # SNOMED CT — clinical meaning (multi-edition)
+      # Edition modules: US, Swedish, Canadian, international
+      class SNOMED < Base
+        EDITION_VERSIONS = {
+          us: "http://snomed.info/sct/731000124108",
+          se: "http://snomed.info/sct/45991000052106",
+          ca: "http://snomed.info/sct/20611000087101",
+          nil => nil
+        }.freeze
+
+        def initialize(code, edition: nil)
+          super(code)
+          @edition = edition
+        end
+
+        def system
+          "http://snomed.info/sct"
+        end
+
+        def to_coding
+          coding = super
+          version = EDITION_VERSIONS[@edition]
+          coding[:version] = version if version && status == :mapped
+          coding
+        end
+      end
+    end
+  end
+end

--- a/test/terminology/lakeraven/ehr/terminology_test.rb
+++ b/test/terminology/lakeraven/ehr/terminology_test.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class TerminologyDecoratorTest < ActiveSupport::TestCase
+      # =============================================================================
+      # ICD-10 (US Clinical Modification — default)
+      # =============================================================================
+
+      test "ICD10 resolves code and display" do
+        icd = Terminology::ICD10.new("E11.9")
+
+        assert_equal "E11.9", icd.code
+        assert_equal "http://hl7.org/fhir/sid/icd-10-cm", icd.system
+        refute_nil icd.display
+      end
+
+      test "ICD10 to_coding returns hash with system, code, display" do
+        icd = Terminology::ICD10.new("E11.9")
+        coding = icd.to_coding
+
+        assert_equal "E11.9", coding[:code]
+        assert_equal "http://hl7.org/fhir/sid/icd-10-cm", coding[:system]
+        assert coding[:display].is_a?(String)
+      end
+
+      test "ICD10 with nil code returns unmapped" do
+        icd = Terminology::ICD10.new(nil)
+
+        assert_nil icd.code
+        assert_equal :unmapped, icd.status
+      end
+
+      test "ICD10 with blank code returns unmapped" do
+        icd = Terminology::ICD10.new("")
+
+        assert_equal :unmapped, icd.status
+      end
+
+      # =============================================================================
+      # ICD-10 VARIANTS (Swedish, Canadian)
+      # =============================================================================
+
+      test "ICD10 Swedish Edition uses SE system URI" do
+        icd = Terminology::ICD10.new("E11.9", edition: :se)
+
+        assert_equal "E11.9", icd.code
+        assert_includes icd.system, "icd-10-se"
+      end
+
+      test "ICD10 Canadian Edition uses CA system URI" do
+        icd = Terminology::ICD10.new("E11.9", edition: :ca)
+
+        assert_equal "E11.9", icd.code
+        assert_includes icd.system, "icd-10-ca"
+      end
+
+      test "ICD10 defaults to CM edition" do
+        icd = Terminology::ICD10.new("E11.9")
+
+        assert_includes icd.system, "icd-10-cm"
+      end
+
+      # =============================================================================
+      # LOINC (universal — no editions)
+      # =============================================================================
+
+      test "LOINC resolves code" do
+        loinc = Terminology::LOINC.new("2339-0")
+
+        assert_equal "2339-0", loinc.code
+        assert_equal "http://loinc.org", loinc.system
+      end
+
+      test "LOINC to_coding returns hash" do
+        loinc = Terminology::LOINC.new("2339-0")
+        coding = loinc.to_coding
+
+        assert_equal "2339-0", coding[:code]
+        assert_equal "http://loinc.org", coding[:system]
+      end
+
+      test "LOINC with nil code returns unmapped" do
+        loinc = Terminology::LOINC.new(nil)
+
+        assert_equal :unmapped, loinc.status
+      end
+
+      # =============================================================================
+      # RXNORM (US)
+      # =============================================================================
+
+      test "RxNorm resolves code" do
+        rxnorm = Terminology::RxNorm.new("197884")
+
+        assert_equal "197884", rxnorm.code
+        assert_equal "http://www.nlm.nih.gov/research/umls/rxnorm", rxnorm.system
+      end
+
+      test "RxNorm to_coding returns hash" do
+        rxnorm = Terminology::RxNorm.new("197884")
+        coding = rxnorm.to_coding
+
+        assert_equal "197884", coding[:code]
+        assert_includes coding[:system], "rxnorm"
+      end
+
+      # =============================================================================
+      # ATC (WHO — Sweden, international)
+      # =============================================================================
+
+      test "ATC resolves code" do
+        atc = Terminology::ATC.new("C09AA05")
+
+        assert_equal "C09AA05", atc.code
+        assert_equal "http://www.whocc.no/atc", atc.system
+      end
+
+      test "ATC to_coding returns hash" do
+        atc = Terminology::ATC.new("C09AA05")
+        coding = atc.to_coding
+
+        assert_equal "C09AA05", coding[:code]
+        assert_includes coding[:system], "atc"
+      end
+
+      # =============================================================================
+      # DIN (Health Canada)
+      # =============================================================================
+
+      test "DIN resolves code" do
+        din = Terminology::DIN.new("02248057")
+
+        assert_equal "02248057", din.code
+        assert_equal "https://health-products.canada.ca/dpd-bdpp", din.system
+      end
+
+      # =============================================================================
+      # SNOMED CT (multi-edition)
+      # =============================================================================
+
+      test "SNOMED resolves code with US edition" do
+        snomed = Terminology::SNOMED.new("44054006")
+
+        assert_equal "44054006", snomed.code
+        assert_equal "http://snomed.info/sct", snomed.system
+      end
+
+      test "SNOMED with nil code returns unmapped" do
+        snomed = Terminology::SNOMED.new(nil)
+
+        assert_equal :unmapped, snomed.status
+      end
+
+      test "SNOMED to_coding includes edition version when specified" do
+        snomed = Terminology::SNOMED.new("44054006", edition: :se)
+        coding = snomed.to_coding
+
+        assert_equal "44054006", coding[:code]
+        assert_equal "http://snomed.info/sct", coding[:system]
+        assert_equal "http://snomed.info/sct/45991000052106", coding[:version]
+      end
+
+      # =============================================================================
+      # BASE CONTRACT
+      # =============================================================================
+
+      test "all terminology decorators respond to code, system, display, to_coding, status" do
+        decorators = [
+          Terminology::ICD10.new("E11.9"),
+          Terminology::LOINC.new("2339-0"),
+          Terminology::RxNorm.new("197884"),
+          Terminology::ATC.new("C09AA05"),
+          Terminology::DIN.new("02248057"),
+          Terminology::SNOMED.new("44054006")
+        ]
+
+        decorators.each do |d|
+          assert_respond_to d, :code
+          assert_respond_to d, :system
+          assert_respond_to d, :display
+          assert_respond_to d, :to_coding
+          assert_respond_to d, :status
+        end
+      end
+
+      test "mapped status for valid codes" do
+        icd = Terminology::ICD10.new("E11.9")
+
+        assert_equal :mapped, icd.status
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Phase 3 of the ratified domain model architecture (layer contract).

Pure-transform terminology decorators for 6 coding systems across 4 international markets. No I/O — these are Domain layer objects that project a code value into its terminology system using in-memory data.

### Terminology systems

| Decorator | System URI | Markets |
|---|---|---|
| ICD10 | icd-10-cm / icd-10-se / icd-10-ca | US, Sweden, Canada |
| SNOMED | snomed.info/sct (+ edition versions) | All |
| LOINC | loinc.org | All (universal) |
| RxNorm | nlm.nih.gov/research/umls/rxnorm | US |
| ATC | whocc.no/atc | Sweden, international |
| DIN | health-products.canada.ca/dpd-bdpp | Canada |

### Contract

All decorators implement: `code`, `system`, `display`, `to_coding`, `status` (:mapped / :unmapped).

No I/O in any method. Crosswalk caches (BSTS, BLS) will be injected by repositories at hydration time (Phase 2 pattern). Not yet wired — this PR establishes the decorator contract.

## Test plan

- [x] `bundle exec rails test` — 2276 runs, 0 failures
- [x] `bundle exec cucumber` — 323 scenarios, 323 passed
- [x] `bundle exec rubocop` — 0 offenses
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)