### PR TITLE
Port Encounter + Practitioner serializer tests (Batch 2) (+18 tests)

### DIFF
--- a/app/services/lakeraven/ehr/fhir/encounter_serializer.rb
+++ b/app/services/lakeraven/ehr/fhir/encounter_serializer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    module FHIR
+      # Serializes Encounter domain object to FHIR R4 Encounter hash.
+      # Delegates to Encounter#to_fhir for structure, adds policy filtering.
+      class EncounterSerializer
+        def initialize(encounter, policy: nil)
+          @encounter = encounter
+          @policy = policy || RedactionPolicy.new(view: :full)
+        end
+
+        def to_h
+          resource = @encounter.to_fhir
+          @policy.apply(resource)
+        end
+      end
+    end
+  end
+end

--- a/test/services/lakeraven/ehr/fhir/encounter_serializer_test.rb
+++ b/test/services/lakeraven/ehr/fhir/encounter_serializer_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    module FHIR
+      class EncounterSerializerTest < ActiveSupport::TestCase
+        test "serializes resourceType and id" do
+          result = serialize(build_encounter)
+
+          assert_equal "Encounter", result[:resourceType]
+          assert_equal "42", result[:id]
+        end
+
+        test "includes status" do
+          result = serialize(build_encounter(status: "in-progress"))
+
+          assert_equal "in-progress", result[:status]
+        end
+
+        test "includes class coding" do
+          result = serialize(build_encounter(class_code: "AMB"))
+
+          assert_equal "AMB", result[:class][:code]
+        end
+
+        test "includes subject patient reference" do
+          result = serialize(build_encounter(patient_identifier: "123"))
+
+          assert_equal "Patient/123", result[:subject][:reference]
+        end
+
+        test "includes period with start and end" do
+          result = serialize(build_encounter(
+            period_start: DateTime.new(2024, 1, 15, 9, 0),
+            period_end: DateTime.new(2024, 1, 15, 10, 30)
+          ))
+
+          refute_nil result[:period]
+          refute_nil result[:period][:start]
+          refute_nil result[:period][:end]
+        end
+
+        test "includes type when present" do
+          result = serialize(build_encounter(type_code: "WELLNESS", type_display: "Wellness Visit"))
+
+          refute_nil result[:type]
+          assert result[:type].any? { |t| t[:coding].any? { |c| c[:code] == "WELLNESS" } }
+        end
+
+        test "includes reason when present" do
+          result = serialize(build_encounter(reason_code: "CHECKUP", reason_display: "Annual checkup"))
+
+          refute_nil result[:reasonCode]
+        end
+
+        test "includes location when present" do
+          result = serialize(build_encounter(location_ien: 100))
+
+          refute_nil result[:location]
+          assert result[:location].any? { |l| l[:location][:reference].include?("100") }
+        end
+
+        test "handles minimal encounter" do
+          enc = Encounter.new(ien: 1, status: "finished", patient_identifier: "1")
+          result = EncounterSerializer.new(enc).to_h
+
+          assert_equal "Encounter", result[:resourceType]
+          assert_equal "finished", result[:status]
+        end
+
+        test "redaction policy applies" do
+          result = serialize(build_encounter)
+          policy = RedactionPolicy.new(view: :full)
+          redacted = policy.apply(result)
+
+          assert_equal "Encounter", redacted[:resourceType]
+        end
+
+        private
+
+        def build_encounter(attrs = {})
+          defaults = {
+            ien: 42, status: "in-progress", patient_identifier: "1",
+            class_code: "AMB", period_start: DateTime.new(2024, 1, 15, 9, 0),
+            period_end: DateTime.new(2024, 1, 15, 10, 30)
+          }
+          Encounter.new(defaults.merge(attrs))
+        end
+
+        def serialize(encounter)
+          EncounterSerializer.new(encounter).to_h
+        end
+      end
+    end
+  end
+end

--- a/test/services/lakeraven/ehr/fhir/practitioner_serializer_test.rb
+++ b/test/services/lakeraven/ehr/fhir/practitioner_serializer_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    module FHIR
+      class PractitionerSerializerTest < ActiveSupport::TestCase
+        test "serializes resourceType and id" do
+          result = serialize(build_practitioner)
+
+          assert_equal "Practitioner", result[:resourceType]
+          refute_nil result[:id]
+        end
+
+        test "includes NPI identifier" do
+          result = serialize(build_practitioner(npi: "1234567890"))
+
+          npi = result[:identifier].find { |i| i[:system]&.include?("npi") }
+          refute_nil npi
+          assert_equal "1234567890", npi[:value]
+        end
+
+        test "includes name with family and given" do
+          result = serialize(build_practitioner(name: "MARTINEZ,SARAH"))
+
+          name = result[:name]&.first
+          refute_nil name
+          assert_equal "MARTINEZ", name[:family]
+        end
+
+        test "includes qualification with specialty" do
+          result = serialize(build_practitioner(specialty: "Cardiology"))
+
+          quals = result[:qualification]
+          refute_nil quals
+          assert quals.any? { |q| q[:code][:text] == "Cardiology" }
+        end
+
+        test "includes telecom with phone" do
+          result = serialize(build_practitioner(phone: "907-555-9999"))
+
+          telecom = result[:telecom]&.first
+          refute_nil telecom
+          assert_equal "phone", telecom[:system]
+          assert_equal "907-555-9999", telecom[:value]
+        end
+
+        test "omits phone when blank" do
+          result = serialize(build_practitioner(phone: nil))
+
+          assert_empty(result[:telecom] || [])
+        end
+
+        test "handles missing optional fields" do
+          pract = Practitioner.new(ien: 1, name: "DOE,JOHN")
+          result = PractitionerSerializer.call(pract)
+
+          assert_equal "Practitioner", result[:resourceType]
+        end
+
+        test "redaction policy applies" do
+          result = serialize(build_practitioner)
+          policy = RedactionPolicy.new(view: :research)
+          redacted = policy.apply(result)
+
+          assert_equal "Practitioner", redacted[:resourceType]
+        end
+
+        private
+
+        def build_practitioner(attrs = {})
+          defaults = {
+            ien: 101, name: "MARTINEZ,SARAH", title: "MD",
+            service_section: "Internal Medicine", specialty: "Cardiology",
+            npi: "1234567890", phone: "907-555-9999"
+          }
+          Practitioner.new(defaults.merge(attrs))
+        end
+
+        def serialize(practitioner)
+          PractitionerSerializer.call(practitioner)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Phase 5 batch 2: port rpms_redux FhirEncounter (26 tests) and FhirPractitioner (26 tests) decorator tests as serializer + policy tests.

18 tests covering Encounter and Practitioner FHIR serialization + RedactionPolicy integration. Also adds EncounterSerializer class (delegates to Encounter#to_fhir + policy).

Cumulative Phase 5: 46 of 197 FHIR decorator tests ported (Batch 1: 28 Patient + Batch 2: 18 Encounter/Practitioner).

## Test plan

- [x] `bundle exec rails test` — 2341 runs, 0 failures
- [x] `bundle exec cucumber` — 323 scenarios, 323 passed
- [x] `bundle exec rubocop` — 0 offenses
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)