### PR TITLE
Port ServiceRequest + Communication serializer tests (Batch 3) (+21 tests)

### DIFF
--- a/app/services/lakeraven/ehr/fhir/communication_serializer.rb
+++ b/app/services/lakeraven/ehr/fhir/communication_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    module FHIR
+      class CommunicationSerializer
+        def initialize(communication, policy: nil)
+          @comm = communication
+          @policy = policy || RedactionPolicy.new(view: :full)
+        end
+
+        def to_h
+          resource = @comm.to_fhir
+          @policy.apply(resource)
+        end
+      end
+    end
+  end
+end

--- a/app/services/lakeraven/ehr/fhir/service_request_serializer.rb
+++ b/app/services/lakeraven/ehr/fhir/service_request_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    module FHIR
+      class ServiceRequestSerializer
+        def initialize(service_request, policy: nil)
+          @sr = service_request
+          @policy = policy || RedactionPolicy.new(view: :full)
+        end
+
+        def to_h
+          resource = @sr.to_fhir
+          @policy.apply(resource)
+        end
+      end
+    end
+  end
+end

--- a/test/services/lakeraven/ehr/fhir/communication_serializer_test.rb
+++ b/test/services/lakeraven/ehr/fhir/communication_serializer_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    module FHIR
+      class CommunicationSerializerTest < ActiveSupport::TestCase
+        test "serializes resourceType" do
+          result = serialize(build_comm)
+          assert_equal "Communication", result[:resourceType]
+        end
+
+        test "includes status" do
+          result = serialize(build_comm(status: "completed"))
+          assert_equal "completed", result[:status]
+        end
+
+        test "includes subject patient reference" do
+          result = serialize(build_comm(subject_patient_dfn: "123"))
+          assert_equal "Patient/123", result[:subject][:reference]
+        end
+
+        test "includes sender reference" do
+          result = serialize(build_comm(sender_type: "Practitioner", sender_id: "101"))
+          sender = result[:sender]
+          refute_nil sender
+          assert_equal "Practitioner/101", sender[:reference]
+        end
+
+        test "includes recipient reference" do
+          result = serialize(build_comm(recipient_type: "Practitioner", recipient_id: "102"))
+          recipients = result[:recipient]
+          refute_nil recipients
+          assert recipients.any? { |r| r[:reference] == "Practitioner/102" }
+        end
+
+        test "includes payload content" do
+          result = serialize(build_comm(payload_content: "Lab results are ready"))
+          payload = result[:payload]
+          refute_nil payload
+          assert payload.any? { |p| p[:contentString] == "Lab results are ready" }
+        end
+
+        test "includes priority when present" do
+          result = serialize(build_comm(priority: "urgent"))
+          assert_equal "urgent", result[:priority]
+        end
+
+        test "includes category when present" do
+          result = serialize(build_comm(category: "notification"))
+          refute_nil result[:category]
+        end
+
+        test "includes sent timestamp" do
+          sent_time = Time.new(2026, 1, 15, 10, 30, 0)
+          result = serialize(build_comm(sent: sent_time))
+          refute_nil result[:sent]
+        end
+
+        test "handles minimal communication" do
+          comm = Communication.new(
+            subject_patient_dfn: "1",
+            sender_id: "101",
+            payload_content: "Test"
+          )
+          result = CommunicationSerializer.new(comm).to_h
+          assert_equal "Communication", result[:resourceType]
+        end
+
+        test "redaction policy applies" do
+          policy = RedactionPolicy.new(view: :research)
+          result = CommunicationSerializer.new(build_comm, policy: policy).to_h
+          assert_equal "Communication", result[:resourceType]
+        end
+
+        private
+
+        def build_comm(attrs = {})
+          defaults = {
+            ien: "msg-001", subject_patient_dfn: "1", status: "completed",
+            sender_type: "Practitioner", sender_id: "101",
+            recipient_type: "Practitioner", recipient_id: "102",
+            payload_content: "Follow-up appointment scheduled",
+            priority: "routine", category: "notification"
+          }
+          Communication.new(defaults.merge(attrs))
+        end
+
+        def serialize(comm)
+          CommunicationSerializer.new(comm).to_h
+        end
+      end
+    end
+  end
+end

--- a/test/services/lakeraven/ehr/fhir/service_request_serializer_test.rb
+++ b/test/services/lakeraven/ehr/fhir/service_request_serializer_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    module FHIR
+      class ServiceRequestSerializerTest < ActiveSupport::TestCase
+        test "serializes resourceType" do
+          result = serialize(build_sr)
+          assert_equal "ServiceRequest", result[:resourceType]
+        end
+
+        test "includes id" do
+          result = serialize(build_sr(ien: 42))
+          assert_equal "42", result[:id]
+        end
+
+        test "includes status" do
+          result = serialize(build_sr(status: "active"))
+          assert_equal "active", result[:status]
+        end
+
+        test "includes subject patient reference" do
+          result = serialize(build_sr(patient_dfn: 123))
+          assert_equal "Patient/123", result[:subject][:reference]
+        end
+
+        test "includes intent as order" do
+          result = serialize(build_sr)
+          assert_equal "order", result[:intent]
+        end
+
+        test "includes code with service requested" do
+          result = serialize(build_sr(service_requested: "Cardiology Consultation"))
+          refute_nil result[:code]
+          assert_equal "Cardiology Consultation", result[:code][:text]
+        end
+
+        test "includes reason for referral" do
+          result = serialize(build_sr(reason_for_referral: "Chest pain evaluation"))
+          reason = result[:reasonCode]
+          refute_nil reason
+        end
+
+        test "includes priority" do
+          result = serialize(build_sr(urgency: "URGENT"))
+          refute_nil result[:priority]
+        end
+
+        test "handles missing optional fields" do
+          sr = ServiceRequest.new(ien: 1, patient_dfn: 1, status: "draft")
+          result = ServiceRequestSerializer.new(sr).to_h
+          assert_equal "ServiceRequest", result[:resourceType]
+        end
+
+        test "redaction policy applies" do
+          policy = RedactionPolicy.new(view: :research)
+          result = ServiceRequestSerializer.new(build_sr, policy: policy).to_h
+          assert_equal "ServiceRequest", result[:resourceType]
+        end
+
+        private
+
+        def build_sr(attrs = {})
+          defaults = {
+            ien: 42, patient_dfn: 1, status: "active",
+            requesting_provider_ien: 101,
+            service_requested: "Cardiology Consultation",
+            reason_for_referral: "Chest pain evaluation",
+            urgency: "ROUTINE"
+          }
+          ServiceRequest.new(defaults.merge(attrs))
+        end
+
+        def serialize(sr)
+          ServiceRequestSerializer.new(sr).to_h
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Phase 5 batch 3: ServiceRequest (26 rpms_redux tests) and Communication (26 rpms_redux tests) FHIR serializers + tests.

21 new tests + 2 new serializer classes. Both delegate to model#to_fhir + RedactionPolicy.

Cumulative Phase 5: 67 of 197 FHIR decorator tests ported.

## Test plan

- [x] `bundle exec rails test` — 2362 runs, 0 failures
- [x] `bundle exec cucumber` — 323 scenarios, 323 passed
- [x] `bundle exec rubocop` — 0 offenses
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)