### PR TITLE
Migrate gateways to rpms-rpc symbolic API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/lakeraven/rpms-rpc.git
-  revision: 1b0d8ad4f31b81c89a2354100b2d0db45df7f7f0
+  revision: 03400976dacbedd6ca8c9345565ed7fe3cdc622c
   branch: main
   specs:
     rpms-rpc (0.1.0)

--- a/app/gateways/lakeraven/ehr/location_gateway.rb
+++ b/app/gateways/lakeraven/ehr/location_gateway.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
+require "rpms_rpc/api/location"
 
 module Lakeraven
   module EHR
     class LocationGateway
       def self.find(ien)
-        RpmsRpc::DataMapper.hospital_location.fetch_one(ien.to_s)
+        RpmsRpc::Location.find(ien)
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/organization_gateway.rb
+++ b/app/gateways/lakeraven/ehr/organization_gateway.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
+require "rpms_rpc/api/organization"
 
 module Lakeraven
   module EHR
     class OrganizationGateway
       def self.find(ien)
-        RpmsRpc::DataMapper.institution.fetch_one(ien.to_s)
+        RpmsRpc::Organization.find(ien)
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/patient_gateway.rb
+++ b/app/gateways/lakeraven/ehr/patient_gateway.rb
@@ -1,28 +1,25 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
+require "rpms_rpc/api/patient"
 
 module Lakeraven
   module EHR
     class PatientGateway
       class << self
         def find(dfn)
-          attrs = RpmsRpc::DataMapper.patient_select.fetch_one(dfn.to_s, extras: { dfn: dfn.to_i })
+          attrs = RpmsRpc::Patient.find(dfn.to_i)
           return nil unless attrs
-
-          extended = RpmsRpc::DataMapper.patient_id_info.fetch_one(dfn.to_s)
-          attrs.merge!(extended) if extended
 
           Patient.new(**attrs)
         end
 
         def search(name_pattern)
-          results = RpmsRpc::DataMapper.patient_list.fetch_many(name_pattern, "1")
+          results = RpmsRpc::Patient.search(name_pattern)
           results.map { |attrs| Patient.new(**attrs) }
         end
 
         def find_by_ssn(ssn)
-          attrs = RpmsRpc::DataMapper.patient_ssn.fetch_one(ssn)
+          attrs = RpmsRpc::Patient.find_by_ssn(ssn)
           attrs ? Patient.new(**attrs) : nil
         end
       end

--- a/app/gateways/lakeraven/ehr/service_request_gateway.rb
+++ b/app/gateways/lakeraven/ehr/service_request_gateway.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
+require "rpms_rpc/api/referral"
 
 module Lakeraven
   module EHR
@@ -8,7 +8,7 @@ module Lakeraven
       DELETABLE_STATUSES = %w[draft pending submitted].freeze
 
       def self.for_patient(dfn)
-        RpmsRpc::DataMapper.referral_search.fetch_many(dfn.to_s)
+        RpmsRpc::Referral.for_patient(dfn.to_s)
       end
 
       def self.delete(ien, reason: nil)
@@ -25,7 +25,7 @@ module Lakeraven
           return { success: false, error: "Reason required for #{status} referral", ien: ien }
         end
 
-        result = RpmsRpc::DataMapper.referral_delete.fetch_one(ien, reason)
+        result = RpmsRpc::Referral.delete(ien, reason: reason)
         if result && result[:success]
           { success: true, message: "Referral deleted", ien: ien }
         else
@@ -41,7 +41,7 @@ module Lakeraven
         referral = find_referral(ien)
         return { success: false, error: "Referral not found" } unless referral
 
-        result = RpmsRpc::DataMapper.referral_delete.fetch_one(ien, reason)
+        result = RpmsRpc::Referral.delete(ien, reason: reason)
         if result && result[:success]
           { success: true, message: "Referral cancelled", ien: ien }
         else
@@ -59,7 +59,7 @@ module Lakeraven
       end
 
       def self.find_referral(ien)
-        RpmsRpc::DataMapper.referral_detail.fetch_one(ien.to_s)
+        RpmsRpc::Referral.find(ien.to_s)
       end
       private_class_method :find_referral
     end


### PR DESCRIPTION
## Summary

Migrate 4 gateways from DataMapper references to the rpms-rpc symbolic API:

| Gateway | Before | After |
|---|---|---|
| PatientGateway | `DataMapper.patient_select.fetch_one` | `RpmsRpc::Patient.find` |
| OrganizationGateway | `DataMapper.institution.fetch_one` | `RpmsRpc::Organization.find` |
| LocationGateway | `DataMapper.hospital_location.fetch_one` | `RpmsRpc::Location.find` |
| ServiceRequestGateway | `DataMapper.referral_*.fetch_*` | `RpmsRpc::Referral.*` |

Partial progress on #197. 7 clinical gateways still use DataMapper (pending clinical API modules in rpms-rpc).

## Test plan

- [x] `bundle exec rails test` — 2387 runs, 0 failures
- [x] `bundle exec cucumber` — 323 scenarios, 323 passed
- [x] `bundle exec rubocop` — 0 offenses
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)