### PR TITLE
Migrate clinical gateways to symbolic API (closes #207)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/lakeraven/rpms-rpc.git
-  revision: 03400976dacbedd6ca8c9345565ed7fe3cdc622c
+  revision: f7dfb35c127bbdc0e402105ef173e5f20fdaae8f
   branch: main
   specs:
     rpms-rpc (0.1.0)

--- a/app/gateways/lakeraven/ehr/allergy_intolerance_gateway.rb
+++ b/app/gateways/lakeraven/ehr/allergy_intolerance_gateway.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
+require "rpms_rpc/api/allergy"
 
 module Lakeraven
   module EHR
     class AllergyIntoleranceGateway
-      MAPPING = :allergy_list
-
       def self.for_patient(dfn)
-        RpmsRpc::DataMapper.public_send(MAPPING).fetch_many(dfn.to_s)
+        RpmsRpc::Allergy.for_patient(dfn.to_s)
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/condition_gateway.rb
+++ b/app/gateways/lakeraven/ehr/condition_gateway.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
+require "rpms_rpc/api/problem"
 
 module Lakeraven
   module EHR
     class ConditionGateway
-      MAPPING = :problem_list
-
       def self.for_patient(dfn)
-        RpmsRpc::DataMapper.public_send(MAPPING).fetch_many(dfn.to_s)
+        RpmsRpc::Problem.for_patient(dfn.to_s)
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/encounter_gateway.rb
+++ b/app/gateways/lakeraven/ehr/encounter_gateway.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
+require "rpms_rpc/api/encounter"
 
 module Lakeraven
   module EHR
     class EncounterGateway
-      MAPPING = :patient_appointments
-
       def self.for_patient(dfn)
-        RpmsRpc::DataMapper.public_send(MAPPING).fetch_many(dfn.to_s)
+        RpmsRpc::Encounter.for_patient(dfn.to_s)
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/immunization_gateway.rb
+++ b/app/gateways/lakeraven/ehr/immunization_gateway.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
+require "rpms_rpc/api/allergy"
 
 module Lakeraven
   module EHR
     class ImmunizationGateway
+      # TODO: migrate to RpmsRpc::Immunization.for_patient when
+      # immunization-specific RPC (BIPC IMMLIST) is wired.
+      # Currently delegates to allergy_list for backward compatibility.
       def self.for_patient(dfn)
-        RpmsRpc::DataMapper.allergy_list.fetch_many(dfn.to_s)
+        RpmsRpc::Allergy.for_patient(dfn.to_s)
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/medication_request_gateway.rb
+++ b/app/gateways/lakeraven/ehr/medication_request_gateway.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
+require "rpms_rpc/api/medication"
 
 module Lakeraven
   module EHR
     class MedicationRequestGateway
-      MAPPING = :medication_list
-
       def self.for_patient(dfn)
-        RpmsRpc::DataMapper.public_send(MAPPING).fetch_many(dfn.to_s)
+        RpmsRpc::Medication.for_patient(dfn.to_s)
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/observation_gateway.rb
+++ b/app/gateways/lakeraven/ehr/observation_gateway.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
+require "rpms_rpc/api/vital"
 
 module Lakeraven
   module EHR
     class ObservationGateway
-      MAPPING = :vitals
-
       def self.for_patient(dfn)
-        RpmsRpc::DataMapper.public_send(MAPPING).fetch_many(dfn.to_s)
+        RpmsRpc::Vital.for_patient(dfn.to_s)
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/procedure_gateway.rb
+++ b/app/gateways/lakeraven/ehr/procedure_gateway.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
+require "rpms_rpc/api/procedure"
 
 module Lakeraven
   module EHR
     class ProcedureGateway
       def self.for_patient(dfn)
-        RpmsRpc::DataMapper.procedure_list.fetch_many(dfn.to_s)
+        RpmsRpc::Procedure.for_patient(dfn.to_s)
       end
     end
   end


### PR DESCRIPTION
## Summary

Migrate all 7 remaining clinical gateways from DataMapper to rpms-rpc symbolic API. **Zero DataMapper references remain in any gateway file.**

| Gateway | Before | After |
|---|---|---|
| AllergyIntoleranceGateway | DataMapper.allergy_list | RpmsRpc::Allergy.for_patient |
| ConditionGateway | DataMapper.problem_list | RpmsRpc::Problem.for_patient |
| EncounterGateway | DataMapper.patient_appointments | RpmsRpc::Encounter.for_patient |
| MedicationRequestGateway | DataMapper.medication_list | RpmsRpc::Medication.for_patient |
| ObservationGateway | DataMapper.vitals | RpmsRpc::Vital.for_patient |
| ProcedureGateway | DataMapper.procedure_list | RpmsRpc::Procedure.for_patient |
| ImmunizationGateway | DataMapper.allergy_list | RpmsRpc::Allergy (TODO: migrate to Immunization) |

Note: ImmunizationGateway keeps calling allergy_list for backward compatibility. The known bug (wrong mapping) is preserved to avoid breaking tests; proper immunization RPC wiring is tracked separately.

Closes #207

## Test plan

- [x] `bundle exec rails test` — 2387 runs, 0 failures
- [x] `bundle exec cucumber` — 323 scenarios, 323 passed
- [x] `bundle exec rubocop` — 0 offenses
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)