### PR TITLE
Port CQM + clinical alert service test gaps (+9 tests)

### DIFF
--- a/app/services/lakeraven/ehr/clinical_alert_service.rb
+++ b/app/services/lakeraven/ehr/clinical_alert_service.rb
@@ -56,11 +56,12 @@ module Lakeraven
         @allergies.map do |a|
           allergen = a.respond_to?(:allergen) ? a.allergen : a[:allergen]
           severity_val = a.respond_to?(:severity) ? a.severity : a[:severity]
+          criticality_val = a.respond_to?(:criticality) ? a.criticality : a[:criticality]
 
           Alert.new(
             type: :allergy,
             description: allergen || (a.respond_to?(:description) ? a.description : a[:description]),
-            severity: map_allergy_severity(severity_val)
+            severity: map_allergy_severity(severity_val, criticality: criticality_val)
           )
         end
       end
@@ -73,12 +74,24 @@ module Lakeraven
         end
       end
 
-      def map_allergy_severity(severity)
-        case severity&.downcase
-        when "severe", "high" then :high
-        when "moderate" then :moderate
-        when "mild", "low" then :low
-        else :moderate # unknown severity defaults to moderate
+      def map_allergy_severity(severity, criticality: nil)
+        if severity.present?
+          case severity.downcase
+          when "severe", "high" then :high
+          when "moderate" then :moderate
+          when "mild", "low" then :low
+          else criticality_fallback(criticality)
+          end
+        else
+          criticality_fallback(criticality)
+        end
+      end
+
+      def criticality_fallback(criticality)
+        case criticality&.downcase
+        when "high" then :high
+        when "low", "unable-to-assess" then :low
+        else :moderate
         end
       end
     end

--- a/test/services/lakeraven/ehr/clinical_alert_service_test.rb
+++ b/test/services/lakeraven/ehr/clinical_alert_service_test.rb
@@ -119,6 +119,33 @@ module Lakeraven
         assert_equal :moderate, allergy_alert.severity
       end
 
+      test "falls back to criticality when severity is nil" do
+        service = ClinicalAlertService.new(reminders: [], allergies: [
+          AllergyIntolerance.new(allergen: "Test", severity: nil, criticality: "high", clinical_status: "active")
+        ])
+        alerts = service.background_alerts
+        allergy_alert = alerts.find { |a| a.type == :allergy }
+        assert_equal :high, allergy_alert.severity
+      end
+
+      test "maps low criticality to :low" do
+        service = ClinicalAlertService.new(reminders: [], allergies: [
+          AllergyIntolerance.new(allergen: "Test", severity: nil, criticality: "low", clinical_status: "active")
+        ])
+        alerts = service.background_alerts
+        allergy_alert = alerts.find { |a| a.type == :allergy }
+        assert_equal :low, allergy_alert.severity
+      end
+
+      test "severity field takes precedence over criticality" do
+        service = ClinicalAlertService.new(reminders: [], allergies: [
+          AllergyIntolerance.new(allergen: "Test", severity: "mild", criticality: "high", clinical_status: "active")
+        ])
+        alerts = service.background_alerts
+        allergy_alert = alerts.find { |a| a.type == :allergy }
+        assert_equal :low, allergy_alert.severity
+      end
+
       # =============================================================================
       # REMINDER SEVERITY MAPPING
       # =============================================================================

--- a/test/services/lakeraven/ehr/cqm_calculation_service_test.rb
+++ b/test/services/lakeraven/ehr/cqm_calculation_service_test.rb
@@ -106,6 +106,82 @@ module Lakeraven
         assert_equal 1, report.numerator_count
       end
 
+      # =============================================================================
+      # ADDITIONAL SCENARIOS (ported from rpms_redux)
+      # =============================================================================
+
+      test "observation outside period is not counted in numerator" do
+        service = build_service(
+          measure: @diabetes_measure,
+          conditions: [ build_condition("pt_1", "2.16.840.1.113883.3.464.1003.103.12.1001") ],
+          observations: [ build_observation("pt_1", 9.5, Date.new(2024, 6, 1)) ]
+        )
+
+        report = service.evaluate("CMS122v5", "pt_1", period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
+        assert_equal 0, report.numerator_count
+      end
+
+      test "patient without qualifying condition is not in initial population" do
+        service = build_service(
+          measure: @diabetes_measure,
+          conditions: [],
+          observations: [ build_observation("pt_1", 9.5, Date.new(2026, 6, 1)) ]
+        )
+
+        report = service.evaluate("CMS122v5", "pt_1", period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
+        assert_equal 0, report.initial_population_count
+      end
+
+      test "returns nil for non-existent measure" do
+        service = build_service(
+          measure: nil,
+          conditions: [],
+          observations: []
+        )
+
+        report = service.evaluate("NONEXISTENT", "pt_1", period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
+        assert_nil report
+      end
+
+      test "report includes period dates" do
+        service = build_service(
+          measure: @diabetes_measure,
+          conditions: [ build_condition("pt_1", "2.16.840.1.113883.3.464.1003.103.12.1001") ],
+          observations: [ build_observation("pt_1", 8.0, Date.new(2026, 6, 1)) ]
+        )
+
+        report = service.evaluate("CMS122v5", "pt_1", period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
+        assert_equal Date.new(2026, 1, 1), report.period_start
+        assert_equal Date.new(2026, 12, 31), report.period_end
+      end
+
+      test "report is individual type" do
+        service = build_service(
+          measure: @diabetes_measure,
+          conditions: [ build_condition("pt_1", "2.16.840.1.113883.3.464.1003.103.12.1001") ],
+          observations: [ build_observation("pt_1", 8.0, Date.new(2026, 6, 1)) ]
+        )
+
+        report = service.evaluate("CMS122v5", "pt_1", period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
+        assert_equal "individual", report.report_type
+      end
+
+      test "evaluate_population excludes patients not in initial population" do
+        service = build_service(
+          measure: @diabetes_measure,
+          conditions: [
+            build_condition("pt_1", "2.16.840.1.113883.3.464.1003.103.12.1001")
+          ],
+          observations: [
+            build_observation("pt_1", 8.0, Date.new(2026, 6, 1)),
+            build_observation("pt_2", 9.0, Date.new(2026, 6, 1))
+          ]
+        )
+
+        report = service.evaluate_population("CMS122v5", %w[pt_1 pt_2], period: Date.new(2026, 1, 1)..Date.new(2026, 12, 31))
+        assert_equal 1, report.initial_population_count
+      end
+
       private
 
       def build_service(measure:, conditions: [], observations: [])


### PR DESCRIPTION
## Summary

Close remaining service test gaps where implementations exist:

- **CQM** (+5): outside-period exclusion, nil measure, period dates, report type, population filtering
- **Clinical alert** (+4): criticality fallback (severity nil → use criticality), low criticality mapping, severity-over-criticality precedence. Implementation fix: `map_allergy_severity` now accepts `criticality:` kwarg as fallback.

Drug interaction remaining gap (23 tests) is rpms_redux adapter factory/production guard specific — not portable to the layer contract architecture.

## Test plan

- [x] `bundle exec rails test` — 2462 runs, 0 failures
- [x] `bundle exec cucumber` — 323 scenarios, 323 passed
- [x] `bundle exec rubocop` — 0 offenses
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)