### PR TITLE
Port ELR services + Observation SDOH tests (+13 tests)

### DIFF
--- a/app/services/lakeraven/ehr/elr/eclrs_transmission_service.rb
+++ b/app/services/lakeraven/ehr/elr/eclrs_transmission_service.rb
@@ -28,6 +28,19 @@ module Lakeraven
           end
 
           result
+        rescue => e
+          AuditEvent.create!(
+            event_type: "application",
+            action: "C",
+            outcome: "8",
+            agent_who_type: "Practitioner",
+            agent_who_identifier: provider_duz,
+            entity_type: "ORU",
+            entity_identifier: patient_dfn,
+            outcome_desc: "elr.lab_report.failed: #{e.message}"
+          )
+
+          { success: false, error: e.message }
         end
       end
     end

--- a/test/models/lakeraven/ehr/observation_sdoh_test.rb
+++ b/test/models/lakeraven/ehr/observation_sdoh_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class ObservationSdohTest < ActiveSupport::TestCase
+      test "defines SDOH screening LOINC codes" do
+        assert Observation::SDOH_CODES.is_a?(Hash)
+        assert Observation::SDOH_CODES.key?(:housing_status)
+        assert Observation::SDOH_CODES.key?(:food_insecurity)
+      end
+
+      test "social-history observation is SDOH" do
+        obs = Observation.new(patient_dfn: "1", display: "Housing status", category: "social-history")
+        assert obs.sdoh?
+      end
+
+      test "survey observation is SDOH" do
+        obs = Observation.new(patient_dfn: "1", display: "SDOH screening", category: "survey")
+        assert obs.sdoh?
+      end
+
+      test "vital-signs observation is not SDOH" do
+        obs = Observation.new(patient_dfn: "1", display: "Blood pressure", category: "vital-signs")
+        refute obs.sdoh?
+      end
+
+      test "SDOH observation to_fhir has correct category coding" do
+        obs = Observation.new(
+          patient_dfn: "1", display: "Housing status",
+          category: "social-history", code: "71802-3"
+        )
+        fhir = obs.to_fhir
+
+        cat = fhir[:category]&.first
+        refute_nil cat
+        assert_equal "social-history", cat[:coding].first[:code]
+      end
+
+      test "SDOH observation has LOINC-coded code" do
+        obs = Observation.new(
+          patient_dfn: "1", display: "Housing status",
+          category: "social-history", code: "71802-3", code_system: "loinc"
+        )
+        fhir = obs.to_fhir
+
+        code_coding = fhir[:code][:coding]&.first
+        refute_nil code_coding
+        assert_equal "71802-3", code_coding[:code]
+        assert_equal "http://loinc.org", code_coding[:system]
+      end
+
+      test "SDOH observation has valueString for text answers" do
+        obs = Observation.new(
+          patient_dfn: "1", display: "Housing status",
+          category: "social-history", code: "71802-3",
+          value: "Permanently housed"
+        )
+        fhir = obs.to_fhir
+
+        assert_equal "Permanently housed", fhir[:valueString]
+      end
+
+      test "SDOH observation has patient reference" do
+        obs = Observation.new(
+          patient_dfn: "123", display: "Food insecurity",
+          category: "social-history", code: "88122-7"
+        )
+        fhir = obs.to_fhir
+
+        assert_equal "Patient/123", fhir[:subject][:reference]
+      end
+    end
+  end
+end

--- a/test/services/lakeraven/ehr/elr/elr_services_test.rb
+++ b/test/services/lakeraven/ehr/elr/elr_services_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    module Elr
+      class ElrServicesTest < ActiveSupport::TestCase
+        test "submit succeeds with mock adapter" do
+          adapter = MockEclrsAdapter.new
+          service = EclrsTransmissionService.new(adapter: adapter)
+
+          result = service.submit(
+            oru_message: "MSH|^~\\&|Lab|ECLRS||...",
+            patient_dfn: "12345",
+            provider_duz: "789"
+          )
+
+          assert result[:success]
+          assert result[:tracking_id].present?
+        end
+
+        test "submit creates audit event" do
+          adapter = MockEclrsAdapter.new
+          service = EclrsTransmissionService.new(adapter: adapter)
+
+          assert_difference "AuditEvent.count", 1 do
+            service.submit(
+              oru_message: "MSH|^~\\&|Lab|ECLRS||...",
+              patient_dfn: "12345",
+              provider_duz: "789"
+            )
+          end
+        end
+
+        test "submit records transmission in adapter" do
+          adapter = MockEclrsAdapter.new
+          service = EclrsTransmissionService.new(adapter: adapter)
+
+          service.submit(
+            oru_message: "MSH|^~\\&|Lab|ECLRS||...",
+            patient_dfn: "12345",
+            provider_duz: "789"
+          )
+
+          assert_equal 1, adapter.submissions.size
+        end
+
+        test "submit audits failure when adapter raises" do
+          failing_adapter = Object.new
+          failing_adapter.define_singleton_method(:transmit) { |_msg| raise "Connection refused" }
+          service = EclrsTransmissionService.new(adapter: failing_adapter)
+
+          result = nil
+          assert_difference "AuditEvent.count", 1 do
+            result = service.submit(
+              oru_message: "MSH|^~\\&|Lab|ECLRS||...",
+              patient_dfn: "12345",
+              provider_duz: "789"
+            )
+          end
+
+          refute result[:success]
+        end
+
+        test "mock adapter tracks submissions" do
+          adapter = MockEclrsAdapter.new
+
+          result = adapter.transmit("MSH|^~\\&|Lab|ECLRS||...")
+
+          assert result[:success]
+          assert result[:tracking_id].present?
+          assert_equal 1, adapter.submissions.size
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- ELR EclrsTransmissionService: 5 tests + error handling fix
- Observation SDOH: 8 tests for social-history/survey categories

QRDA (31) and ORU (17) were already fully ported — earlier gap analysis missed subdirectory paths.

## Test plan

- [x] 2475 runs, 0 failures
- [x] 323 scenarios passed
- [x] 0 offenses
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)