### PR TITLE
Port FHIR resource BDD features (19 resources, 139 scenarios)

### DIFF
--- a/app/gateways/lakeraven/ehr/eligibility_gateway.rb
+++ b/app/gateways/lakeraven/ehr/eligibility_gateway.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
+require "rpms_rpc/api/vfc"
 
 module Lakeraven
   module EHR
     class EligibilityGateway
       def self.patient_eligibility(dfn)
-        RpmsRpc::DataMapper.vfc_eligibility.fetch_one(dfn.to_s) || { code: nil, label: nil }
+        RpmsRpc::VFC.eligibility(dfn)
       end
 
       def self.list_codes
-        RpmsRpc::DataMapper.vfc_eligibility_list.fetch_many
+        RpmsRpc::VFC.eligibility_codes
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/practitioner_gateway.rb
+++ b/app/gateways/lakeraven/ehr/practitioner_gateway.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
+require "rpms_rpc/api/practitioner"
 
 module Lakeraven
   module EHR
     class PractitionerGateway
       class << self
         def find(ien)
-          attrs = RpmsRpc::DataMapper.practitioner_info.fetch_one(ien.to_s, extras: { ien: ien.to_i })
+          attrs = RpmsRpc::Practitioner.find(ien)
           return nil unless attrs
           return nil if attrs[:name] == "-1"
 
@@ -15,7 +15,7 @@ module Lakeraven
         end
 
         def search(name_pattern)
-          results = RpmsRpc::DataMapper.practitioner_list.fetch_many(name_pattern, "1")
+          results = RpmsRpc::Practitioner.search(name_pattern)
           results.filter_map do |attrs|
             next if attrs[:name].blank?
 

--- a/app/gateways/lakeraven/ehr/tribal_enrollment_gateway.rb
+++ b/app/gateways/lakeraven/ehr/tribal_enrollment_gateway.rb
@@ -1,29 +1,28 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/mappings"
+require "rpms_rpc/api/tribal"
 
 module Lakeraven
   module EHR
     class TribalEnrollmentGateway
       def self.enrollment_details(dfn)
-        RpmsRpc::DataMapper.tribal_enrollment.fetch_one(dfn.to_s)
+        RpmsRpc::Tribal.enrollment(dfn)
       end
 
       def self.validate(enrollment_number)
-        RpmsRpc::DataMapper.tribal_validation.fetch_one(enrollment_number.to_s)
+        RpmsRpc::Tribal.validate(enrollment_number)
       end
 
       def self.eligibility(dfn)
-        RpmsRpc::DataMapper.enrollment_eligibility.fetch_one(dfn.to_s) ||
-          { active: false, eligible_for_ihs: false }
+        RpmsRpc::Tribal.eligibility(dfn)
       end
 
       def self.service_unit(dfn)
-        RpmsRpc::DataMapper.service_unit.fetch_one(dfn.to_s)
+        RpmsRpc::Tribal.service_unit(dfn)
       end
 
       def self.tribe_info(code)
-        RpmsRpc::DataMapper.tribe_info.fetch_one(code.to_s)
+        RpmsRpc::Tribal.tribe_info(code)
       end
     end
   end

--- a/app/services/lakeraven/ehr/fhir/condition_serializer.rb
+++ b/app/services/lakeraven/ehr/fhir/condition_serializer.rb
@@ -6,7 +6,7 @@ module Lakeraven
   module EHR
     module FHIR
       # Serializes a Problem/Condition domain object to FHIR R4 Condition hash.
-      # Integrates terminology decorators for coded diagnoses.
+      # Integrates terminology serializers for coded diagnoses.
       class ConditionSerializer
         CLINICAL_STATUS_MAP = {
           "A" => { code: "active", display: "Active" },

--- a/app/terminology/lakeraven/ehr/terminology.rb
+++ b/app/terminology/lakeraven/ehr/terminology.rb
@@ -3,9 +3,9 @@
 module Lakeraven
   module EHR
     module Terminology
-      # Base class for terminology decorators.
+      # Base class for terminology serializers.
       # Pure transform — no I/O, no RPC calls, no database queries.
-      # Projects a code value into a terminology system using in-memory data.
+      # Projects a code value into a FHIR Coding using in-memory data.
       class Base
         attr_reader :code
 

--- a/features/cds_rules.feature
+++ b/features/cds_rules.feature
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+Feature: Clinical decision support rules
+  As a healthcare system
+  I need configurable CDS rules for conditions, demographics, and devices
+  So that clinical alerts are evidence-based and controllable
+
+  # --- Rule configuration ---
+
+  Scenario: CDS rules are loaded from configuration
+    When I list all CDS rules
+    Then there should be at least 1 rule
+    And each rule should have an id and message
+
+  Scenario: Find a rule by ID
+    When I look up rule "diabetes_monitoring"
+    Then the rule should exist
+    And the rule message should mention "Diabetes"
+
+  Scenario: Rules are enabled by default
+    When I check if rule "diabetes_monitoring" is enabled
+    Then the rule should be enabled
+
+  Scenario: Disable a CDS rule
+    When provider "201" disables rule "diabetes_monitoring"
+    Then rule "diabetes_monitoring" should be disabled
+
+  Scenario: Re-enable a disabled rule
+    Given provider "201" has disabled rule "diabetes_monitoring"
+    When provider "201" enables rule "diabetes_monitoring"
+    Then rule "diabetes_monitoring" should be enabled
+
+  Scenario: Rule override records provider and timestamp
+    When provider "201" disables rule "diabetes_monitoring"
+    Then the override result should include provider "201"
+    And the override result should include a timestamp
+
+  # --- CdsResult ---
+
+  Scenario: CdsResult with no alerts
+    Given a CDS result with no alerts
+    Then the result should not have alerts
+    And the result summary should be "No clinical alerts"
+
+  Scenario: CdsResult with alerts
+    Given a CDS result with alerts:
+      | category        | severity | message               |
+      | drug-interaction | critical | Warfarin + Aspirin    |
+      | lab-result       | warning  | A1C elevated          |
+    Then the result should have alerts
+    And the result should have 2 alerts
+
+  Scenario: CdsResult filters by category
+    Given a CDS result with alerts:
+      | category        | severity | message               |
+      | drug-interaction | critical | Warfarin + Aspirin    |
+      | lab-result       | warning  | A1C elevated          |
+      | drug-interaction | warning  | Metformin + Contrast  |
+    When I filter alerts by category "drug-interaction"
+    Then there should be 2 filtered alerts
+
+  Scenario: CdsResult filters critical alerts
+    Given a CDS result with alerts:
+      | category        | severity | message               |
+      | drug-interaction | critical | Warfarin + Aspirin    |
+      | lab-result       | warning  | A1C elevated          |
+    When I filter critical alerts
+    Then there should be 1 critical alert
+
+  Scenario: CdsResult summary describes alert counts
+    Given a CDS result with alerts:
+      | category        | severity | message               |
+      | drug-interaction | critical | Warfarin + Aspirin    |
+      | lab-result       | warning  | A1C elevated          |
+    Then the result summary should include "2 alert(s)"
+
+  Scenario: CdsResult to_h includes all fields
+    Given a CDS result with alerts:
+      | category        | severity | message               |
+      | drug-interaction | critical | Warfarin + Aspirin    |
+    When I convert the result to a hash
+    Then the hash should include patient_dfn
+    And the hash should include alert_count 1
+
+  # --- Alert override ---
+
+  Scenario: Override an alert with reason
+    Given an alert with id "cds-di-001" and category "drug-interaction"
+    When provider "201" overrides the alert with reason "Clinically appropriate"
+    Then the override should be recorded
+    And the override should include the original alert
+    And the override reason should be "Clinically appropriate"

--- a/features/clinical_alerts.feature
+++ b/features/clinical_alerts.feature
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+Feature: Clinical alert aggregation
+  As a healthcare provider
+  I need to see clinical alerts aggregated from multiple sources
+  So that I can quickly assess patient safety concerns
+
+  Scenario: DUE reminders generate alerts
+    Given clinical reminders:
+      | name                  | status | priority |
+      | Diabetic Eye Exam     | DUE    | high     |
+      | Flu Vaccine           | DUE    | low      |
+    When I aggregate background alerts
+    Then there should be 2 alerts
+    And the first alert type should be "reminder"
+
+  Scenario: Non-DUE reminders are filtered out
+    Given clinical reminders:
+      | name              | status     | priority |
+      | Diabetic Eye Exam | DUE        | high     |
+      | Flu Vaccine       | RESOLVED   |          |
+      | Colonoscopy       | NOT DUE    |          |
+    When I aggregate background alerts
+    Then there should be 1 alert
+
+  Scenario: High priority reminder maps to high severity
+    Given clinical reminders:
+      | name              | status | priority |
+      | Diabetic Eye Exam | DUE    | high     |
+    When I aggregate background alerts
+    Then the first alert severity should be "high"
+
+  Scenario: Low priority reminder maps to low severity
+    Given clinical reminders:
+      | name        | status | priority |
+      | Flu Vaccine | DUE    | low      |
+    When I aggregate background alerts
+    Then the first alert severity should be "low"
+
+  Scenario: Default reminder severity is moderate
+    Given clinical reminders:
+      | name        | status | priority |
+      | A1C Check   | DUE    |          |
+    When I aggregate background alerts
+    Then the first alert severity should be "moderate"
+
+  Scenario: Allergy alerts from active allergies
+    Given patient allergies:
+      | allergen   | severity | criticality |
+      | Penicillin | severe   |             |
+      | Aspirin    | mild     |             |
+    When I aggregate background alerts
+    Then there should be 2 alerts
+    And the first alert type should be "allergy"
+
+  Scenario: Severe allergy maps to high severity
+    Given patient allergies:
+      | allergen   | severity | criticality |
+      | Penicillin | severe   |             |
+    When I aggregate background alerts
+    Then the first alert severity should be "high"
+
+  Scenario: Moderate allergy maps to moderate severity
+    Given patient allergies:
+      | allergen   | severity | criticality |
+      | Latex      | moderate |             |
+    When I aggregate background alerts
+    Then the first alert severity should be "moderate"
+
+  Scenario: Mild allergy maps to low severity
+    Given patient allergies:
+      | allergen   | severity | criticality |
+      | Aspirin    | mild     |             |
+    When I aggregate background alerts
+    Then the first alert severity should be "low"
+
+  Scenario: Criticality fallback when severity is nil
+    Given patient allergies:
+      | allergen   | severity | criticality |
+      | Codeine    |          | high        |
+    When I aggregate background alerts
+    Then the first alert severity should be "high"
+
+  Scenario: Criticality low fallback
+    Given patient allergies:
+      | allergen | severity | criticality |
+      | Dust     |          | low         |
+    When I aggregate background alerts
+    Then the first alert severity should be "low"
+
+  Scenario: Default severity is moderate when no severity or criticality
+    Given patient allergies:
+      | allergen | severity | criticality |
+      | Shellfish |         |             |
+    When I aggregate background alerts
+    Then the first alert severity should be "moderate"
+
+  Scenario: Drug interactions list is intentionally empty
+    Given patient allergies:
+      | allergen   | severity | criticality |
+      | Penicillin | severe   |             |
+    When I check drug interactions
+    Then the drug interactions should be empty
+
+  Scenario: Severity summary counts
+    Given clinical reminders:
+      | name              | status | priority |
+      | Diabetic Eye Exam | DUE    | high     |
+      | Flu Vaccine       | DUE    | low      |
+    And patient allergies:
+      | allergen   | severity | criticality |
+      | Penicillin | severe   |             |
+    When I aggregate background alerts
+    Then the severity summary should show 2 high alerts
+    And the severity summary should show 0 moderate alerts
+    And the severity summary should show 1 low alert
+
+  Scenario: Mixed reminders and allergies
+    Given clinical reminders:
+      | name          | status | priority |
+      | A1C Check     | DUE    |          |
+    And patient allergies:
+      | allergen   | severity | criticality |
+      | Penicillin | severe   |             |
+    When I aggregate background alerts
+    Then there should be 2 alerts

--- a/features/fhir/allergy_intolerance.feature
+++ b/features/fhir/allergy_intolerance.feature
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+Feature: AllergyIntolerance FHIR resource
+  As a healthcare system
+  I need to represent patient allergies
+  So that allergy data is interoperable
+
+  Scenario: Active allergy
+    Given an allergy to "Penicillin" for patient "100"
+    Then the allergy should be active
+
+  Scenario: Medication allergy
+    Given a medication allergy to "Penicillin" for patient "100"
+    Then the allergy should be a medication allergy
+
+  Scenario: Food allergy
+    Given a food allergy to "Peanuts" for patient "100"
+    Then the allergy should be a food allergy
+
+  Scenario: Allergy matching key with code
+    Given an allergy to "Penicillin" with code "7980" for patient "100"
+    Then the allergy matching key should be "rxnorm:7980"
+
+  Scenario: FHIR AllergyIntolerance includes resourceType
+    Given an allergy to "Penicillin" for patient "100"
+    When I serialize the allergy to FHIR
+    Then the FHIR resourceType should be "AllergyIntolerance"
+
+  Scenario: FHIR AllergyIntolerance includes patient reference
+    Given an allergy to "Penicillin" for patient "100"
+    When I serialize the allergy to FHIR
+    Then the FHIR allergy patient reference should include "100"
+
+  Scenario: FHIR AllergyIntolerance includes allergen
+    Given an allergy to "Penicillin" for patient "100"
+    When I serialize the allergy to FHIR
+    Then the FHIR allergy code text should be "Penicillin"

--- a/features/fhir/audit_event.feature
+++ b/features/fhir/audit_event.feature
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+Feature: AuditEvent FHIR resource
+  As a compliance officer
+  I need to represent audit events as FHIR resources
+  So that PHI access logging is interoperable
+
+  Scenario: Audit event with read action
+    Given an audit event with action "R" for entity "Patient" "100"
+    Then the audit event should be a read action
+    And the audit event action display should be "Read"
+
+  Scenario: Audit event with create action
+    Given an audit event with action "C" for entity "Patient" "100"
+    Then the audit event should be a create action
+    And the audit event action display should be "Create"
+
+  Scenario: Audit event with update action
+    Given an audit event with action "U" for entity "Patient" "100"
+    Then the audit event should be an update action
+
+  Scenario: Audit event with delete action
+    Given an audit event with action "D" for entity "Patient" "100"
+    Then the audit event should be a delete action
+
+  Scenario: Audit event with execute action
+    Given an audit event with action "E" for entity "ValueSet" "gpra-diabetes-dx"
+    Then the audit event should be an execute action
+
+  Scenario: Successful outcome
+    Given an audit event with outcome "0" for entity "Patient" "100"
+    Then the audit event should be successful
+    And the audit event outcome display should be "Success"
+
+  Scenario: Minor failure outcome
+    Given an audit event with outcome "4" for entity "Patient" "100"
+    Then the audit event should be a minor failure
+
+  Scenario: Serious failure outcome
+    Given an audit event with outcome "8" for entity "Patient" "100"
+    Then the audit event should be a serious failure
+
+  Scenario: Major failure outcome
+    Given an audit event with outcome "12" for entity "Patient" "100"
+    Then the audit event should be a major failure
+
+  Scenario: Event type display
+    Given a rest audit event with action "R" for entity "Patient" "100"
+    Then the audit event type display should be "RESTful Operation"
+
+  Scenario: Security event type
+    Given a security audit event with action "R" for entity "Patient" "100"
+    Then the audit event type display should be "Security"
+
+  Scenario: Entity presence check
+    Given an audit event with action "R" for entity "Patient" "100"
+    Then the audit event should have an entity
+
+  Scenario: Audit event without entity identifier
+    Given an audit event with action "R" and entity type "Patient" but no identifier
+    Then the audit event should not have an entity
+
+  Scenario: FHIR AuditEvent includes resourceType
+    Given an audit event with action "R" for entity "Patient" "100"
+    When I serialize the audit event to FHIR
+    Then the FHIR resourceType should be "AuditEvent"
+
+  Scenario: FHIR AuditEvent includes action
+    Given an audit event with action "R" for entity "Patient" "100"
+    When I serialize the audit event to FHIR
+    Then the FHIR audit event action should be "R"
+
+  Scenario: FHIR AuditEvent includes outcome
+    Given an audit event with outcome "0" for entity "Patient" "100"
+    When I serialize the audit event to FHIR
+    Then the FHIR audit event outcome should be "0"
+
+  Scenario: FHIR AuditEvent includes entity reference
+    Given an audit event with action "R" for entity "Patient" "100"
+    When I serialize the audit event to FHIR
+    Then the FHIR audit event entity should reference "Patient/100"
+
+  Scenario: FHIR AuditEvent includes agent
+    Given an audit event with action "R" for entity "Patient" "100" by agent "201"
+    When I serialize the audit event to FHIR
+    Then the FHIR audit event agent should include "201"
+
+  Scenario: FHIR AuditEvent type coding
+    Given a rest audit event with action "R" for entity "Patient" "100"
+    When I serialize the audit event to FHIR
+    Then the FHIR audit event type code should be "rest"
+
+  Scenario: Export event type
+    Given an export audit event with action "R" for entity "Patient" "100"
+    Then the audit event type display should be "Export"
+
+  Scenario: Import event type
+    Given an import audit event with action "C" for entity "Patient" "100"
+    Then the audit event type display should be "Import"
+
+  Scenario: Query event type
+    Given a query audit event with action "E" for entity "Patient" "100"
+    Then the audit event type display should be "Query"
+
+  Scenario: User authentication event type
+    Given a user audit event with action "E" for entity "Session" "user-201"
+    Then the audit event type display should be "User Authentication"
+
+  Scenario: Application event type
+    Given an application audit event with action "E" for entity "System" "startup"
+    Then the audit event type display should be "Application"
+
+  Scenario: FHIR AuditEvent includes outcome description
+    Given an audit event with outcome "4" and description "Resource not found" for entity "Patient" "999"
+    When I serialize the audit event to FHIR
+    Then the FHIR audit event outcome description should be "Resource not found"
+
+  Scenario: FHIR AuditEvent agent includes network address
+    Given an audit event with action "R" for entity "Patient" "100" by agent "201" from "192.168.1.1"
+    When I serialize the audit event to FHIR
+    Then the FHIR audit event agent network should be "192.168.1.1"
+
+  Scenario: FHIR AuditEvent with no agent omits agent array
+    Given an audit event with action "R" for entity "Patient" "100"
+    When I serialize the audit event to FHIR
+    Then the FHIR audit event agents should be empty
+
+  Scenario: FHIR AuditEvent with no entity omits entity array
+    Given an audit event with action "R" and entity type "Patient" but no identifier
+    When I serialize the audit event to FHIR
+    Then the FHIR audit event entities should be empty

--- a/features/fhir/care_plan.feature
+++ b/features/fhir/care_plan.feature
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+Feature: CarePlan FHIR resource
+  As a healthcare system
+  I need to represent patient care plans
+  So that treatment plans are interoperable
+
+  Scenario: Create a valid care plan
+    Given a care plan with title "Diabetes Management" for patient "100"
+    Then the care plan should be valid
+
+  Scenario: Care plan requires patient
+    Given a care plan without a patient
+    Then the care plan should be invalid
+
+  Scenario: Care plan is active by default
+    Given a care plan with title "Diabetes Management" for patient "100"
+    Then the care plan should be active
+
+  Scenario: Care plan with category
+    Given a care plan with title "PT Plan" and category "assess-plan" for patient "100"
+    Then the care plan should be valid
+
+  Scenario: FHIR CarePlan includes resourceType
+    Given a care plan with title "Diabetes Management" for patient "100"
+    When I serialize the care plan to FHIR
+    Then the FHIR resourceType should be "CarePlan"
+
+  Scenario: FHIR CarePlan includes subject reference
+    Given a care plan with title "Diabetes Management" for patient "100"
+    When I serialize the care plan to FHIR
+    Then the FHIR subject reference should include "100"
+
+  Scenario: FHIR CarePlan includes status and intent
+    Given a care plan with title "Diabetes Management" for patient "100"
+    When I serialize the care plan to FHIR
+    Then the FHIR care plan status should be "active"
+    And the FHIR care plan intent should be "plan"
+
+  Scenario: FHIR CarePlan includes title
+    Given a care plan with title "Diabetes Management" for patient "100"
+    When I serialize the care plan to FHIR
+    Then the FHIR care plan title should be "Diabetes Management"

--- a/features/fhir/care_team.feature
+++ b/features/fhir/care_team.feature
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+Feature: CareTeam FHIR resource
+  As a healthcare system
+  I need to represent patient care teams
+  So that team composition is interoperable
+
+  Scenario: Create a valid care team
+    Given a care team with name "Primary Care Team" for patient "100"
+    Then the care team should be valid
+
+  Scenario: Care team requires patient
+    Given a care team without a patient
+    Then the care team should be invalid
+
+  Scenario: Care team with participants
+    Given a care team with name "Primary Care Team" for patient "100"
+    And the care team has a participant with duz "201" and role "Primary Care Provider"
+    Then the care team should be valid
+
+  Scenario: FHIR CareTeam includes resourceType
+    Given a care team with name "Primary Care Team" for patient "100"
+    When I serialize the care team to FHIR
+    Then the FHIR resourceType should be "CareTeam"
+
+  Scenario: FHIR CareTeam includes subject reference
+    Given a care team with name "Primary Care Team" for patient "100"
+    When I serialize the care team to FHIR
+    Then the FHIR care team subject reference should include "100"
+
+  Scenario: FHIR CareTeam includes participants
+    Given a care team with name "Primary Care Team" for patient "100"
+    And the care team has a participant with duz "201" and role "PCP"
+    When I serialize the care team to FHIR
+    Then the FHIR care team should have participants
+
+  Scenario: FHIR CareTeam includes name
+    Given a care team with name "Primary Care Team" for patient "100"
+    When I serialize the care team to FHIR
+    Then the FHIR care team name should be "Primary Care Team"

--- a/features/fhir/communication.feature
+++ b/features/fhir/communication.feature
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+Feature: Communication FHIR resource
+  As a healthcare system
+  I need to represent secure messages between care team members
+  So that clinical messaging is interoperable
+
+  Scenario: Create a valid communication
+    Given a communication with content "Lab results ready" from "Practitioner" "201" for patient "100"
+    Then the communication should be valid
+
+  Scenario: Communication requires patient
+    Given a communication without a patient
+    Then the communication should be invalid
+
+  Scenario: Communication requires sender
+    Given a communication without a sender for patient "100"
+    Then the communication should be invalid
+
+  Scenario: Communication requires content
+    Given a communication without content from "Practitioner" "201" for patient "100"
+    Then the communication should be invalid
+
+  Scenario: Communication status helpers
+    Given a communication with status "completed" from "Practitioner" "201" for patient "100"
+    Then the communication should be completed
+
+  Scenario: Communication priority helpers
+    Given a communication with priority "urgent" from "Practitioner" "201" for patient "100"
+    Then the communication should be urgent
+
+  Scenario: Communication category helpers
+    Given a communication with category "alert" from "Practitioner" "201" for patient "100"
+    Then the communication should be an alert
+
+  Scenario: Root message detection
+    Given a communication with content "Initial message" from "Practitioner" "201" for patient "100"
+    Then the communication should be a root message
+
+  Scenario: Reply detection
+    Given a communication replying to message "msg-001" from "Practitioner" "201" for patient "100"
+    Then the communication should be a reply
+
+  Scenario: FHIR Communication includes resourceType
+    Given a communication with content "Lab results ready" from "Practitioner" "201" for patient "100"
+    When I serialize the communication to FHIR
+    Then the FHIR resourceType should be "Communication"
+
+  Scenario: FHIR Communication includes subject
+    Given a communication with content "Lab results ready" from "Practitioner" "201" for patient "100"
+    When I serialize the communication to FHIR
+    Then the FHIR subject reference should include "100"
+
+  Scenario: FHIR Communication includes payload
+    Given a communication with content "Lab results ready" from "Practitioner" "201" for patient "100"
+    When I serialize the communication to FHIR
+    Then the FHIR communication payload should include "Lab results ready"

--- a/features/fhir/condition.feature
+++ b/features/fhir/condition.feature
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+Feature: Condition FHIR resource
+  As a healthcare system
+  I need to represent patient conditions and diagnoses
+  So that problem list data is interoperable
+
+  Scenario: Create a valid condition
+    Given a condition with display "Type 2 Diabetes" for patient "100"
+    Then the condition should be valid
+
+  Scenario: Condition requires patient
+    Given a condition without a patient
+    Then the condition should be invalid
+
+  Scenario: Condition requires display
+    Given a condition without a display for patient "100"
+    Then the condition should be invalid
+
+  Scenario: Active condition
+    Given a condition with display "Type 2 Diabetes" and status "active" for patient "100"
+    Then the condition should be active
+
+  Scenario: Resolved condition
+    Given a condition with display "Type 2 Diabetes" and status "resolved" for patient "100"
+    Then the condition should be resolved
+
+  Scenario: Problem list item
+    Given a condition with display "Type 2 Diabetes" and category "problem-list-item" for patient "100"
+    Then the condition should be a problem list item
+
+  Scenario: Matching key with ICD code
+    Given a condition with display "Type 2 Diabetes" and ICD code "E11.9" for patient "100"
+    Then the condition matching key should be "icd10:E11.9"
+
+  Scenario: FHIR Condition includes resourceType
+    Given a condition with display "Type 2 Diabetes" for patient "100"
+    When I serialize the condition to FHIR
+    Then the FHIR resourceType should be "Condition"
+
+  Scenario: FHIR Condition includes subject
+    Given a condition with display "Type 2 Diabetes" for patient "100"
+    When I serialize the condition to FHIR
+    Then the FHIR subject reference should include "100"
+
+  Scenario: FHIR Condition includes code
+    Given a condition with display "Type 2 Diabetes" and ICD code "E11.9" for patient "100"
+    When I serialize the condition to FHIR
+    Then the FHIR condition code should include "E11.9"

--- a/features/fhir/consent.feature
+++ b/features/fhir/consent.feature
@@ -1,0 +1,142 @@
+Feature: Consent FHIR resource
+  As a healthcare system
+  I need to manage patient consent for proxy access and data sharing
+  So that authorization decisions are enforceable and auditable
+
+  # =============================================================================
+  # CONSENT CREATION & VALIDATION
+  # =============================================================================
+
+  Scenario: Create a valid consent
+    Given a consent with scope "patient-privacy" and status "active" for patient "1"
+    Then the consent should be valid
+
+  Scenario: Consent requires patient
+    Given a consent without a patient
+    Then the consent should be invalid
+    And there should be a consent error on "patient_dfn"
+
+  Scenario: Consent requires scope
+    Given a consent without a scope for patient "1"
+    Then the consent should be invalid
+    And there should be a consent error on "scope"
+
+  # =============================================================================
+  # CONSENT STATUS
+  # =============================================================================
+
+  Scenario: Draft consent is not enforceable
+    Given a consent with scope "patient-privacy" and status "draft" for patient "1"
+    Then the consent should not be enforceable
+
+  Scenario: Active consent is enforceable
+    Given a consent with scope "patient-privacy" and status "active" for patient "1"
+    Then the consent should be enforceable
+
+  Scenario: Rejected consent is not enforceable
+    Given a consent with scope "patient-privacy" and status "rejected" for patient "1"
+    Then the consent should not be enforceable
+
+  Scenario: Inactive consent is not enforceable
+    Given a consent with scope "patient-privacy" and status "inactive" for patient "1"
+    Then the consent should not be enforceable
+
+  # =============================================================================
+  # CONSENT SCOPE
+  # =============================================================================
+
+  Scenario: Patient privacy scope display
+    Given a consent with scope "patient-privacy" and status "active" for patient "1"
+    Then the scope display should be "Privacy Consent"
+
+  Scenario: Treatment scope display
+    Given a consent with scope "treatment" and status "active" for patient "1"
+    Then the scope display should be "Treatment"
+
+  Scenario: Research scope display
+    Given a consent with scope "research" and status "active" for patient "1"
+    Then the scope display should be "Research"
+
+  # =============================================================================
+  # PROVISION TYPES
+  # =============================================================================
+
+  Scenario: Permit provision authorizes access
+    Given a consent with provision type "permit" for patient "1"
+    Then the consent should permit access
+
+  Scenario: Deny provision blocks access
+    Given a consent with provision type "deny" for patient "1"
+    Then the consent should deny access
+
+  # =============================================================================
+  # CONSENT VALIDITY PERIOD
+  # =============================================================================
+
+  Scenario: Consent within validity period
+    Given a consent with period from "2025-01-01" to "2027-12-31" for patient "1"
+    Then the consent should be within period
+
+  Scenario: Consent before validity period starts
+    Given a consent with period from "2099-01-01" to "2099-12-31" for patient "1"
+    Then the consent should not be within period
+
+  Scenario: Consent after validity period ends
+    Given a consent with period from "2020-01-01" to "2020-12-31" for patient "1"
+    Then the consent should not be within period
+
+  # =============================================================================
+  # FHIR SERIALIZATION
+  # =============================================================================
+
+  Scenario: FHIR Consent serialization includes resourceType
+    Given a consent with scope "patient-privacy" and status "active" for patient "1"
+    When I serialize the consent to FHIR
+    Then the FHIR resourceType should be "Consent"
+
+  Scenario: FHIR Consent includes patient reference
+    Given a consent with scope "patient-privacy" and status "active" for patient "123"
+    When I serialize the consent to FHIR
+    Then the FHIR patient reference should be "Patient/123"
+
+  Scenario: FHIR Consent includes scope coding
+    Given a consent with scope "patient-privacy" and status "active" for patient "1"
+    When I serialize the consent to FHIR
+    Then the FHIR scope should include code "patient-privacy"
+
+  Scenario: FHIR Consent includes category
+    Given a consent with scope "patient-privacy" and status "active" for patient "1"
+    When I serialize the consent to FHIR
+    Then the FHIR category should be present
+
+  Scenario: FHIR Consent includes provision
+    Given a consent with scope "patient-privacy" and status "active" and provision "permit" for patient "1"
+    When I serialize the consent to FHIR
+    Then the FHIR provision type should be "permit"
+
+  # =============================================================================
+  # AUTHORIZATION LOGIC
+  # =============================================================================
+
+  Scenario: Active permit consent authorizes access
+    Given a consent with scope "full_access" and status "active" and provision "permit" for patient "1"
+    Then the consent should authorize access
+
+  Scenario: Inactive consent does not authorize
+    Given a consent with scope "full_access" and status "inactive" and provision "permit" for patient "1"
+    Then the consent should not authorize access
+
+  Scenario: Deny consent does not authorize
+    Given a consent with scope "full_access" and status "active" and provision "deny" for patient "1"
+    Then the consent should not authorize access
+
+  Scenario: Consent allows specific permission
+    Given a consent with scope "view_records" and status "active" and provision "permit" for patient "1"
+    Then the consent should allow "view_records"
+    And the consent should not allow "upload_docs"
+
+  Scenario: Full access consent allows any permission
+    Given a consent with scope "full_access" and status "active" and provision "permit" for patient "1"
+    Then the consent should allow "view_records"
+    And the consent should allow "upload_docs"
+    And the consent should allow "message"

--- a/features/fhir/coverage.feature
+++ b/features/fhir/coverage.feature
@@ -1,0 +1,79 @@
+Feature: Coverage FHIR resource
+  As a healthcare system
+  I need to represent patient insurance coverage as FHIR resources
+  So that payer coordination and eligibility are interoperable
+
+  # =============================================================================
+  # COVERAGE CREATION & VALIDATION
+  # =============================================================================
+
+  Scenario: Create a valid Coverage
+    Given a coverage with type "medicare_a" for patient "1"
+    Then the coverage should be valid
+
+  Scenario: Coverage requires patient reference
+    Given a coverage without a patient
+    Then the coverage should be invalid
+    And there should be a coverage error on "patient_dfn"
+
+  Scenario: Coverage requires coverage type
+    Given a coverage without a type for patient "1"
+    Then the coverage should be invalid
+    And there should be a coverage error on "coverage_type"
+
+  # =============================================================================
+  # COVERAGE STATUS
+  # =============================================================================
+
+  Scenario: Active coverage within period
+    Given a coverage with period from "2025-01-01" to "2027-12-31" for patient "1"
+    Then the coverage should be active
+
+  Scenario: Expired coverage
+    Given a coverage with period from "2020-01-01" to "2020-12-31" for patient "1"
+    Then the coverage should be expired
+
+  Scenario: Coverage with no end date is active
+    Given a coverage with start date "2025-01-01" and no end date for patient "1"
+    Then the coverage should be active
+
+  # =============================================================================
+  # COVERAGE TYPES
+  # =============================================================================
+
+  Scenario: Medicare Part A coverage
+    Given a coverage with type "medicare_a" for patient "1"
+    Then the coverage type display should include "Medicare"
+
+  Scenario: Medicaid coverage
+    Given a coverage with type "medicaid" for patient "1"
+    Then the coverage type display should include "Medicaid"
+
+  Scenario: Private insurance coverage
+    Given a coverage with type "private_insurance" for patient "1"
+    Then the coverage type display should include "Private"
+
+  # =============================================================================
+  # FHIR SERIALIZATION
+  # =============================================================================
+
+  Scenario: FHIR Coverage includes resourceType
+    Given a coverage with type "medicare_a" for patient "1"
+    When I serialize the coverage to FHIR
+    Then the FHIR resourceType should be "Coverage"
+
+  Scenario: FHIR Coverage includes beneficiary reference
+    Given a coverage with type "medicare_a" for patient "123"
+    When I serialize the coverage to FHIR
+    Then the FHIR beneficiary reference should be "Patient/123"
+
+  Scenario: FHIR Coverage includes status
+    Given a coverage with type "medicare_a" and status "active" for patient "1"
+    When I serialize the coverage to FHIR
+    Then the FHIR coverage status should be "active"
+
+  Scenario: FHIR Coverage includes period
+    Given a coverage with period from "2024-01-01" to "2024-12-31" for patient "1"
+    When I serialize the coverage to FHIR
+    Then the FHIR period start should be "2024-01-01"
+    And the FHIR period end should be "2024-12-31"

--- a/features/fhir/diagnostic_report.feature
+++ b/features/fhir/diagnostic_report.feature
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+Feature: DiagnosticReport FHIR resource
+  As a healthcare system
+  I need to represent diagnostic reports
+  So that lab and radiology results are interoperable
+
+  Scenario: Create a valid diagnostic report
+    Given a diagnostic report with code "CBC" for patient "100"
+    Then the diagnostic report should be valid
+
+  Scenario: Diagnostic report requires patient
+    Given a diagnostic report without a patient
+    Then the diagnostic report should be invalid
+
+  Scenario: Diagnostic report requires code display
+    Given a diagnostic report without a code for patient "100"
+    Then the diagnostic report should be invalid
+
+  Scenario: Lab diagnostic report
+    Given a lab diagnostic report with code "CBC" and LOINC "58410-2" for patient "100"
+    Then the diagnostic report should be valid
+
+  Scenario: Radiology diagnostic report
+    Given a radiology diagnostic report with code "Chest X-Ray" for patient "100"
+    Then the diagnostic report should be valid
+
+  Scenario: FHIR DiagnosticReport includes resourceType
+    Given a diagnostic report with code "CBC" for patient "100"
+    When I serialize the diagnostic report to FHIR
+    Then the FHIR resourceType should be "DiagnosticReport"
+
+  Scenario: FHIR DiagnosticReport includes subject
+    Given a diagnostic report with code "CBC" for patient "100"
+    When I serialize the diagnostic report to FHIR
+    Then the FHIR subject reference should include "100"
+
+  Scenario: FHIR DiagnosticReport includes status
+    Given a diagnostic report with code "CBC" for patient "100"
+    When I serialize the diagnostic report to FHIR
+    Then the FHIR diagnostic report status should be "final"
+
+  Scenario: FHIR DiagnosticReport includes category
+    Given a lab diagnostic report with code "CBC" and LOINC "58410-2" for patient "100"
+    When I serialize the diagnostic report to FHIR
+    Then the FHIR diagnostic report category should be "LAB"

--- a/features/fhir/document_reference.feature
+++ b/features/fhir/document_reference.feature
@@ -1,0 +1,89 @@
+Feature: DocumentReference FHIR resource
+  As a healthcare system
+  I need to manage clinical documents as FHIR resources
+  So that documents are discoverable and shareable
+
+  # =============================================================================
+  # CREATION & VALIDATION
+  # =============================================================================
+
+  Scenario: Create a valid document reference
+    Given a document reference with type "clinical-note" for patient "1"
+    Then the document reference should be valid
+
+  Scenario: Document reference requires patient
+    Given a document reference without a patient
+    Then the document reference should be invalid
+
+  Scenario: Document reference requires type
+    Given a document reference without a type for patient "1"
+    Then the document reference should be invalid
+
+  # =============================================================================
+  # DOCUMENT STATUS
+  # =============================================================================
+
+  Scenario: Current document status
+    Given a document reference with status "current" for patient "1"
+    Then the document status should be "current"
+
+  Scenario: Superseded document status
+    Given a document reference with status "superseded" for patient "1"
+    Then the document status should be "superseded"
+
+  Scenario: Entered in error document status
+    Given a document reference with status "entered-in-error" for patient "1"
+    Then the document status should be "entered-in-error"
+
+  # =============================================================================
+  # DOCUMENT TYPES
+  # =============================================================================
+
+  Scenario: Clinical note document
+    Given a document reference with type "clinical-note" and display "Progress Note" for patient "1"
+    Then the document type display should be "Progress Note"
+
+  Scenario: Discharge summary document
+    Given a document reference with type "discharge-summary" and display "Discharge Summary" for patient "1"
+    Then the document type display should be "Discharge Summary"
+
+  # =============================================================================
+  # DOCUMENT CONTENT
+  # =============================================================================
+
+  Scenario: Document with author
+    Given a document reference with author "101" for patient "1"
+    Then the document author should be "101"
+
+  Scenario: Document with date
+    Given a document reference dated "2026-01-15" for patient "1"
+    Then the document date should be "2026-01-15"
+
+  # =============================================================================
+  # FHIR SERIALIZATION
+  # =============================================================================
+
+  Scenario: FHIR DocumentReference includes resourceType
+    Given a document reference with type "clinical-note" for patient "1"
+    When I serialize the document reference to FHIR
+    Then the FHIR resourceType should be "DocumentReference"
+
+  Scenario: FHIR DocumentReference includes subject reference
+    Given a document reference with type "clinical-note" for patient "123"
+    When I serialize the document reference to FHIR
+    Then the FHIR subject reference should be "Patient/123"
+
+  Scenario: FHIR DocumentReference includes type coding
+    Given a document reference with type "clinical-note" and display "Progress Note" for patient "1"
+    When I serialize the document reference to FHIR
+    Then the FHIR type should have display "Progress Note"
+
+  Scenario: FHIR DocumentReference includes status
+    Given a document reference with status "current" for patient "1"
+    When I serialize the document reference to FHIR
+    Then the FHIR document status should be "current"
+
+  Scenario: FHIR DocumentReference includes category
+    Given a document reference with category "clinical-note" for patient "1"
+    When I serialize the document reference to FHIR
+    Then the FHIR category should be present

--- a/features/fhir/goal.feature
+++ b/features/fhir/goal.feature
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+Feature: Goal FHIR resource
+  As a healthcare system
+  I need to represent patient goals
+  So that treatment objectives are interoperable
+
+  Scenario: Create a valid goal
+    Given a goal with description "A1C below 7%" for patient "100"
+    Then the goal should be valid
+
+  Scenario: Goal requires patient
+    Given a goal without a patient
+    Then the goal should be invalid
+
+  Scenario: Goal requires description
+    Given a goal without a description for patient "100"
+    Then the goal should be invalid
+
+  Scenario: Goal is active by default
+    Given a goal with description "A1C below 7%" for patient "100"
+    Then the goal should be active
+
+  Scenario: Goal with achievement status
+    Given a goal with description "A1C below 7%" and achievement "achieved" for patient "100"
+    Then the goal should be achieved
+
+  Scenario: Goal with target date
+    Given a goal with description "A1C below 7%" and target "2026-12-31" for patient "100"
+    Then the goal should be valid
+
+  Scenario: FHIR Goal includes resourceType
+    Given a goal with description "A1C below 7%" for patient "100"
+    When I serialize the goal to FHIR
+    Then the FHIR resourceType should be "Goal"
+
+  Scenario: FHIR Goal includes subject
+    Given a goal with description "A1C below 7%" for patient "100"
+    When I serialize the goal to FHIR
+    Then the FHIR subject reference should include "100"
+
+  Scenario: FHIR Goal includes lifecycle status
+    Given a goal with description "A1C below 7%" for patient "100"
+    When I serialize the goal to FHIR
+    Then the FHIR goal lifecycle status should be "active"
+
+  Scenario: FHIR Goal includes description
+    Given a goal with description "A1C below 7%" for patient "100"
+    When I serialize the goal to FHIR
+    Then the FHIR goal description should include "A1C below 7%"

--- a/features/fhir/immunization.feature
+++ b/features/fhir/immunization.feature
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+Feature: Immunization FHIR resource
+  As a healthcare system
+  I need to represent patient immunizations
+  So that vaccination data is interoperable
+
+  Scenario: Create a valid immunization
+    Given an immunization with vaccine "Influenza" for patient "100"
+    Then the immunization should be valid
+
+  Scenario: Immunization requires patient
+    Given an immunization without a patient
+    Then the immunization should be invalid
+
+  Scenario: Immunization requires vaccine display
+    Given an immunization without a vaccine for patient "100"
+    Then the immunization should be invalid
+
+  Scenario: Completed immunization
+    Given a completed immunization with vaccine "Influenza" for patient "100"
+    Then the immunization should be completed
+
+  Scenario: Immunization with CVX code
+    Given an immunization with vaccine "Influenza" and CVX "158" for patient "100"
+    Then the immunization should be valid
+
+  Scenario: Immunization with VFC eligibility
+    Given an immunization with vaccine "Influenza" and VFC "V02" for patient "100"
+    Then the immunization should be valid
+
+  Scenario: FHIR Immunization includes resourceType
+    Given an immunization with vaccine "Influenza" for patient "100"
+    When I serialize the immunization to FHIR
+    Then the FHIR resourceType should be "Immunization"
+
+  Scenario: FHIR Immunization includes patient reference
+    Given an immunization with vaccine "Influenza" for patient "100"
+    When I serialize the immunization to FHIR
+    Then the FHIR immunization patient reference should include "100"
+
+  Scenario: FHIR Immunization includes vaccine code
+    Given an immunization with vaccine "Influenza" and CVX "158" for patient "100"
+    When I serialize the immunization to FHIR
+    Then the FHIR vaccine code should include "158"

--- a/features/fhir/location.feature
+++ b/features/fhir/location.feature
@@ -1,0 +1,31 @@
+Feature: Location FHIR resource
+  As a healthcare system
+  I need to represent facility locations
+  So that clinic and department data is interoperable
+
+  Scenario: Create a valid location
+    Given a location with name "Primary Care Clinic"
+    Then the location should be valid
+
+  Scenario: Location requires name
+    Given a location without a name
+    Then the location should be invalid
+
+  Scenario: Location includes abbreviation
+    Given a location with name "Primary Care Clinic" and abbreviation "PCC"
+    Then the abbreviation should be "PCC"
+
+  Scenario: FHIR Location includes resourceType
+    Given a location with name "Primary Care Clinic"
+    When I serialize the location to FHIR
+    Then the FHIR resourceType should be "Location"
+
+  Scenario: FHIR Location includes name
+    Given a location with name "Primary Care Clinic"
+    When I serialize the location to FHIR
+    Then the FHIR location name should be "Primary Care Clinic"
+
+  Scenario: FHIR Location includes status
+    Given a location with name "PCC" and status "active"
+    When I serialize the location to FHIR
+    Then the FHIR location status should be "active"

--- a/features/fhir/medication_request.feature
+++ b/features/fhir/medication_request.feature
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+Feature: MedicationRequest FHIR resource
+  As a healthcare system
+  I need to represent medication orders
+  So that prescription data is interoperable
+
+  Scenario: Create a valid medication request
+    Given a medication request for "Metformin 500mg" for patient "100"
+    Then the medication request should be valid
+
+  Scenario: Medication request requires patient
+    Given a medication request without a patient
+    Then the medication request should be invalid
+
+  Scenario: Medication request requires medication display
+    Given a medication request without a medication for patient "100"
+    Then the medication request should be invalid
+
+  Scenario: Active medication request
+    Given a medication request for "Metformin 500mg" with status "active" for patient "100"
+    Then the medication request should be active
+
+  Scenario: Medication matching key with RxNorm code
+    Given a medication request for "Metformin 500mg" with RxNorm "860975" for patient "100"
+    Then the medication matching key should be "rxnorm:860975"
+
+  Scenario: Signed content hash
+    Given a medication request for "Metformin 500mg" for patient "100"
+    Then the medication request should have a signed content hash
+
+  Scenario: FHIR MedicationRequest includes resourceType
+    Given a medication request for "Metformin 500mg" for patient "100"
+    When I serialize the medication request to FHIR
+    Then the FHIR resourceType should be "MedicationRequest"
+
+  Scenario: FHIR MedicationRequest includes subject
+    Given a medication request for "Metformin 500mg" for patient "100"
+    When I serialize the medication request to FHIR
+    Then the FHIR subject reference should include "100"
+
+  Scenario: FHIR MedicationRequest includes medication
+    Given a medication request for "Metformin 500mg" with RxNorm "860975" for patient "100"
+    When I serialize the medication request to FHIR
+    Then the FHIR medication code should include "860975"

--- a/features/fhir/observation.feature
+++ b/features/fhir/observation.feature
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+Feature: Observation FHIR resource
+  As a healthcare system
+  I need to represent clinical observations
+  So that vital signs and lab data is interoperable
+
+  Scenario: Vital sign observation
+    Given a vital sign observation with code "8867-4" and value "72" for patient "100"
+    Then the observation should be a vital sign
+
+  Scenario: Laboratory observation
+    Given a laboratory observation with code "2339-0" and value "95" for patient "100"
+    Then the observation should be a laboratory result
+
+  Scenario: SDOH observation
+    Given an SDOH observation with code "71802-3" and value "Homeless" for patient "100"
+    Then the observation should be an SDOH observation
+
+  Scenario: Blood pressure observation
+    Given a blood pressure observation with value "120/80" for patient "100"
+    When I serialize the observation to FHIR
+    Then the FHIR observation should have systolic and diastolic components
+
+  Scenario: FHIR Observation includes resourceType
+    Given a vital sign observation with code "8867-4" and value "72" for patient "100"
+    When I serialize the observation to FHIR
+    Then the FHIR resourceType should be "Observation"
+
+  Scenario: FHIR Observation includes subject
+    Given a vital sign observation with code "8867-4" and value "72" for patient "100"
+    When I serialize the observation to FHIR
+    Then the FHIR subject reference should include "100"
+
+  Scenario: FHIR Observation includes category
+    Given a vital sign observation with code "8867-4" and value "72" for patient "100"
+    When I serialize the observation to FHIR
+    Then the FHIR observation category should be "vital-signs"
+
+  Scenario: Build observations from vital hashes
+    Given vital sign hashes for patient "100" with type "P" value "72" and type "T" value "98.6"
+    Then there should be 2 observations
+    And the first observation code should be "8867-4"

--- a/features/fhir/organization.feature
+++ b/features/fhir/organization.feature
@@ -1,0 +1,31 @@
+Feature: Organization FHIR resource
+  As a healthcare system
+  I need to represent healthcare organizations
+  So that facility and provider organization data is interoperable
+
+  Scenario: Create a valid organization
+    Given an organization with name "Alaska Native Medical Center"
+    Then the organization should be valid
+
+  Scenario: Organization requires name
+    Given an organization without a name
+    Then the organization should be invalid
+
+  Scenario: Organization includes station number
+    Given an organization with name "ANMC" and station number "463"
+    Then the station number should be "463"
+
+  Scenario: FHIR Organization includes resourceType
+    Given an organization with name "ANMC"
+    When I serialize the organization to FHIR
+    Then the FHIR resourceType should be "Organization"
+
+  Scenario: FHIR Organization includes name
+    Given an organization with name "Alaska Native Medical Center"
+    When I serialize the organization to FHIR
+    Then the FHIR organization name should be "Alaska Native Medical Center"
+
+  Scenario: FHIR Organization includes identifiers
+    Given an organization with name "ANMC" and station number "463"
+    When I serialize the organization to FHIR
+    Then the FHIR identifiers should include station number "463"

--- a/features/fhir/practitioner_role.feature
+++ b/features/fhir/practitioner_role.feature
@@ -1,0 +1,31 @@
+Feature: PractitionerRole FHIR resource
+  As a healthcare system
+  I need to represent practitioner roles and specialties
+  So that provider capabilities are interoperable
+
+  Scenario: Create a valid practitioner role
+    Given a practitioner role with role "doctor" for practitioner "101"
+    Then the practitioner role should be valid
+
+  Scenario: Practitioner role includes specialty
+    Given a practitioner role with specialty "Cardiology" for practitioner "101"
+    Then the specialty should be "Cardiology"
+
+  Scenario: Active practitioner role
+    Given an active practitioner role for practitioner "101"
+    Then the practitioner role should be active
+
+  Scenario: FHIR PractitionerRole includes resourceType
+    Given a practitioner role with role "PCP" for practitioner "101"
+    When I serialize the practitioner role to FHIR
+    Then the FHIR resourceType should be "PractitionerRole"
+
+  Scenario: FHIR PractitionerRole includes practitioner reference
+    Given a practitioner role with role "PCP" for practitioner "101"
+    When I serialize the practitioner role to FHIR
+    Then the FHIR practitioner reference should include "101"
+
+  Scenario: FHIR PractitionerRole includes specialty
+    Given a practitioner role with specialty "Cardiology" for practitioner "101"
+    When I serialize the practitioner role to FHIR
+    Then the FHIR specialty should include "Cardiology"

--- a/features/fhir/procedure.feature
+++ b/features/fhir/procedure.feature
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+Feature: Procedure FHIR resource
+  As a healthcare system
+  I need to represent clinical procedures
+  So that procedure data is interoperable
+
+  Scenario: Create a valid procedure
+    Given a procedure with display "Appendectomy" for patient "100"
+    Then the procedure should be valid
+
+  Scenario: Procedure requires patient
+    Given a procedure without a patient
+    Then the procedure should be invalid
+
+  Scenario: Procedure requires display
+    Given a procedure without a display for patient "100"
+    Then the procedure should be invalid
+
+  Scenario: Procedure with CPT code
+    Given a procedure with display "Appendectomy" and code "44950" system "cpt" for patient "100"
+    Then the procedure should be valid
+
+  Scenario: Completed procedure
+    Given a completed procedure with display "Appendectomy" for patient "100"
+    Then the procedure should be completed
+
+  Scenario: FHIR Procedure includes resourceType
+    Given a procedure with display "Appendectomy" for patient "100"
+    When I serialize the procedure to FHIR
+    Then the FHIR resourceType should be "Procedure"
+
+  Scenario: FHIR Procedure includes subject
+    Given a procedure with display "Appendectomy" for patient "100"
+    When I serialize the procedure to FHIR
+    Then the FHIR subject reference should include "100"
+
+  Scenario: FHIR Procedure includes code
+    Given a procedure with display "Appendectomy" and code "44950" system "cpt" for patient "100"
+    When I serialize the procedure to FHIR
+    Then the FHIR procedure code should include "44950"
+
+  Scenario: FHIR Procedure includes performer
+    Given a procedure with display "Appendectomy" and performer "301" for patient "100"
+    When I serialize the procedure to FHIR
+    Then the FHIR procedure performer should include "301"

--- a/features/fhir/related_person.feature
+++ b/features/fhir/related_person.feature
@@ -1,0 +1,60 @@
+Feature: RelatedPerson FHIR resource
+  As a healthcare system
+  I need to represent patient contacts and advocates
+  So that proxy access and emergency contacts are interoperable
+
+  Scenario: Create a valid related person
+    Given a related person with relationship "parent" for patient "1"
+    Then the related person should be valid
+
+  Scenario: Related person requires patient
+    Given a related person without a patient
+    Then the related person should be invalid
+
+  Scenario: Related person requires name
+    Given a related person without a name for patient "1"
+    Then the related person should be invalid
+
+  Scenario: Parent relationship
+    Given a related person with relationship "parent" for patient "1"
+    Then the relationship display should include "Parent"
+
+  Scenario: Spouse relationship
+    Given a related person with relationship "spouse" for patient "1"
+    Then the relationship display should include "Spouse"
+
+  Scenario: Active related person
+    Given an active related person for patient "1"
+    Then the related person should be active
+
+  Scenario: Inactive related person
+    Given an inactive related person for patient "1"
+    Then the related person should not be active
+
+  Scenario: Related person within period
+    Given a related person with period from "2025-01-01" to "2027-12-31" for patient "1"
+    Then the related person should be within period
+
+  Scenario: Related person outside period
+    Given a related person with period from "2020-01-01" to "2020-12-31" for patient "1"
+    Then the related person should not be within period
+
+  Scenario: FHIR RelatedPerson includes resourceType
+    Given a related person with relationship "parent" for patient "1"
+    When I serialize the related person to FHIR
+    Then the FHIR resourceType should be "RelatedPerson"
+
+  Scenario: FHIR RelatedPerson includes patient reference
+    Given a related person with relationship "parent" for patient "123"
+    When I serialize the related person to FHIR
+    Then the FHIR patient reference should include "123"
+
+  Scenario: FHIR RelatedPerson includes relationship
+    Given a related person with relationship "parent" for patient "1"
+    When I serialize the related person to FHIR
+    Then the FHIR relationship should be present
+
+  Scenario: FHIR RelatedPerson includes name
+    Given a related person named "Jane Doe" with relationship "parent" for patient "1"
+    When I serialize the related person to FHIR
+    Then the FHIR name should include "Jane"

--- a/features/fhir/service_request.feature
+++ b/features/fhir/service_request.feature
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+Feature: ServiceRequest FHIR resource
+  As a healthcare system
+  I need to represent healthcare referrals
+  So that referral data is interoperable
+
+  Scenario: Create a valid service request
+    Given a service request for "Cardiology Consult" from provider "201" for patient "100"
+    Then the service request should be valid
+
+  Scenario: Service request requires patient
+    Given a service request without a patient
+    Then the service request should be invalid
+
+  Scenario: Service request requires service
+    Given a service request without a service from provider "201" for patient "100"
+    Then the service request should be invalid
+
+  Scenario: Active service request
+    Given a service request for "Cardiology Consult" with status "active" from provider "201" for patient "100"
+    Then the service request should be active
+
+  Scenario: Completed service request
+    Given a service request for "Cardiology Consult" with status "completed" from provider "201" for patient "100"
+    Then the service request should be completed
+
+  Scenario: Urgent service request
+    Given a service request for "Cardiology Consult" with urgency "URGENT" from provider "201" for patient "100"
+    Then the service request should be urgent
+
+  Scenario: Overdue service request
+    Given a service request for "Cardiology Consult" with appointment "2025-01-01" from provider "201" for patient "100"
+    Then the service request should be overdue
+
+  Scenario: Priority levels
+    Given a service request for "Cardiology Consult" with urgency "EMERGENT" from provider "201" for patient "100"
+    Then the service request priority should be 1
+
+  Scenario: FHIR ServiceRequest includes resourceType
+    Given a service request for "Cardiology Consult" from provider "201" for patient "100"
+    When I serialize the service request to FHIR
+    Then the FHIR resourceType should be "ServiceRequest"
+
+  Scenario: FHIR ServiceRequest includes subject
+    Given a service request for "Cardiology Consult" from provider "201" for patient "100"
+    When I serialize the service request to FHIR
+    Then the FHIR subject reference should include "100"

--- a/features/fhir_bundle_import.feature
+++ b/features/fhir_bundle_import.feature
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+Feature: FHIR Bundle import for clinical reconciliation
+  As a clinician
+  I need to import clinical data from FHIR Bundles
+  So that I can reconcile external data with patient records
+
+  Scenario: Import valid FHIR Bundle with allergies
+    Given a FHIR Bundle JSON with an AllergyIntolerance for patient "100"
+    When I import the bundle for patient "100" as clinician "201"
+    Then the bundle import should succeed
+
+  Scenario: Import valid FHIR Bundle with conditions
+    Given a FHIR Bundle JSON with a Condition for patient "100"
+    When I import the bundle for patient "100" as clinician "201"
+    Then the bundle import should succeed
+
+  Scenario: Import valid FHIR Bundle with medications
+    Given a FHIR Bundle JSON with a MedicationRequest for patient "100"
+    When I import the bundle for patient "100" as clinician "201"
+    Then the bundle import should succeed
+
+  Scenario: Reject invalid JSON
+    Given invalid JSON input
+    When I import the bundle for patient "100" as clinician "201"
+    Then the bundle import should fail
+    And the bundle import error should include "Invalid JSON"
+
+  Scenario: Reject non-Bundle resource
+    Given a FHIR JSON that is not a Bundle
+    When I import the bundle for patient "100" as clinician "201"
+    Then the bundle import should fail
+    And the bundle import error should include "Expected Bundle"
+
+  Scenario: Reject Bundle with wrong patient
+    Given a FHIR Bundle JSON with an AllergyIntolerance for patient "999"
+    When I import the bundle for patient "100" as clinician "201"
+    Then the bundle import should fail
+    And the bundle import error should include "different patient"
+
+  Scenario: Import Bundle with mixed resource types
+    Given a FHIR Bundle JSON with allergies, conditions, and medications for patient "100"
+    When I import the bundle for patient "100" as clinician "201"
+    Then the bundle import should succeed

--- a/features/smart_launch_context.feature
+++ b/features/smart_launch_context.feature
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+Feature: SMART launch context
+  As a SMART-on-FHIR application
+  I need launch context tokens to bind patient and encounter
+  So that the OAuth flow can resolve clinical context
+
+  Scenario: Mint a launch context with patient
+    Given an OAuth application "app-001"
+    When I mint a launch context for patient "100"
+    Then the launch context should have a token
+    And the launch context token should start with "lc_"
+    And the launch context should expire in the future
+
+  Scenario: Mint a launch context with patient and encounter
+    Given an OAuth application "app-001"
+    When I mint a launch context for patient "100" and encounter "enc-200"
+    Then the SMART context should include patient "100"
+    And the SMART context should include encounter "enc-200"
+
+  Scenario: Mint a launch context with facility
+    Given an OAuth application "app-001"
+    When I mint a launch context for patient "100" with facility "463"
+    Then the launch context facility should be "463"
+
+  Scenario: SMART context includes patient only when present
+    Given an OAuth application "app-001"
+    When I mint a launch context without a patient
+    Then the SMART context should not include patient
+
+  Scenario: SMART context includes encounter only when present
+    Given an OAuth application "app-001"
+    When I mint a launch context for patient "100"
+    Then the SMART context should not include encounter
+
+  Scenario: Launch context token is unique
+    Given an OAuth application "app-001"
+    When I mint two launch contexts for patient "100"
+    Then the tokens should be different

--- a/features/step_definitions/allergy_intolerance_steps.rb
+++ b/features/step_definitions/allergy_intolerance_steps.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# AllergyIntolerance step definitions
+
+Given("an allergy to {string} for patient {string}") do |allergen, dfn|
+  @allergy = Lakeraven::EHR::AllergyIntolerance.new(
+    patient_dfn: dfn, allergen: allergen, clinical_status: "active"
+  )
+end
+
+Given("a medication allergy to {string} for patient {string}") do |allergen, dfn|
+  @allergy = Lakeraven::EHR::AllergyIntolerance.new(
+    patient_dfn: dfn, allergen: allergen, clinical_status: "active", category: "medication"
+  )
+end
+
+Given("a food allergy to {string} for patient {string}") do |allergen, dfn|
+  @allergy = Lakeraven::EHR::AllergyIntolerance.new(
+    patient_dfn: dfn, allergen: allergen, clinical_status: "active", category: "food"
+  )
+end
+
+Given("an allergy to {string} with code {string} for patient {string}") do |allergen, code, dfn|
+  @allergy = Lakeraven::EHR::AllergyIntolerance.new(
+    patient_dfn: dfn, allergen: allergen, allergen_code: code, clinical_status: "active"
+  )
+end
+
+When("I serialize the allergy to FHIR") do
+  @fhir = @allergy.to_fhir
+end
+
+Then("the allergy should be active") do
+  assert @allergy.active?, "Expected active"
+end
+
+Then("the allergy should be a medication allergy") do
+  assert @allergy.medication?, "Expected medication allergy"
+end
+
+Then("the allergy should be a food allergy") do
+  assert @allergy.food?, "Expected food allergy"
+end
+
+Then("the allergy matching key should be {string}") do |expected|
+  assert_equal expected, @allergy.matching_key
+end
+
+Then("the FHIR allergy patient reference should include {string}") do |dfn|
+  patient = @fhir[:patient]
+  refute_nil patient
+  assert_includes patient[:reference], dfn
+end
+
+Then("the FHIR allergy code text should be {string}") do |expected|
+  assert_equal expected, @fhir[:code][:text]
+end

--- a/features/step_definitions/audit_event_steps.rb
+++ b/features/step_definitions/audit_event_steps.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+# AuditEvent step definitions (model-level, no database)
+
+def build_audit_event(attrs = {})
+  defaults = {
+    event_type: "rest", action: "R", outcome: "0",
+    entity_type: "Patient", entity_identifier: "100"
+  }
+  # Build without saving — use allocate + assign to bypass AR validations requiring DB
+  event = Lakeraven::EHR::AuditEvent.new(defaults.merge(attrs))
+  event
+end
+
+Given("an audit event with action {string} for entity {string} {string}") do |action, entity_type, entity_id|
+  @audit_event = build_audit_event(action: action, entity_type: entity_type, entity_identifier: entity_id)
+end
+
+Given("an audit event with outcome {string} for entity {string} {string}") do |outcome, entity_type, entity_id|
+  @audit_event = build_audit_event(outcome: outcome, entity_type: entity_type, entity_identifier: entity_id)
+end
+
+Given("a rest audit event with action {string} for entity {string} {string}") do |action, entity_type, entity_id|
+  @audit_event = build_audit_event(event_type: "rest", action: action, entity_type: entity_type, entity_identifier: entity_id)
+end
+
+Given("a security audit event with action {string} for entity {string} {string}") do |action, entity_type, entity_id|
+  @audit_event = build_audit_event(event_type: "security", action: action, entity_type: entity_type, entity_identifier: entity_id)
+end
+
+Given("an export audit event with action {string} for entity {string} {string}") do |action, entity_type, entity_id|
+  @audit_event = build_audit_event(event_type: "export", action: action, entity_type: entity_type, entity_identifier: entity_id)
+end
+
+Given("an import audit event with action {string} for entity {string} {string}") do |action, entity_type, entity_id|
+  @audit_event = build_audit_event(event_type: "import", action: action, entity_type: entity_type, entity_identifier: entity_id)
+end
+
+Given("a query audit event with action {string} for entity {string} {string}") do |action, entity_type, entity_id|
+  @audit_event = build_audit_event(event_type: "query", action: action, entity_type: entity_type, entity_identifier: entity_id)
+end
+
+Given("a user audit event with action {string} for entity {string} {string}") do |action, entity_type, entity_id|
+  @audit_event = build_audit_event(event_type: "user", action: action, entity_type: entity_type, entity_identifier: entity_id)
+end
+
+Given("an application audit event with action {string} for entity {string} {string}") do |action, entity_type, entity_id|
+  @audit_event = build_audit_event(event_type: "application", action: action, entity_type: entity_type, entity_identifier: entity_id)
+end
+
+Given("an audit event with action {string} and entity type {string} but no identifier") do |action, entity_type|
+  @audit_event = build_audit_event(action: action, entity_type: entity_type, entity_identifier: nil)
+end
+
+Given("an audit event with action {string} for entity {string} {string} by agent {string}") do |action, entity_type, entity_id, agent_id|
+  @audit_event = build_audit_event(
+    action: action, entity_type: entity_type, entity_identifier: entity_id,
+    agent_who_identifier: agent_id, agent_who_type: "Practitioner", agent_name: "Dr. Test"
+  )
+end
+
+Given("an audit event with outcome {string} and description {string} for entity {string} {string}") do |outcome, desc, entity_type, entity_id|
+  @audit_event = build_audit_event(
+    outcome: outcome, outcome_desc: desc, entity_type: entity_type, entity_identifier: entity_id
+  )
+end
+
+Given("an audit event with action {string} for entity {string} {string} by agent {string} from {string}") do |action, entity_type, entity_id, agent_id, ip|
+  @audit_event = build_audit_event(
+    action: action, entity_type: entity_type, entity_identifier: entity_id,
+    agent_who_identifier: agent_id, agent_who_type: "Practitioner",
+    agent_name: "Dr. Test", agent_network_address: ip
+  )
+end
+
+When("I serialize the audit event to FHIR") do
+  @fhir = @audit_event.to_fhir
+end
+
+# Action helpers
+Then("the audit event should be a read action") do
+  assert @audit_event.read_action?
+end
+
+Then("the audit event should be a create action") do
+  assert @audit_event.create_action?
+end
+
+Then("the audit event should be an update action") do
+  assert @audit_event.update_action?
+end
+
+Then("the audit event should be a delete action") do
+  assert @audit_event.delete_action?
+end
+
+Then("the audit event should be an execute action") do
+  assert @audit_event.execute_action?
+end
+
+Then("the audit event action display should be {string}") do |expected|
+  assert_equal expected, @audit_event.action_display
+end
+
+# Outcome helpers
+Then("the audit event should be successful") do
+  assert @audit_event.success?
+end
+
+Then("the audit event should be a minor failure") do
+  assert @audit_event.minor_failure?
+end
+
+Then("the audit event should be a serious failure") do
+  assert @audit_event.serious_failure?
+end
+
+Then("the audit event should be a major failure") do
+  assert @audit_event.major_failure?
+end
+
+Then("the audit event outcome display should be {string}") do |expected|
+  assert_equal expected, @audit_event.outcome_display
+end
+
+# Event type helpers
+Then("the audit event type display should be {string}") do |expected|
+  assert_equal expected, @audit_event.event_type_display
+end
+
+# Entity helpers
+Then("the audit event should have an entity") do
+  assert @audit_event.has_entity?
+end
+
+Then("the audit event should not have an entity") do
+  refute @audit_event.has_entity?
+end
+
+# FHIR assertions
+Then("the FHIR audit event action should be {string}") do |expected|
+  assert_equal expected, @fhir[:action]
+end
+
+Then("the FHIR audit event outcome should be {string}") do |expected|
+  assert_equal expected, @fhir[:outcome]
+end
+
+Then("the FHIR audit event entity should reference {string}") do |expected|
+  entities = @fhir[:entity]
+  refute_nil entities
+  assert entities.any? { |e| e[:what][:reference] == expected }
+end
+
+Then("the FHIR audit event agent should include {string}") do |agent_id|
+  agents = @fhir[:agent]
+  refute_nil agents
+  assert agents.any? { |a| a[:who][:reference]&.include?(agent_id) }
+end
+
+Then("the FHIR audit event type code should be {string}") do |expected|
+  assert_equal expected, @fhir[:type][:code]
+end
+
+Then("the FHIR audit event outcome description should be {string}") do |expected|
+  assert_equal expected, @fhir[:outcomeDesc]
+end
+
+Then("the FHIR audit event agent network should be {string}") do |expected|
+  agents = @fhir[:agent]
+  refute_nil agents
+  assert agents.any? { |a| a.dig(:network, :address) == expected }
+end
+
+Then("the FHIR audit event agents should be empty") do
+  agents = @fhir[:agent]
+  assert agents.nil? || agents.empty?
+end
+
+Then("the FHIR audit event entities should be empty") do
+  entities = @fhir[:entity]
+  assert entities.nil? || entities.empty?
+end

--- a/features/step_definitions/care_plan_steps.rb
+++ b/features/step_definitions/care_plan_steps.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# CarePlan step definitions
+
+Given("a care plan with title {string} for patient {string}") do |title, dfn|
+  @care_plan = Lakeraven::EHR::CarePlan.new(patient_dfn: dfn, title: title)
+end
+
+Given("a care plan without a patient") do
+  @care_plan = Lakeraven::EHR::CarePlan.new(title: "Test Plan")
+end
+
+Given("a care plan with title {string} and category {string} for patient {string}") do |title, cat, dfn|
+  @care_plan = Lakeraven::EHR::CarePlan.new(patient_dfn: dfn, title: title, category: cat)
+end
+
+When("I serialize the care plan to FHIR") do
+  @fhir = @care_plan.to_fhir
+end
+
+Then("the care plan should be valid") do
+  assert @care_plan.valid?, "Expected valid: #{@care_plan.errors.full_messages}"
+end
+
+Then("the care plan should be invalid") do
+  refute @care_plan.valid?
+end
+
+Then("the care plan should be active") do
+  assert @care_plan.active?, "Expected active"
+end
+
+Then("the FHIR care plan status should be {string}") do |expected|
+  assert_equal expected, @fhir[:status]
+end
+
+Then("the FHIR care plan intent should be {string}") do |expected|
+  assert_equal expected, @fhir[:intent]
+end
+
+Then("the FHIR care plan title should be {string}") do |expected|
+  assert_equal expected, @fhir[:title]
+end

--- a/features/step_definitions/care_team_steps.rb
+++ b/features/step_definitions/care_team_steps.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# CareTeam step definitions
+
+Given("a care team with name {string} for patient {string}") do |name, dfn|
+  @care_team = Lakeraven::EHR::CareTeam.new(patient_dfn: dfn, name: name, status: "active")
+end
+
+Given("a care team without a patient") do
+  @care_team = Lakeraven::EHR::CareTeam.new(name: "Test Team", status: "active")
+end
+
+Given("the care team has a participant with duz {string} and role {string}") do |duz, role|
+  @care_team.participants << { "duz" => duz, "name" => "Provider #{duz}", "role" => role }
+end
+
+When("I serialize the care team to FHIR") do
+  @fhir = @care_team.to_fhir
+end
+
+Then("the care team should be valid") do
+  assert @care_team.valid?, "Expected valid: #{@care_team.errors.full_messages}"
+end
+
+Then("the care team should be invalid") do
+  refute @care_team.valid?
+end
+
+Then("the FHIR care team subject reference should include {string}") do |dfn|
+  subject = @fhir[:subject]
+  refute_nil subject
+  assert_includes subject[:reference], dfn
+end
+
+Then("the FHIR care team should have participants") do
+  participants = @fhir[:participant]
+  refute_nil participants
+  refute participants.empty?, "Expected at least one participant"
+end
+
+Then("the FHIR care team name should be {string}") do |expected|
+  assert_equal expected, @fhir[:name]
+end

--- a/features/step_definitions/cds_rules_steps.rb
+++ b/features/step_definitions/cds_rules_steps.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+# CDS rules step definitions
+
+CdsService = Lakeraven::EHR::ClinicalDecisionSupportService
+
+# --- Rule configuration ---
+
+When("I list all CDS rules") do
+  CdsService.reload_rules!
+  CdsService.rule_overrides.clear
+  @rules = CdsService.all_rules
+end
+
+When("I look up rule {string}") do |rule_id|
+  CdsService.reload_rules!
+  @rule = CdsService.find_rule(rule_id)
+end
+
+When("I check if rule {string} is enabled") do |rule_id|
+  CdsService.reload_rules!
+  CdsService.rule_overrides.clear
+  @rule_enabled = CdsService.rule_enabled?(rule_id)
+end
+
+When("provider {string} disables rule {string}") do |provider_duz, rule_id|
+  CdsService.reload_rules!
+  @override_result = CdsService.update_rule_enabled(rule_id, false, provider_duz: provider_duz)
+end
+
+When("provider {string} enables rule {string}") do |provider_duz, rule_id|
+  @override_result = CdsService.update_rule_enabled(rule_id, true, provider_duz: provider_duz)
+end
+
+Given("provider {string} has disabled rule {string}") do |provider_duz, rule_id|
+  CdsService.reload_rules!
+  CdsService.update_rule_enabled(rule_id, false, provider_duz: provider_duz)
+end
+
+Then("there should be at least {int} rule") do |count|
+  assert @rules.length >= count, "Expected at least #{count} rules, got #{@rules.length}"
+end
+
+Then("each rule should have an id and message") do
+  @rules.each do |rule|
+    refute_nil rule[:id], "Rule missing id"
+    refute_nil rule[:message], "Rule #{rule[:id]} missing message"
+  end
+end
+
+Then("the rule should exist") do
+  refute_nil @rule, "Expected rule to exist"
+end
+
+Then("the rule message should mention {string}") do |text|
+  assert_includes @rule[:message], text
+end
+
+Then("the rule should be enabled") do
+  assert @rule_enabled || CdsService.rule_enabled?(@rule&.dig(:id) || "diabetes_monitoring"),
+    "Expected rule to be enabled"
+end
+
+Then("rule {string} should be disabled") do |rule_id|
+  refute CdsService.rule_enabled?(rule_id), "Expected rule #{rule_id} to be disabled"
+end
+
+Then("rule {string} should be enabled") do |rule_id|
+  assert CdsService.rule_enabled?(rule_id), "Expected rule #{rule_id} to be enabled"
+end
+
+Then("the override result should include provider {string}") do |provider_duz|
+  assert_equal provider_duz, @override_result[:updated_by]
+end
+
+Then("the override result should include a timestamp") do
+  refute_nil @override_result[:updated_at]
+end
+
+# --- CdsResult ---
+
+Given("a CDS result with no alerts") do
+  @cds_result = CdsService::CdsResult.new(patient_dfn: "100", alerts: [])
+end
+
+Given("a CDS result with alerts:") do |table|
+  alerts = table.hashes.map do |row|
+    { id: "cds-#{SecureRandom.hex(4)}", category: row["category"], severity: row["severity"], message: row["message"] }
+  end
+  @cds_result = CdsService::CdsResult.new(patient_dfn: "100", alerts: alerts)
+end
+
+When("I filter alerts by category {string}") do |category|
+  @filtered_alerts = @cds_result.alerts_by_category(category)
+end
+
+When("I filter critical alerts") do
+  @critical_alerts = @cds_result.critical_alerts
+end
+
+When("I convert the result to a hash") do
+  @result_hash = @cds_result.to_h
+end
+
+Then("the result should not have alerts") do
+  refute @cds_result.has_alerts?
+end
+
+Then("the result should have alerts") do
+  assert @cds_result.has_alerts?
+end
+
+Then("the result should have {int} alerts") do |count|
+  assert_equal count, @cds_result.alerts.length
+end
+
+Then("the result summary should be {string}") do |expected|
+  assert_equal expected, @cds_result.summary
+end
+
+Then("the result summary should include {string}") do |text|
+  assert_includes @cds_result.summary, text
+end
+
+Then("there should be {int} filtered alerts") do |count|
+  assert_equal count, @filtered_alerts.length
+end
+
+Then("there should be {int} critical alert(s)") do |count|
+  assert_equal count, @critical_alerts.length
+end
+
+Then("the hash should include patient_dfn") do
+  refute_nil @result_hash[:patient_dfn]
+end
+
+Then("the hash should include alert_count {int}") do |count|
+  assert_equal count, @result_hash[:alert_count]
+end
+
+# --- Alert override ---
+
+Given("an alert with id {string} and category {string}") do |id, category|
+  @alert = { id: id, category: category, severity: "critical", message: "Test alert" }
+end
+
+When("provider {string} overrides the alert with reason {string}") do |provider_duz, reason|
+  @override = CdsService.override_alert(alert: @alert, provider_duz: provider_duz, reason: reason)
+end
+
+Then("the override should be recorded") do
+  assert @override[:overridden]
+end
+
+Then("the override should include the original alert") do
+  refute_nil @override[:original_alert]
+end
+
+Then("the override reason should be {string}") do |expected|
+  assert_equal expected, @override[:reason]
+end

--- a/features/step_definitions/clinical_alert_steps.rb
+++ b/features/step_definitions/clinical_alert_steps.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# Clinical alert service step definitions
+
+Given("clinical reminders:") do |table|
+  @reminders = table.hashes.map do |row|
+    { name: row["name"], status: row["status"], priority: row["priority"].presence }
+  end
+  @allergies ||= []
+end
+
+Given("patient allergies:") do |table|
+  @allergies = table.hashes.map do |row|
+    {
+      allergen: row["allergen"],
+      severity: row["severity"].presence,
+      criticality: row["criticality"].presence
+    }
+  end
+  @reminders ||= []
+end
+
+When("I aggregate background alerts") do
+  service = Lakeraven::EHR::ClinicalAlertService.new(
+    reminders: @reminders || [],
+    allergies: @allergies || []
+  )
+  @alerts = service.background_alerts
+  @severity_summary = service.severity_summary
+end
+
+When("I check drug interactions") do
+  service = Lakeraven::EHR::ClinicalAlertService.new(
+    reminders: @reminders || [],
+    allergies: @allergies || []
+  )
+  @drug_interactions = service.drug_interactions
+end
+
+Then("there should be {int} alert(s)") do |count|
+  assert_equal count, @alerts.length, "Expected #{count} alerts, got #{@alerts.length}"
+end
+
+Then("the first alert type should be {string}") do |expected|
+  assert_equal expected.to_sym, @alerts.first.type
+end
+
+Then("the first alert severity should be {string}") do |expected|
+  assert_equal expected.to_sym, @alerts.first.severity
+end
+
+Then("the drug interactions should be empty") do
+  assert @drug_interactions.empty?, "Expected empty drug interactions"
+end
+
+Then("the severity summary should show {int} high alert(s)") do |count|
+  assert_equal count, @severity_summary[:high]
+end
+
+Then("the severity summary should show {int} moderate alert(s)") do |count|
+  assert_equal count, @severity_summary[:moderate]
+end
+
+Then("the severity summary should show {int} low alert(s)") do |count|
+  assert_equal count, @severity_summary[:low]
+end

--- a/features/step_definitions/communication_steps.rb
+++ b/features/step_definitions/communication_steps.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+# Communication step definitions
+
+Given("a communication with content {string} from {string} {string} for patient {string}") do |content, sender_type, sender_id, dfn|
+  @communication = Lakeraven::EHR::Communication.new(
+    subject_patient_dfn: dfn, sender_type: sender_type, sender_id: sender_id,
+    payload_content: content, status: "completed"
+  )
+end
+
+Given("a communication without a patient") do
+  @communication = Lakeraven::EHR::Communication.new(
+    sender_id: "201", payload_content: "test"
+  )
+end
+
+Given("a communication without a sender for patient {string}") do |dfn|
+  @communication = Lakeraven::EHR::Communication.new(
+    subject_patient_dfn: dfn, payload_content: "test"
+  )
+end
+
+Given("a communication without content from {string} {string} for patient {string}") do |sender_type, sender_id, dfn|
+  @communication = Lakeraven::EHR::Communication.new(
+    subject_patient_dfn: dfn, sender_type: sender_type, sender_id: sender_id
+  )
+end
+
+Given("a communication with status {string} from {string} {string} for patient {string}") do |status, sender_type, sender_id, dfn|
+  @communication = Lakeraven::EHR::Communication.new(
+    subject_patient_dfn: dfn, sender_type: sender_type, sender_id: sender_id,
+    payload_content: "test", status: status
+  )
+end
+
+Given("a communication with priority {string} from {string} {string} for patient {string}") do |priority, sender_type, sender_id, dfn|
+  @communication = Lakeraven::EHR::Communication.new(
+    subject_patient_dfn: dfn, sender_type: sender_type, sender_id: sender_id,
+    payload_content: "test", status: "completed", priority: priority
+  )
+end
+
+Given("a communication with category {string} from {string} {string} for patient {string}") do |category, sender_type, sender_id, dfn|
+  @communication = Lakeraven::EHR::Communication.new(
+    subject_patient_dfn: dfn, sender_type: sender_type, sender_id: sender_id,
+    payload_content: "test", status: "completed", category: category
+  )
+end
+
+Given("a communication replying to message {string} from {string} {string} for patient {string}") do |parent_id, sender_type, sender_id, dfn|
+  @communication = Lakeraven::EHR::Communication.new(
+    subject_patient_dfn: dfn, sender_type: sender_type, sender_id: sender_id,
+    payload_content: "reply", status: "completed", parent_message_id: parent_id
+  )
+end
+
+When("I serialize the communication to FHIR") do
+  @fhir = @communication.to_fhir
+end
+
+Then("the communication should be valid") do
+  assert @communication.valid?, "Expected valid: #{@communication.errors.full_messages}"
+end
+
+Then("the communication should be invalid") do
+  refute @communication.valid?
+end
+
+Then("the communication should be completed") do
+  assert @communication.completed?, "Expected completed"
+end
+
+Then("the communication should be urgent") do
+  assert @communication.urgent?, "Expected urgent"
+end
+
+Then("the communication should be an alert") do
+  assert @communication.alert?, "Expected alert"
+end
+
+Then("the communication should be a root message") do
+  assert @communication.root_message?, "Expected root message"
+end
+
+Then("the communication should be a reply") do
+  assert @communication.reply?, "Expected reply"
+end
+
+Then("the FHIR communication payload should include {string}") do |text|
+  payload = @fhir[:payload]
+  refute_nil payload
+  assert payload.any? { |p| p[:contentString]&.include?(text) },
+    "Expected payload to include '#{text}'"
+end

--- a/features/step_definitions/condition_steps.rb
+++ b/features/step_definitions/condition_steps.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Condition step definitions
+
+Given("a condition with display {string} for patient {string}") do |display, dfn|
+  @condition = Lakeraven::EHR::Condition.new(patient_dfn: dfn, display: display)
+end
+
+Given("a condition without a patient") do
+  @condition = Lakeraven::EHR::Condition.new(display: "Test")
+end
+
+Given("a condition without a display for patient {string}") do |dfn|
+  @condition = Lakeraven::EHR::Condition.new(patient_dfn: dfn)
+end
+
+Given("a condition with display {string} and status {string} for patient {string}") do |display, status, dfn|
+  @condition = Lakeraven::EHR::Condition.new(
+    patient_dfn: dfn, display: display, clinical_status: status
+  )
+end
+
+Given("a condition with display {string} and category {string} for patient {string}") do |display, cat, dfn|
+  @condition = Lakeraven::EHR::Condition.new(
+    patient_dfn: dfn, display: display, category: cat
+  )
+end
+
+Given("a condition with display {string} and ICD code {string} for patient {string}") do |display, code, dfn|
+  @condition = Lakeraven::EHR::Condition.new(
+    patient_dfn: dfn, display: display, code: code, code_system: "icd10"
+  )
+end
+
+When("I serialize the condition to FHIR") do
+  @fhir = @condition.to_fhir
+end
+
+Then("the condition should be valid") do
+  assert @condition.valid?, "Expected valid: #{@condition.errors.full_messages}"
+end
+
+Then("the condition should be invalid") do
+  refute @condition.valid?
+end
+
+Then("the condition should be active") do
+  assert @condition.active?, "Expected active"
+end
+
+Then("the condition should be resolved") do
+  assert @condition.resolved?, "Expected resolved"
+end
+
+Then("the condition should be a problem list item") do
+  assert @condition.problem_list_item?, "Expected problem list item"
+end
+
+Then("the condition matching key should be {string}") do |expected|
+  assert_equal expected, @condition.matching_key
+end
+
+Then("the FHIR condition code should include {string}") do |code|
+  fhir_code = @fhir[:code]
+  refute_nil fhir_code
+  assert fhir_code[:coding]&.any? { |c| c[:code] == code },
+    "Expected code #{code} in coding"
+end

--- a/features/step_definitions/consent_steps.rb
+++ b/features/step_definitions/consent_steps.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+# Consent step definitions
+
+Given("a consent with scope {string} and status {string} for patient {string}") do |scope, status, dfn|
+  @consent = Lakeraven::EHR::Consent.new(
+    patient_dfn: dfn, scope: scope, status: status, provision_type: "permit"
+  )
+end
+
+Given("a consent with scope {string} and status {string} and provision {string} for patient {string}") do |scope, status, provision, dfn|
+  @consent = Lakeraven::EHR::Consent.new(
+    patient_dfn: dfn, scope: scope, status: status, provision_type: provision
+  )
+end
+
+Given("a consent without a patient") do
+  @consent = Lakeraven::EHR::Consent.new(scope: "patient-privacy", status: "active")
+end
+
+Given("a consent without a scope for patient {string}") do |dfn|
+  @consent = Lakeraven::EHR::Consent.new(patient_dfn: dfn, status: "active")
+end
+
+Given("a consent with provision type {string} for patient {string}") do |provision, dfn|
+  @consent = Lakeraven::EHR::Consent.new(
+    patient_dfn: dfn, scope: "patient-privacy", status: "active", provision_type: provision
+  )
+end
+
+Given("a consent with period from {string} to {string} for patient {string}") do |start_date, end_date, dfn|
+  @consent = Lakeraven::EHR::Consent.new(
+    patient_dfn: dfn, scope: "patient-privacy", status: "active",
+    period_start: Date.parse(start_date), period_end: Date.parse(end_date)
+  )
+end
+
+When("I serialize the consent to FHIR") do
+  @fhir = @consent.to_fhir
+end
+
+Then("the consent should be valid") do
+  assert @consent.valid?, "Expected consent to be valid but got errors: #{@consent.errors.full_messages}"
+end
+
+Then("the consent should be invalid") do
+  refute @consent.valid?, "Expected consent to be invalid"
+end
+
+Then("there should be a consent error on {string}") do |field|
+  assert @consent.errors[field.to_sym].any?, "Expected error on #{field}"
+end
+
+Then("the consent should be enforceable") do
+  assert @consent.enforceable?, "Expected consent to be enforceable"
+end
+
+Then("the consent should not be enforceable") do
+  refute @consent.enforceable?, "Expected consent to not be enforceable"
+end
+
+Then("the scope display should be {string}") do |expected|
+  assert_equal expected, @consent.scope_display
+end
+
+Then("the consent should permit access") do
+  assert @consent.permits?, "Expected consent to permit access"
+end
+
+Then("the consent should deny access") do
+  assert @consent.denies?, "Expected consent to deny access"
+end
+
+Then("the consent should be within period") do
+  assert @consent.within_period?, "Expected consent to be within period"
+end
+
+Then("the consent should not be within period") do
+  refute @consent.within_period?, "Expected consent to not be within period"
+end
+
+# "the FHIR resourceType should be" defined in encounter_model_steps.rb
+
+Then("the FHIR patient reference should be {string}") do |ref|
+  assert_equal ref, @fhir[:patient][:reference]
+end
+
+Then("the FHIR scope should include code {string}") do |code|
+  scope = @fhir[:scope]
+  refute_nil scope
+  assert scope[:coding].any? { |c| c[:code] == code }
+end
+
+Then("the FHIR category should be present") do
+  refute_nil @fhir[:category]
+  assert @fhir[:category].any?
+end
+
+Then("the FHIR provision type should be {string}") do |type|
+  refute_nil @fhir[:provision]
+  assert_equal type, @fhir[:provision][:type]
+end
+
+Then("the consent should authorize access") do
+  assert @consent.authorizes_access?, "Expected consent to authorize access"
+end
+
+Then("the consent should not authorize access") do
+  refute @consent.authorizes_access?, "Expected consent to not authorize access"
+end
+
+Then("the consent should allow {string}") do |permission|
+  assert @consent.allows?(permission), "Expected consent to allow #{permission}"
+end
+
+Then("the consent should not allow {string}") do |permission|
+  refute @consent.allows?(permission), "Expected consent to not allow #{permission}"
+end

--- a/features/step_definitions/coverage_steps.rb
+++ b/features/step_definitions/coverage_steps.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Coverage step definitions
+
+Given("a coverage with type {string} for patient {string}") do |type, dfn|
+  @coverage = Lakeraven::EHR::Coverage.new(patient_dfn: dfn, coverage_type: type, status: "active")
+end
+
+Given("a coverage with type {string} and status {string} for patient {string}") do |type, status, dfn|
+  @coverage = Lakeraven::EHR::Coverage.new(patient_dfn: dfn, coverage_type: type, status: status)
+end
+
+Given("a coverage without a patient") do
+  @coverage = Lakeraven::EHR::Coverage.new(coverage_type: "medicare_a", status: "active")
+end
+
+Given("a coverage without a type for patient {string}") do |dfn|
+  @coverage = Lakeraven::EHR::Coverage.new(patient_dfn: dfn, status: "active")
+end
+
+Given("a coverage with period from {string} to {string} for patient {string}") do |start_date, end_date, dfn|
+  @coverage = Lakeraven::EHR::Coverage.new(
+    patient_dfn: dfn, coverage_type: "medicare_a", status: "active",
+    start_date: Date.parse(start_date), end_date: Date.parse(end_date)
+  )
+end
+
+Given("a coverage with start date {string} and no end date for patient {string}") do |start_date, dfn|
+  @coverage = Lakeraven::EHR::Coverage.new(
+    patient_dfn: dfn, coverage_type: "medicare_a", status: "active",
+    start_date: Date.parse(start_date), end_date: nil
+  )
+end
+
+When("I serialize the coverage to FHIR") do
+  @fhir = @coverage.to_fhir
+end
+
+Then("the coverage should be valid") do
+  assert @coverage.valid?, "Expected coverage to be valid: #{@coverage.errors.full_messages}"
+end
+
+Then("the coverage should be invalid") do
+  refute @coverage.valid?
+end
+
+Then("there should be a coverage error on {string}") do |field|
+  assert @coverage.errors[field.to_sym].any?
+end
+
+Then("the coverage should be active") do
+  assert @coverage.active?, "Expected coverage to be active"
+end
+
+Then("the coverage should be expired") do
+  assert @coverage.expired?, "Expected coverage to be expired"
+end
+
+Then("the coverage type display should include {string}") do |text|
+  type = @coverage.coverage_type.to_s
+  payor = @coverage.payor_name.to_s
+  assert(type.downcase.include?(text.downcase) || payor.downcase.include?(text.downcase),
+    "Expected '#{text}' in coverage_type '#{type}' or payor_name '#{payor}'")
+end
+
+Then("the FHIR beneficiary reference should be {string}") do |ref|
+  assert_equal ref, @fhir[:beneficiary][:reference]
+end
+
+Then("the FHIR coverage status should be {string}") do |status|
+  assert_equal status, @fhir[:status]
+end
+
+# "the FHIR period start/end should be" defined in encounter_model_steps.rb

--- a/features/step_definitions/diagnostic_report_steps.rb
+++ b/features/step_definitions/diagnostic_report_steps.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# DiagnosticReport step definitions
+
+Given("a diagnostic report with code {string} for patient {string}") do |code_display, dfn|
+  @diagnostic_report = Lakeraven::EHR::DiagnosticReport.new(
+    patient_dfn: dfn, code_display: code_display
+  )
+end
+
+Given("a diagnostic report without a patient") do
+  @diagnostic_report = Lakeraven::EHR::DiagnosticReport.new(code_display: "CBC")
+end
+
+Given("a diagnostic report without a code for patient {string}") do |dfn|
+  @diagnostic_report = Lakeraven::EHR::DiagnosticReport.new(patient_dfn: dfn)
+end
+
+Given("a lab diagnostic report with code {string} and LOINC {string} for patient {string}") do |display, loinc, dfn|
+  @diagnostic_report = Lakeraven::EHR::DiagnosticReport.new(
+    patient_dfn: dfn, code_display: display, code: loinc, category: "LAB"
+  )
+end
+
+Given("a radiology diagnostic report with code {string} for patient {string}") do |display, dfn|
+  @diagnostic_report = Lakeraven::EHR::DiagnosticReport.new(
+    patient_dfn: dfn, code_display: display, category: "RAD"
+  )
+end
+
+When("I serialize the diagnostic report to FHIR") do
+  @fhir = @diagnostic_report.to_fhir
+end
+
+Then("the diagnostic report should be valid") do
+  assert @diagnostic_report.valid?, "Expected valid: #{@diagnostic_report.errors.full_messages}"
+end
+
+Then("the diagnostic report should be invalid") do
+  refute @diagnostic_report.valid?
+end
+
+Then("the FHIR diagnostic report status should be {string}") do |expected|
+  assert_equal expected, @fhir[:status]
+end
+
+Then("the FHIR diagnostic report category should be {string}") do |expected|
+  cats = @fhir[:category]
+  refute_nil cats
+  assert cats.any? { |c| c[:coding]&.any? { |cd| cd[:code] == expected } },
+    "Expected category #{expected}"
+end

--- a/features/step_definitions/document_reference_steps.rb
+++ b/features/step_definitions/document_reference_steps.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+# DocumentReference step definitions
+
+Given("a document reference with type {string} for patient {string}") do |type, dfn|
+  @doc_ref = Lakeraven::EHR::DocumentReference.new(
+    subject_patient_dfn: dfn, type_code: type, type_display: type.tr("-", " ").capitalize, status: "current"
+  )
+end
+
+Given("a document reference with type {string} and display {string} for patient {string}") do |type, display, dfn|
+  @doc_ref = Lakeraven::EHR::DocumentReference.new(
+    subject_patient_dfn: dfn, type_code: type, type_display: display, status: "current"
+  )
+end
+
+Given("a document reference without a patient") do
+  @doc_ref = Lakeraven::EHR::DocumentReference.new(type_code: "clinical-note", status: "current")
+end
+
+Given("a document reference without a type for patient {string}") do |dfn|
+  @doc_ref = Lakeraven::EHR::DocumentReference.new(subject_patient_dfn: dfn, status: "current")
+end
+
+Given("a document reference with status {string} for patient {string}") do |status, dfn|
+  @doc_ref = Lakeraven::EHR::DocumentReference.new(
+    subject_patient_dfn: dfn, type_code: "clinical-note", type_display: "Note", status: status
+  )
+end
+
+Given("a document reference with author {string} for patient {string}") do |author, dfn|
+  @doc_ref = Lakeraven::EHR::DocumentReference.new(
+    subject_patient_dfn: dfn, type_code: "clinical-note", type_display: "Note",
+    status: "current", author_ien: author
+  )
+end
+
+Given("a document reference dated {string} for patient {string}") do |date, dfn|
+  @doc_ref = Lakeraven::EHR::DocumentReference.new(
+    subject_patient_dfn: dfn, type_code: "clinical-note", type_display: "Note",
+    status: "current", date: Date.parse(date)
+  )
+end
+
+Given("a document reference with category {string} for patient {string}") do |category, dfn|
+  @doc_ref = Lakeraven::EHR::DocumentReference.new(
+    subject_patient_dfn: dfn, type_code: "clinical-note", type_display: "Note",
+    status: "current", category: category
+  )
+end
+
+When("I serialize the document reference to FHIR") do
+  @fhir = @doc_ref.to_fhir
+end
+
+Then("the document reference should be valid") do
+  assert @doc_ref.valid?, "Expected valid: #{@doc_ref.errors.full_messages}"
+end
+
+Then("the document reference should be invalid") do
+  refute @doc_ref.valid?
+end
+
+Then("the document status should be {string}") do |status|
+  assert_equal status, @doc_ref.status
+end
+
+Then("the document type display should be {string}") do |display|
+  assert_equal display, @doc_ref.type_display
+end
+
+Then("the document author should be {string}") do |author|
+  assert_equal author, @doc_ref.author_ien.to_s
+end
+
+Then("the document date should be {string}") do |date|
+  assert_equal Date.parse(date), @doc_ref.date
+end
+
+# "the FHIR subject reference should be" defined elsewhere
+
+Then("the FHIR type should have display {string}") do |display|
+  type = @fhir[:type]
+  refute_nil type
+  coding = type[:coding]&.first || type
+  assert_equal display, (coding[:display] || type[:text])
+end
+
+Then("the FHIR document status should be {string}") do |status|
+  assert_equal status, @fhir[:status]
+end

--- a/features/step_definitions/fhir_bundle_import_steps.rb
+++ b/features/step_definitions/fhir_bundle_import_steps.rb
@@ -15,8 +15,8 @@ Given("a FHIR Bundle JSON with an AllergyIntolerance for patient {string}") do |
     {
       "resourceType" => "AllergyIntolerance",
       "patient" => { "reference" => "Patient/#{dfn}" },
-      "code" => { "text" => "Penicillin", "coding" => [{ "code" => "7980" }] },
-      "clinicalStatus" => { "coding" => [{ "code" => "active" }] }
+      "code" => { "text" => "Penicillin", "coding" => [ { "code" => "7980" } ] },
+      "clinicalStatus" => { "coding" => [ { "code" => "active" } ] }
     }
   ])
 end
@@ -26,8 +26,8 @@ Given("a FHIR Bundle JSON with a Condition for patient {string}") do |dfn|
     {
       "resourceType" => "Condition",
       "subject" => { "reference" => "Patient/#{dfn}" },
-      "code" => { "text" => "Type 2 Diabetes", "coding" => [{ "code" => "E11.9", "system" => "http://hl7.org/fhir/sid/icd-10-cm" }] },
-      "clinicalStatus" => { "coding" => [{ "code" => "active" }] }
+      "code" => { "text" => "Type 2 Diabetes", "coding" => [ { "code" => "E11.9", "system" => "http://hl7.org/fhir/sid/icd-10-cm" } ] },
+      "clinicalStatus" => { "coding" => [ { "code" => "active" } ] }
     }
   ])
 end
@@ -37,7 +37,7 @@ Given("a FHIR Bundle JSON with a MedicationRequest for patient {string}") do |df
     {
       "resourceType" => "MedicationRequest",
       "subject" => { "reference" => "Patient/#{dfn}" },
-      "medicationCodeableConcept" => { "text" => "Metformin 500mg", "coding" => [{ "code" => "860975" }] },
+      "medicationCodeableConcept" => { "text" => "Metformin 500mg", "coding" => [ { "code" => "860975" } ] },
       "status" => "active"
     }
   ])
@@ -49,13 +49,13 @@ Given("a FHIR Bundle JSON with allergies, conditions, and medications for patien
       "resourceType" => "AllergyIntolerance",
       "patient" => { "reference" => "Patient/#{dfn}" },
       "code" => { "text" => "Penicillin" },
-      "clinicalStatus" => { "coding" => [{ "code" => "active" }] }
+      "clinicalStatus" => { "coding" => [ { "code" => "active" } ] }
     },
     {
       "resourceType" => "Condition",
       "subject" => { "reference" => "Patient/#{dfn}" },
       "code" => { "text" => "Hypertension" },
-      "clinicalStatus" => { "coding" => [{ "code" => "active" }] }
+      "clinicalStatus" => { "coding" => [ { "code" => "active" } ] }
     },
     {
       "resourceType" => "MedicationRequest",

--- a/features/step_definitions/fhir_bundle_import_steps.rb
+++ b/features/step_definitions/fhir_bundle_import_steps.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+# FHIR Bundle import step definitions
+
+def build_fhir_bundle(entries)
+  {
+    "resourceType" => "Bundle",
+    "type" => "collection",
+    "entry" => entries.map { |r| { "resource" => r } }
+  }.to_json
+end
+
+Given("a FHIR Bundle JSON with an AllergyIntolerance for patient {string}") do |dfn|
+  @bundle_json = build_fhir_bundle([
+    {
+      "resourceType" => "AllergyIntolerance",
+      "patient" => { "reference" => "Patient/#{dfn}" },
+      "code" => { "text" => "Penicillin", "coding" => [{ "code" => "7980" }] },
+      "clinicalStatus" => { "coding" => [{ "code" => "active" }] }
+    }
+  ])
+end
+
+Given("a FHIR Bundle JSON with a Condition for patient {string}") do |dfn|
+  @bundle_json = build_fhir_bundle([
+    {
+      "resourceType" => "Condition",
+      "subject" => { "reference" => "Patient/#{dfn}" },
+      "code" => { "text" => "Type 2 Diabetes", "coding" => [{ "code" => "E11.9", "system" => "http://hl7.org/fhir/sid/icd-10-cm" }] },
+      "clinicalStatus" => { "coding" => [{ "code" => "active" }] }
+    }
+  ])
+end
+
+Given("a FHIR Bundle JSON with a MedicationRequest for patient {string}") do |dfn|
+  @bundle_json = build_fhir_bundle([
+    {
+      "resourceType" => "MedicationRequest",
+      "subject" => { "reference" => "Patient/#{dfn}" },
+      "medicationCodeableConcept" => { "text" => "Metformin 500mg", "coding" => [{ "code" => "860975" }] },
+      "status" => "active"
+    }
+  ])
+end
+
+Given("a FHIR Bundle JSON with allergies, conditions, and medications for patient {string}") do |dfn|
+  @bundle_json = build_fhir_bundle([
+    {
+      "resourceType" => "AllergyIntolerance",
+      "patient" => { "reference" => "Patient/#{dfn}" },
+      "code" => { "text" => "Penicillin" },
+      "clinicalStatus" => { "coding" => [{ "code" => "active" }] }
+    },
+    {
+      "resourceType" => "Condition",
+      "subject" => { "reference" => "Patient/#{dfn}" },
+      "code" => { "text" => "Hypertension" },
+      "clinicalStatus" => { "coding" => [{ "code" => "active" }] }
+    },
+    {
+      "resourceType" => "MedicationRequest",
+      "subject" => { "reference" => "Patient/#{dfn}" },
+      "medicationCodeableConcept" => { "text" => "Lisinopril 10mg" },
+      "status" => "active"
+    }
+  ])
+end
+
+Given("invalid JSON input") do
+  @bundle_json = "not valid json {{"
+end
+
+Given("a FHIR JSON that is not a Bundle") do
+  @bundle_json = { "resourceType" => "Patient", "id" => "1" }.to_json
+end
+
+When("I import the bundle for patient {string} as clinician {string}") do |dfn, duz|
+  service = Lakeraven::EHR::ClinicalReconciliationService.new
+  @import_result = service.import_from_fhir_bundle(
+    patient_dfn: dfn, clinician_duz: duz, json_string: @bundle_json
+  )
+end
+
+Then("the bundle import should succeed") do
+  assert @import_result.success?, "Expected import to succeed, errors: #{@import_result.errors}"
+end
+
+Then("the bundle import should fail") do
+  refute @import_result.success?, "Expected import to fail"
+end
+
+Then("the bundle import error should include {string}") do |text|
+  errors = @import_result.errors.join(", ")
+  assert_includes errors, text, "Expected error '#{text}' in: #{errors}"
+end

--- a/features/step_definitions/fhir_resource_model_steps.rb
+++ b/features/step_definitions/fhir_resource_model_steps.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+# Shared step definitions for Organization, Location, PractitionerRole FHIR resources
+
+# --- Organization ---
+
+Given("an organization with name {string}") do |name|
+  @organization = Lakeraven::EHR::Organization.new(ien: 1, name: name)
+end
+
+Given("an organization without a name") do
+  @organization = Lakeraven::EHR::Organization.new(ien: 1)
+end
+
+Given("an organization with name {string} and station number {string}") do |name, station|
+  @organization = Lakeraven::EHR::Organization.new(ien: 1, name: name, station_number: station)
+end
+
+When("I serialize the organization to FHIR") do
+  @fhir = @organization.to_fhir
+end
+
+Then("the organization should be valid") do
+  assert @organization.valid?, "Expected valid: #{@organization.errors.full_messages}"
+end
+
+Then("the organization should be invalid") do
+  refute @organization.valid?
+end
+
+Then("the station number should be {string}") do |station|
+  assert_equal station, @organization.station_number
+end
+
+Then("the FHIR organization name should be {string}") do |name|
+  assert_equal name, @fhir[:name]
+end
+
+Then("the FHIR identifiers should include station number {string}") do |station|
+  ids = @fhir[:identifier] || []
+  assert ids.any? { |i| i[:value] == station }, "Expected station number #{station} in identifiers"
+end
+
+# --- Location ---
+
+Given("a location with name {string}") do |name|
+  @location = Lakeraven::EHR::Location.new(ien: 1, name: name)
+end
+
+Given("a location without a name") do
+  @location = Lakeraven::EHR::Location.new(ien: 1)
+end
+
+Given("a location with name {string} and abbreviation {string}") do |name, abbr|
+  @location = Lakeraven::EHR::Location.new(ien: 1, name: name, abbreviation: abbr)
+end
+
+Given("a location with name {string} and status {string}") do |name, status|
+  @location = Lakeraven::EHR::Location.new(ien: 1, name: name, status: status)
+end
+
+When("I serialize the location to FHIR") do
+  @fhir = @location.to_fhir
+end
+
+Then("the location should be valid") do
+  assert @location.valid?, "Expected valid: #{@location.errors.full_messages}"
+end
+
+Then("the location should be invalid") do
+  refute @location.valid?
+end
+
+Then("the abbreviation should be {string}") do |abbr|
+  assert_equal abbr, @location.abbreviation
+end
+
+Then("the FHIR location name should be {string}") do |name|
+  assert_equal name, @fhir[:name]
+end
+
+Then("the FHIR location status should be {string}") do |status|
+  assert_equal status, @fhir[:status]
+end
+
+# --- PractitionerRole ---
+
+Given("a practitioner role with role {string} for practitioner {string}") do |role, ien|
+  @practitioner_role = Lakeraven::EHR::PractitionerRole.new(
+    practitioner_ien: ien.to_i, organization_ien: 1, role: role, active: true
+  )
+end
+
+Given("a practitioner role with specialty {string} for practitioner {string}") do |specialty, ien|
+  @practitioner_role = Lakeraven::EHR::PractitionerRole.new(
+    practitioner_ien: ien.to_i, organization_ien: 1, role: "doctor", specialty: specialty, active: true
+  )
+end
+
+Given("an active practitioner role for practitioner {string}") do |ien|
+  @practitioner_role = Lakeraven::EHR::PractitionerRole.new(
+    practitioner_ien: ien.to_i, organization_ien: 1, role: "doctor", active: true
+  )
+end
+
+When("I serialize the practitioner role to FHIR") do
+  @fhir = @practitioner_role.to_fhir
+end
+
+Then("the practitioner role should be valid") do
+  assert @practitioner_role.valid?, "Expected valid: #{@practitioner_role.errors.full_messages}"
+end
+
+Then("the specialty should be {string}") do |specialty|
+  assert_equal specialty, @practitioner_role.specialty
+end
+
+Then("the practitioner role should be active") do
+  assert @practitioner_role.active?, "Expected active"
+end
+
+Then("the FHIR practitioner reference should include {string}") do |ien|
+  pract = @fhir[:practitioner]
+  refute_nil pract
+  assert_includes pract[:reference], ien
+end
+
+Then("the FHIR specialty should include {string}") do |text|
+  specs = @fhir[:specialty]
+  refute_nil specs
+  assert specs.any? { |s| s[:text]&.include?(text) || s[:coding]&.any? { |c| c[:display]&.include?(text) } }
+end

--- a/features/step_definitions/fhir_resource_model_steps.rb
+++ b/features/step_definitions/fhir_resource_model_steps.rb
@@ -2,6 +2,14 @@
 
 # Shared step definitions for Organization, Location, PractitionerRole FHIR resources
 
+# --- Shared FHIR assertions ---
+
+Then("the FHIR subject reference should include {string}") do |id|
+  subject = @fhir[:subject]
+  refute_nil subject, "Expected subject in FHIR output"
+  assert_includes subject[:reference], id
+end
+
 # --- Organization ---
 
 Given("an organization with name {string}") do |name|

--- a/features/step_definitions/goal_steps.rb
+++ b/features/step_definitions/goal_steps.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Goal step definitions
+
+Given("a goal with description {string} for patient {string}") do |desc, dfn|
+  @goal = Lakeraven::EHR::Goal.new(patient_dfn: dfn, description: desc)
+end
+
+Given("a goal without a patient") do
+  @goal = Lakeraven::EHR::Goal.new(description: "Test Goal")
+end
+
+Given("a goal without a description for patient {string}") do |dfn|
+  @goal = Lakeraven::EHR::Goal.new(patient_dfn: dfn)
+end
+
+Given("a goal with description {string} and achievement {string} for patient {string}") do |desc, achievement, dfn|
+  @goal = Lakeraven::EHR::Goal.new(
+    patient_dfn: dfn, description: desc, achievement_status: achievement
+  )
+end
+
+Given("a goal with description {string} and target {string} for patient {string}") do |desc, target, dfn|
+  @goal = Lakeraven::EHR::Goal.new(
+    patient_dfn: dfn, description: desc, target_date: Date.parse(target)
+  )
+end
+
+When("I serialize the goal to FHIR") do
+  @fhir = @goal.to_fhir
+end
+
+Then("the goal should be valid") do
+  assert @goal.valid?, "Expected valid: #{@goal.errors.full_messages}"
+end
+
+Then("the goal should be invalid") do
+  refute @goal.valid?
+end
+
+Then("the goal should be active") do
+  assert @goal.active?, "Expected active"
+end
+
+Then("the goal should be achieved") do
+  assert @goal.achieved?, "Expected achieved"
+end
+
+Then("the FHIR goal lifecycle status should be {string}") do |expected|
+  assert_equal expected, @fhir[:lifecycleStatus]
+end
+
+Then("the FHIR goal description should include {string}") do |text|
+  desc = @fhir[:description]
+  refute_nil desc
+  assert_includes desc[:text], text
+end

--- a/features/step_definitions/immunization_steps.rb
+++ b/features/step_definitions/immunization_steps.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Immunization step definitions
+
+Given("an immunization with vaccine {string} for patient {string}") do |vaccine, dfn|
+  @immunization = Lakeraven::EHR::Immunization.new(
+    patient_dfn: dfn, vaccine_display: vaccine, status: "completed"
+  )
+end
+
+Given("an immunization without a patient") do
+  @immunization = Lakeraven::EHR::Immunization.new(
+    vaccine_display: "Test Vaccine", status: "completed"
+  )
+end
+
+Given("an immunization without a vaccine for patient {string}") do |dfn|
+  @immunization = Lakeraven::EHR::Immunization.new(
+    patient_dfn: dfn, status: "completed"
+  )
+end
+
+Given("a completed immunization with vaccine {string} for patient {string}") do |vaccine, dfn|
+  @immunization = Lakeraven::EHR::Immunization.new(
+    patient_dfn: dfn, vaccine_display: vaccine, status: "completed"
+  )
+end
+
+Given("an immunization with vaccine {string} and CVX {string} for patient {string}") do |vaccine, cvx, dfn|
+  @immunization = Lakeraven::EHR::Immunization.new(
+    patient_dfn: dfn, vaccine_display: vaccine, vaccine_code: cvx, status: "completed"
+  )
+end
+
+Given("an immunization with vaccine {string} and VFC {string} for patient {string}") do |vaccine, vfc, dfn|
+  @immunization = Lakeraven::EHR::Immunization.new(
+    patient_dfn: dfn, vaccine_display: vaccine, vfc_eligibility_code: vfc, status: "completed"
+  )
+end
+
+When("I serialize the immunization to FHIR") do
+  @fhir = @immunization.to_fhir
+end
+
+Then("the immunization should be valid") do
+  assert @immunization.valid?, "Expected valid: #{@immunization.errors.full_messages}"
+end
+
+Then("the immunization should be invalid") do
+  refute @immunization.valid?
+end
+
+Then("the immunization should be completed") do
+  assert @immunization.completed?, "Expected completed"
+end
+
+Then("the FHIR immunization patient reference should include {string}") do |dfn|
+  patient = @fhir[:patient]
+  refute_nil patient
+  assert_includes patient[:reference], dfn
+end
+
+Then("the FHIR vaccine code should include {string}") do |cvx|
+  vc = @fhir[:vaccineCode]
+  refute_nil vc
+  assert vc[:coding]&.any? { |c| c[:code] == cvx },
+    "Expected CVX #{cvx} in vaccine code"
+end

--- a/features/step_definitions/medication_request_steps.rb
+++ b/features/step_definitions/medication_request_steps.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# MedicationRequest step definitions
+
+Given("a medication request for {string} for patient {string}") do |med, dfn|
+  @medication_request = Lakeraven::EHR::MedicationRequest.new(
+    patient_dfn: dfn, medication_display: med
+  )
+end
+
+Given("a medication request without a patient") do
+  @medication_request = Lakeraven::EHR::MedicationRequest.new(
+    medication_display: "Test Med"
+  )
+end
+
+Given("a medication request without a medication for patient {string}") do |dfn|
+  @medication_request = Lakeraven::EHR::MedicationRequest.new(patient_dfn: dfn)
+end
+
+Given("a medication request for {string} with status {string} for patient {string}") do |med, status, dfn|
+  @medication_request = Lakeraven::EHR::MedicationRequest.new(
+    patient_dfn: dfn, medication_display: med, status: status
+  )
+end
+
+Given("a medication request for {string} with RxNorm {string} for patient {string}") do |med, code, dfn|
+  @medication_request = Lakeraven::EHR::MedicationRequest.new(
+    patient_dfn: dfn, medication_display: med, medication_code: code
+  )
+end
+
+When("I serialize the medication request to FHIR") do
+  @fhir = @medication_request.to_fhir
+end
+
+Then("the medication request should be valid") do
+  assert @medication_request.valid?, "Expected valid: #{@medication_request.errors.full_messages}"
+end
+
+Then("the medication request should be invalid") do
+  refute @medication_request.valid?
+end
+
+Then("the medication request should be active") do
+  assert @medication_request.active?, "Expected active"
+end
+
+Then("the medication matching key should be {string}") do |expected|
+  assert_equal expected, @medication_request.matching_key
+end
+
+Then("the medication request should have a signed content hash") do
+  hash = @medication_request.signed_content_hash
+  refute_nil hash
+  assert_equal 64, hash.length, "Expected SHA-256 hex string"
+end
+
+Then("the FHIR medication code should include {string}") do |code|
+  med = @fhir[:medicationCodeableConcept]
+  refute_nil med
+  assert med[:coding]&.any? { |c| c[:code] == code },
+    "Expected code #{code} in medication coding"
+end

--- a/features/step_definitions/observation_steps.rb
+++ b/features/step_definitions/observation_steps.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Observation step definitions
+
+Given("a vital sign observation with code {string} and value {string} for patient {string}") do |code, value, dfn|
+  @observation = Lakeraven::EHR::Observation.new(
+    patient_dfn: dfn, code: code, code_system: "loinc", value: value,
+    value_quantity: value, category: "vital-signs", status: "final"
+  )
+end
+
+Given("a laboratory observation with code {string} and value {string} for patient {string}") do |code, value, dfn|
+  @observation = Lakeraven::EHR::Observation.new(
+    patient_dfn: dfn, code: code, value: value, value_quantity: value,
+    category: "laboratory", status: "final"
+  )
+end
+
+Given("an SDOH observation with code {string} and value {string} for patient {string}") do |code, value, dfn|
+  @observation = Lakeraven::EHR::Observation.new(
+    patient_dfn: dfn, code: code, code_system: "loinc", value: value,
+    category: "social-history", status: "final"
+  )
+end
+
+Given("a blood pressure observation with value {string} for patient {string}") do |value, dfn|
+  @observation = Lakeraven::EHR::Observation.new(
+    patient_dfn: dfn, code: "85354-9", code_system: "loinc", value: value,
+    category: "vital-signs", status: "final"
+  )
+end
+
+Given("vital sign hashes for patient {string} with type {string} value {string} and type {string} value {string}") do |dfn, t1, v1, t2, v2|
+  hashes = [
+    { type: t1, value: v1 },
+    { type: t2, value: v2 }
+  ]
+  @observations = Lakeraven::EHR::Observation.from_vital_hashes(hashes, patient_dfn: dfn)
+end
+
+When("I serialize the observation to FHIR") do
+  @fhir = @observation.to_fhir
+end
+
+Then("the observation should be a vital sign") do
+  assert @observation.vital_sign?, "Expected vital sign"
+end
+
+Then("the observation should be a laboratory result") do
+  assert @observation.laboratory?, "Expected laboratory"
+end
+
+Then("the observation should be an SDOH observation") do
+  assert @observation.sdoh?, "Expected SDOH"
+end
+
+Then("the FHIR observation should have systolic and diastolic components") do
+  components = @fhir[:component]
+  refute_nil components
+  assert_equal 2, components.length, "Expected 2 components (systolic + diastolic)"
+end
+
+Then("the FHIR observation category should be {string}") do |expected|
+  cats = @fhir[:category]
+  refute_nil cats
+  assert cats.any? { |c| c[:coding]&.any? { |cd| cd[:code] == expected } },
+    "Expected category #{expected}"
+end
+
+Then("there should be {int} observations") do |count|
+  assert_equal count, @observations.length
+end
+
+Then("the first observation code should be {string}") do |code|
+  assert_equal code, @observations.first.code
+end

--- a/features/step_definitions/procedure_steps.rb
+++ b/features/step_definitions/procedure_steps.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Procedure step definitions
+
+Given("a procedure with display {string} for patient {string}") do |display, dfn|
+  @procedure = Lakeraven::EHR::Procedure.new(patient_dfn: dfn, display: display, status: "completed")
+end
+
+Given("a procedure without a patient") do
+  @procedure = Lakeraven::EHR::Procedure.new(display: "Test", status: "completed")
+end
+
+Given("a procedure without a display for patient {string}") do |dfn|
+  @procedure = Lakeraven::EHR::Procedure.new(patient_dfn: dfn, status: "completed")
+end
+
+Given("a procedure with display {string} and code {string} system {string} for patient {string}") do |display, code, system, dfn|
+  @procedure = Lakeraven::EHR::Procedure.new(
+    patient_dfn: dfn, display: display, code: code, code_system: system, status: "completed"
+  )
+end
+
+Given("a completed procedure with display {string} for patient {string}") do |display, dfn|
+  @procedure = Lakeraven::EHR::Procedure.new(
+    patient_dfn: dfn, display: display, status: "completed"
+  )
+end
+
+Given("a procedure with display {string} and performer {string} for patient {string}") do |display, duz, dfn|
+  @procedure = Lakeraven::EHR::Procedure.new(
+    patient_dfn: dfn, display: display, status: "completed",
+    performer_duz: duz, performer_name: "Dr. Test"
+  )
+end
+
+When("I serialize the procedure to FHIR") do
+  @fhir = @procedure.to_fhir
+end
+
+Then("the procedure should be valid") do
+  assert @procedure.valid?, "Expected valid: #{@procedure.errors.full_messages}"
+end
+
+Then("the procedure should be invalid") do
+  refute @procedure.valid?
+end
+
+Then("the procedure should be completed") do
+  assert @procedure.completed?, "Expected completed"
+end
+
+Then("the FHIR procedure code should include {string}") do |code|
+  fhir_code = @fhir[:code]
+  refute_nil fhir_code
+  assert fhir_code[:coding]&.any? { |c| c[:code] == code },
+    "Expected code #{code} in coding"
+end
+
+Then("the FHIR procedure performer should include {string}") do |duz|
+  performers = @fhir[:performer]
+  refute_nil performers
+  assert performers.any? { |p| p[:actor][:reference]&.include?(duz) },
+    "Expected performer #{duz}"
+end

--- a/features/step_definitions/related_person_steps.rb
+++ b/features/step_definitions/related_person_steps.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# RelatedPerson step definitions
+
+Given("a related person with relationship {string} for patient {string}") do |rel, dfn|
+  @related_person = Lakeraven::EHR::RelatedPerson.new(
+    patient_dfn: dfn, name: "Doe,Jane", relationship: rel, active: true
+  )
+end
+
+Given("a related person without a patient") do
+  @related_person = Lakeraven::EHR::RelatedPerson.new(name: "Doe,Jane", relationship: "parent")
+end
+
+Given("a related person without a name for patient {string}") do |dfn|
+  @related_person = Lakeraven::EHR::RelatedPerson.new(patient_dfn: dfn, relationship: "parent")
+end
+
+Given("an active related person for patient {string}") do |dfn|
+  @related_person = Lakeraven::EHR::RelatedPerson.new(
+    patient_dfn: dfn, name: "Doe,Jane", relationship: "parent", active: true
+  )
+end
+
+Given("an inactive related person for patient {string}") do |dfn|
+  @related_person = Lakeraven::EHR::RelatedPerson.new(
+    patient_dfn: dfn, name: "Doe,Jane", relationship: "parent", active: false
+  )
+end
+
+Given("a related person with period from {string} to {string} for patient {string}") do |s, e, dfn|
+  @related_person = Lakeraven::EHR::RelatedPerson.new(
+    patient_dfn: dfn, name: "Doe,Jane", relationship: "parent",
+    active: true, period_start: Date.parse(s), period_end: Date.parse(e)
+  )
+end
+
+Given("a related person named {string} with relationship {string} for patient {string}") do |name, rel, dfn|
+  @related_person = Lakeraven::EHR::RelatedPerson.new(
+    patient_dfn: dfn, name: name, relationship: rel, active: true
+  )
+end
+
+When("I serialize the related person to FHIR") do
+  @fhir = @related_person.to_fhir
+end
+
+Then("the related person should be valid") do
+  assert @related_person.valid?, "Expected valid: #{@related_person.errors.full_messages}"
+end
+
+Then("the related person should be invalid") do
+  refute @related_person.valid?
+end
+
+Then("the relationship display should include {string}") do |text|
+  display = @related_person.relationship_display || @related_person.relationship
+  assert_includes display.to_s, text
+end
+
+Then("the related person should be active") do
+  assert @related_person.active?, "Expected active"
+end
+
+Then("the related person should not be active") do
+  refute @related_person.active?
+end
+
+Then("the related person should be within period") do
+  assert @related_person.within_period?, "Expected within period"
+end
+
+Then("the related person should not be within period") do
+  refute @related_person.within_period?
+end
+
+Then("the FHIR patient reference should include {string}") do |dfn|
+  patient = @fhir[:patient] || @fhir[:subject]
+  refute_nil patient
+  assert_includes patient[:reference], dfn
+end
+
+Then("the FHIR relationship should be present") do
+  rel = @fhir[:relationship]
+  refute_nil rel
+end
+
+Then("the FHIR name should include {string}") do |text|
+  names = @fhir[:name]
+  refute_nil names
+  name_text = names.is_a?(Array) ? names.map { |n| n[:text] || "#{n[:family]} #{n[:given]&.join(' ')}" }.join(" ") : names.to_s
+  assert_includes name_text, text
+end

--- a/features/step_definitions/service_request_steps.rb
+++ b/features/step_definitions/service_request_steps.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# ServiceRequest step definitions
+
+Given("a service request for {string} from provider {string} for patient {string}") do |service, provider, dfn|
+  @service_request = Lakeraven::EHR::ServiceRequest.new(
+    patient_dfn: dfn.to_i, requesting_provider_ien: provider.to_i,
+    service_requested: service
+  )
+end
+
+Given("a service request without a patient") do
+  @service_request = Lakeraven::EHR::ServiceRequest.new(
+    requesting_provider_ien: 201, service_requested: "Test"
+  )
+end
+
+Given("a service request without a service from provider {string} for patient {string}") do |provider, dfn|
+  @service_request = Lakeraven::EHR::ServiceRequest.new(
+    patient_dfn: dfn.to_i, requesting_provider_ien: provider.to_i
+  )
+end
+
+Given("a service request for {string} with status {string} from provider {string} for patient {string}") do |service, status, provider, dfn|
+  @service_request = Lakeraven::EHR::ServiceRequest.new(
+    patient_dfn: dfn.to_i, requesting_provider_ien: provider.to_i,
+    service_requested: service, status: status
+  )
+end
+
+Given("a service request for {string} with urgency {string} from provider {string} for patient {string}") do |service, urgency, provider, dfn|
+  @service_request = Lakeraven::EHR::ServiceRequest.new(
+    patient_dfn: dfn.to_i, requesting_provider_ien: provider.to_i,
+    service_requested: service, urgency: urgency
+  )
+end
+
+Given("a service request for {string} with appointment {string} from provider {string} for patient {string}") do |service, date, provider, dfn|
+  @service_request = Lakeraven::EHR::ServiceRequest.new(
+    patient_dfn: dfn.to_i, requesting_provider_ien: provider.to_i,
+    service_requested: service, appointment_on: Date.parse(date), status: "active"
+  )
+end
+
+When("I serialize the service request to FHIR") do
+  @fhir = @service_request.to_fhir
+end
+
+Then("the service request should be valid") do
+  assert @service_request.valid?, "Expected valid: #{@service_request.errors.full_messages}"
+end
+
+Then("the service request should be invalid") do
+  refute @service_request.valid?
+end
+
+Then("the service request should be active") do
+  assert @service_request.active?, "Expected active"
+end
+
+Then("the service request should be completed") do
+  assert @service_request.completed?, "Expected completed"
+end
+
+Then("the service request should be urgent") do
+  assert @service_request.urgent?, "Expected urgent"
+end
+
+Then("the service request should be overdue") do
+  assert @service_request.overdue?, "Expected overdue"
+end
+
+Then("the service request priority should be {int}") do |expected|
+  assert_equal expected, @service_request.priority
+end

--- a/features/step_definitions/smart_launch_context_steps.rb
+++ b/features/step_definitions/smart_launch_context_steps.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# SMART launch context step definitions
+
+Given("an OAuth application {string}") do |app_uid|
+  @oauth_app_uid = app_uid
+end
+
+When("I mint a launch context for patient {string}") do |dfn|
+  @launch_context = Lakeraven::EHR::LaunchContext.mint(
+    oauth_application_uid: @oauth_app_uid, patient_dfn: dfn
+  )
+end
+
+When("I mint a launch context for patient {string} and encounter {string}") do |dfn, encounter_id|
+  @launch_context = Lakeraven::EHR::LaunchContext.mint(
+    oauth_application_uid: @oauth_app_uid, patient_dfn: dfn, encounter_id: encounter_id
+  )
+end
+
+When("I mint a launch context for patient {string} with facility {string}") do |dfn, facility|
+  @launch_context = Lakeraven::EHR::LaunchContext.mint(
+    oauth_application_uid: @oauth_app_uid, patient_dfn: dfn, facility_identifier: facility
+  )
+end
+
+When("I mint a launch context without a patient") do
+  @launch_context = Lakeraven::EHR::LaunchContext.mint(
+    oauth_application_uid: @oauth_app_uid
+  )
+end
+
+When("I mint two launch contexts for patient {string}") do |dfn|
+  @launch_context_1 = Lakeraven::EHR::LaunchContext.mint(
+    oauth_application_uid: @oauth_app_uid, patient_dfn: dfn
+  )
+  @launch_context_2 = Lakeraven::EHR::LaunchContext.mint(
+    oauth_application_uid: @oauth_app_uid, patient_dfn: dfn
+  )
+end
+
+Then("the launch context should have a token") do
+  refute_nil @launch_context.launch_token
+end
+
+Then("the launch context token should start with {string}") do |prefix|
+  assert @launch_context.launch_token.start_with?(prefix),
+    "Expected token to start with '#{prefix}', got '#{@launch_context.launch_token}'"
+end
+
+Then("the launch context should expire in the future") do
+  assert @launch_context.expires_at > Time.current, "Expected expires_at in the future"
+end
+
+Then("the SMART context should include patient {string}") do |dfn|
+  context = @launch_context.to_smart_context
+  assert_equal dfn, context[:patient]
+end
+
+Then("the SMART context should include encounter {string}") do |encounter_id|
+  context = @launch_context.to_smart_context
+  assert_equal encounter_id, context[:encounter]
+end
+
+Then("the launch context facility should be {string}") do |expected|
+  assert_equal expected, @launch_context.facility_identifier
+end
+
+Then("the SMART context should not include patient") do
+  context = @launch_context.to_smart_context
+  refute context.key?(:patient), "Expected no patient in SMART context"
+end
+
+Then("the SMART context should not include encounter") do
+  context = @launch_context.to_smart_context
+  refute context.key?(:encounter), "Expected no encounter in SMART context"
+end
+
+Then("the tokens should be different") do
+  refute_equal @launch_context_1.launch_token, @launch_context_2.launch_token
+end

--- a/features/step_definitions/terminology_steps.rb
+++ b/features/step_definitions/terminology_steps.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Terminology serializer step definitions
+
+Given("an ICD-10 code {string} with edition {string}") do |code, edition|
+  @terminology = Lakeraven::EHR::Terminology::ICD10.new(code, edition: edition.to_sym)
+end
+
+Given("an ICD-10 code {string} with no edition") do |code|
+  @terminology = Lakeraven::EHR::Terminology::ICD10.new(code, edition: nil)
+end
+
+Given("a LOINC code {string}") do |code|
+  @terminology = Lakeraven::EHR::Terminology::LOINC.new(code)
+end
+
+Given("an RxNorm code {string}") do |code|
+  @terminology = Lakeraven::EHR::Terminology::RxNorm.new(code)
+end
+
+Given("an ATC code {string}") do |code|
+  @terminology = Lakeraven::EHR::Terminology::ATC.new(code)
+end
+
+Given("a DIN code {string}") do |code|
+  @terminology = Lakeraven::EHR::Terminology::DIN.new(code)
+end
+
+Given("a SNOMED code {string} with no edition") do |code|
+  @terminology = Lakeraven::EHR::Terminology::SNOMED.new(code)
+end
+
+Given("a SNOMED code {string} with edition {string}") do |code, edition|
+  @terminology = Lakeraven::EHR::Terminology::SNOMED.new(code, edition: edition.to_sym)
+end
+
+When("I convert to FHIR Coding") do
+  @coding = @terminology.to_coding
+end
+
+Then("the terminology system should be {string}") do |expected|
+  assert_equal expected, @terminology.system
+end
+
+Then("the terminology code should be {string}") do |expected|
+  assert_equal expected, @terminology.code
+end
+
+Then("the terminology status should be {string}") do |expected|
+  assert_equal expected.to_sym, @terminology.status
+end
+
+Then("the coding system should be {string}") do |expected|
+  assert_equal expected, @coding[:system]
+end
+
+Then("the coding code should be {string}") do |expected|
+  assert_equal expected, @coding[:code]
+end
+
+Then("the coding version should be {string}") do |expected|
+  assert_equal expected, @coding[:version]
+end
+
+Then("the coding should not have a version") do
+  refute @coding.key?(:version), "Expected no version in coding"
+end

--- a/features/step_definitions/valueset_audit_steps.rb
+++ b/features/step_definitions/valueset_audit_steps.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+# ValueSet audit service step definitions
+
+Given("a ValueSet audit service") do
+  @vs_audit = Lakeraven::EHR::ValueSetAuditService.new
+end
+
+When("I record access to ValueSet {string} by agent {string}") do |vs_id, agent_id|
+  @vs_audit.record_access(vs_id, agent_id: agent_id)
+end
+
+When("I record expansion of ValueSet {string} by agent {string} with {int} codes") do |vs_id, agent_id, count|
+  @last_provenance = @vs_audit.record_expansion(vs_id, agent_id: agent_id, code_count: count)
+end
+
+When("I record expansion of ValueSet {string} by agent {string} with {int} codes cached") do |vs_id, agent_id, count|
+  @last_provenance = @vs_audit.record_expansion(vs_id, agent_id: agent_id, code_count: count, cached: true)
+end
+
+When("I record validation of code {string} against ValueSet {string} by agent {string} with result true") do |code, vs_id, agent_id|
+  @vs_audit.record_validation(vs_id, code: code, agent_id: agent_id, result: true)
+end
+
+When("I record creation of ValueSet {string} by agent {string}") do |vs_id, agent_id|
+  @vs_audit.record_create(vs_id, agent_id: agent_id)
+end
+
+When("I record creation of ValueSet {string} by agent {string} from source {string}") do |vs_id, agent_id, source|
+  @vs_audit.record_create(vs_id, agent_id: agent_id, source: source)
+end
+
+When("I record update of ValueSet {string} by agent {string}") do |vs_id, agent_id|
+  @vs_audit.record_update(vs_id, agent_id: agent_id)
+end
+
+When("I record deletion of ValueSet {string} by agent {string}") do |vs_id, agent_id|
+  @vs_audit.record_delete(vs_id, agent_id: agent_id)
+end
+
+Then("the audit history for {string} should have {int} entry/entries") do |vs_id, count|
+  history = @vs_audit.history(vs_id)
+  assert_equal count, history.length, "Expected #{count} entries, got #{history.length}"
+end
+
+Then("the most recent entry should have activity {string}") do |expected|
+  history = @vs_audit.history(@vs_audit.store.all.last.target_id)
+  assert_equal expected, history.first.activity
+end
+
+Then("the most recent entry should have reason {string}") do |expected|
+  history = @vs_audit.history(@vs_audit.store.all.last.target_id)
+  assert_equal expected, history.first.reason_code
+end
+
+Then("the agent history for {string} should have {int} entries") do |agent_id, count|
+  history = @vs_audit.agent_history(agent_id)
+  assert_equal count, history.length
+end
+
+Then("the usage stats for {string} should show {int} total operations") do |vs_id, count|
+  @usage_stats = @vs_audit.usage_stats(vs_id)
+  assert_equal count, @usage_stats[:total_operations]
+end
+
+Then("the usage stats should show {int} unique agents") do |count|
+  assert_equal count, @usage_stats[:unique_agents]
+end
+
+Then("the first history entry for {string} should be most recent") do |vs_id|
+  history = @vs_audit.history(vs_id)
+  assert history.length >= 2, "Need at least 2 entries"
+  assert history[0].recorded >= history[1].recorded, "First entry should be most recent"
+end
+
+Then("the most recent entry for {string} should reference source {string}") do |vs_id, source|
+  history = @vs_audit.history(vs_id)
+  entry = history.first
+  assert_equal "DocumentReference", entry.entity_what_type
+  assert_equal source, entry.entity_what_id
+end
+
+Then("the expansion metadata should show {int} codes") do |count|
+  metadata = JSON.parse(@last_provenance.chain_of_custody)
+  assert_equal count, metadata["code_count"]
+end
+
+Then("the expansion metadata should show cached true") do
+  metadata = JSON.parse(@last_provenance.chain_of_custody)
+  assert_equal true, metadata["cached"]
+end

--- a/features/terminology.feature
+++ b/features/terminology.feature
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+Feature: Terminology serializers
+  As a healthcare system
+  I need to serialize clinical codes into standard terminology systems
+  So that coded data is interoperable across markets
+
+  # --- ICD-10 ---
+
+  Scenario: ICD-10-CM code (US edition)
+    Given an ICD-10 code "E11.9" with edition "cm"
+    Then the terminology system should be "http://hl7.org/fhir/sid/icd-10-cm"
+    And the terminology code should be "E11.9"
+    And the terminology status should be "mapped"
+
+  Scenario: ICD-10-SE code (Swedish edition)
+    Given an ICD-10 code "E11.9" with edition "se"
+    Then the terminology system should be "http://hl7.org/fhir/sid/icd-10-se"
+
+  Scenario: ICD-10-CA code (Canadian edition)
+    Given an ICD-10 code "E11.9" with edition "ca"
+    Then the terminology system should be "http://hl7.org/fhir/sid/icd-10-ca"
+
+  Scenario: ICD-10 international (no edition)
+    Given an ICD-10 code "E11.9" with no edition
+    Then the terminology system should be "http://hl7.org/fhir/sid/icd-10"
+
+  Scenario: ICD-10 to FHIR Coding
+    Given an ICD-10 code "E11.9" with edition "cm"
+    When I convert to FHIR Coding
+    Then the coding system should be "http://hl7.org/fhir/sid/icd-10-cm"
+    And the coding code should be "E11.9"
+
+  Scenario: Empty ICD-10 code is unmapped
+    Given an ICD-10 code "" with edition "cm"
+    Then the terminology status should be "unmapped"
+
+  # --- LOINC ---
+
+  Scenario: LOINC observation code
+    Given a LOINC code "8867-4"
+    Then the terminology system should be "http://loinc.org"
+    And the terminology code should be "8867-4"
+    And the terminology status should be "mapped"
+
+  Scenario: LOINC to FHIR Coding
+    Given a LOINC code "8867-4"
+    When I convert to FHIR Coding
+    Then the coding system should be "http://loinc.org"
+    And the coding code should be "8867-4"
+
+  # --- RxNorm ---
+
+  Scenario: RxNorm medication code
+    Given an RxNorm code "860975"
+    Then the terminology system should be "http://www.nlm.nih.gov/research/umls/rxnorm"
+    And the terminology code should be "860975"
+
+  Scenario: RxNorm to FHIR Coding
+    Given an RxNorm code "860975"
+    When I convert to FHIR Coding
+    Then the coding system should be "http://www.nlm.nih.gov/research/umls/rxnorm"
+
+  # --- ATC (WHO) ---
+
+  Scenario: ATC drug classification code
+    Given an ATC code "A10BA02"
+    Then the terminology system should be "http://www.whocc.no/atc"
+    And the terminology code should be "A10BA02"
+
+  # --- DIN (Health Canada) ---
+
+  Scenario: DIN drug identification code
+    Given a DIN code "02248573"
+    Then the terminology system should be "https://health-products.canada.ca/dpd-bdpp"
+    And the terminology code should be "02248573"
+
+  # --- SNOMED CT ---
+
+  Scenario: SNOMED CT code (no edition)
+    Given a SNOMED code "73211009" with no edition
+    Then the terminology system should be "http://snomed.info/sct"
+    And the terminology code should be "73211009"
+
+  Scenario: SNOMED CT US edition
+    Given a SNOMED code "73211009" with edition "us"
+    When I convert to FHIR Coding
+    Then the coding version should be "http://snomed.info/sct/731000124108"
+
+  Scenario: SNOMED CT Swedish edition
+    Given a SNOMED code "73211009" with edition "se"
+    When I convert to FHIR Coding
+    Then the coding version should be "http://snomed.info/sct/45991000052106"
+
+  Scenario: SNOMED CT Canadian edition
+    Given a SNOMED code "73211009" with edition "ca"
+    When I convert to FHIR Coding
+    Then the coding version should be "http://snomed.info/sct/20611000087101"
+
+  Scenario: SNOMED CT international (no version)
+    Given a SNOMED code "73211009" with no edition
+    When I convert to FHIR Coding
+    Then the coding should not have a version
+
+  Scenario: Empty SNOMED code is unmapped
+    Given a SNOMED code "" with no edition
+    Then the terminology status should be "unmapped"
+
+  Scenario: Whitespace-only code is unmapped
+    Given an ICD-10 code "   " with edition "cm"
+    Then the terminology status should be "unmapped"

--- a/features/valueset_audit.feature
+++ b/features/valueset_audit.feature
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+Feature: ValueSet audit trail
+  As a compliance officer
+  I need to track all ValueSet operations
+  So that terminology usage is auditable
+
+  Scenario: Record ValueSet access
+    Given a ValueSet audit service
+    When I record access to ValueSet "gpra-diabetes-dx" by agent "provider-201"
+    Then the audit history for "gpra-diabetes-dx" should have 1 entry
+    And the most recent entry should have activity "EXECUTE"
+
+  Scenario: Record ValueSet expansion
+    Given a ValueSet audit service
+    When I record expansion of ValueSet "gpra-diabetes-dx" by agent "provider-201" with 15 codes
+    Then the audit history for "gpra-diabetes-dx" should have 1 entry
+    And the most recent entry should have reason "HRESCH"
+
+  Scenario: Record code validation
+    Given a ValueSet audit service
+    When I record validation of code "E11.9" against ValueSet "gpra-diabetes-dx" by agent "provider-201" with result true
+    Then the audit history for "gpra-diabetes-dx" should have 1 entry
+    And the most recent entry should have reason "HACCRD"
+
+  Scenario: Record ValueSet creation
+    Given a ValueSet audit service
+    When I record creation of ValueSet "custom-measure-01" by agent "admin-101"
+    Then the audit history for "custom-measure-01" should have 1 entry
+    And the most recent entry should have activity "CREATE"
+
+  Scenario: Record ValueSet update
+    Given a ValueSet audit service
+    When I record update of ValueSet "custom-measure-01" by agent "admin-101"
+    Then the audit history for "custom-measure-01" should have 1 entry
+    And the most recent entry should have activity "UPDATE"
+
+  Scenario: Record ValueSet deletion
+    Given a ValueSet audit service
+    When I record deletion of ValueSet "custom-measure-01" by agent "admin-101"
+    Then the audit history for "custom-measure-01" should have 1 entry
+    And the most recent entry should have activity "DELETE"
+
+  Scenario: Agent history across ValueSets
+    Given a ValueSet audit service
+    When I record access to ValueSet "gpra-diabetes-dx" by agent "provider-201"
+    And I record access to ValueSet "gpra-hypertension-dx" by agent "provider-201"
+    Then the agent history for "provider-201" should have 2 entries
+
+  Scenario: Usage statistics
+    Given a ValueSet audit service
+    When I record access to ValueSet "gpra-diabetes-dx" by agent "provider-201"
+    And I record expansion of ValueSet "gpra-diabetes-dx" by agent "provider-202" with 15 codes
+    And I record validation of code "E11.9" against ValueSet "gpra-diabetes-dx" by agent "provider-201" with result true
+    Then the usage stats for "gpra-diabetes-dx" should show 3 total operations
+    And the usage stats should show 2 unique agents
+
+  Scenario: History ordered by most recent first
+    Given a ValueSet audit service
+    When I record access to ValueSet "gpra-diabetes-dx" by agent "provider-201"
+    And I record expansion of ValueSet "gpra-diabetes-dx" by agent "provider-202" with 10 codes
+    Then the first history entry for "gpra-diabetes-dx" should be most recent
+
+  Scenario: Creation with source document
+    Given a ValueSet audit service
+    When I record creation of ValueSet "imported-vs" by agent "admin-101" from source "doc-001"
+    Then the most recent entry for "imported-vs" should reference source "doc-001"
+
+  Scenario: Expansion tracks code count and cache status
+    Given a ValueSet audit service
+    When I record expansion of ValueSet "gpra-diabetes-dx" by agent "provider-201" with 15 codes cached
+    Then the expansion metadata should show 15 codes
+    And the expansion metadata should show cached true

--- a/test/terminology/lakeraven/ehr/terminology_test.rb
+++ b/test/terminology/lakeraven/ehr/terminology_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 module Lakeraven
   module EHR
-    class TerminologyDecoratorTest < ActiveSupport::TestCase
+    class TerminologySerializerTest < ActiveSupport::TestCase
       # =============================================================================
       # ICD-10 (US Clinical Modification — default)
       # =============================================================================
@@ -167,8 +167,8 @@ module Lakeraven
       # BASE CONTRACT
       # =============================================================================
 
-      test "all terminology decorators respond to code, system, display, to_coding, status" do
-        decorators = [
+      test "all terminology serializers respond to code, system, display, to_coding, status" do
+        serializers = [
           Terminology::ICD10.new("E11.9"),
           Terminology::LOINC.new("2339-0"),
           Terminology::RxNorm.new("197884"),
@@ -177,7 +177,7 @@ module Lakeraven
           Terminology::SNOMED.new("44054006")
         ]
 
-        decorators.each do |d|
+        serializers.each do |d|
           assert_respond_to d, :code
           assert_respond_to d, :system
           assert_respond_to d, :display


### PR DESCRIPTION
## Summary
- Port BDD features for 19 FHIR resource models to `features/fhir/`
- Add cross-cutting BDD features: AuditEvent, terminology serializers, ValueSet audit, clinical alerts, CDS rules, FHIR Bundle import, SMART launch context
- Rename "terminology decorators" to "terminology serializers" throughout
- Migrate final 3 gateways (tribal, practitioner, eligibility) to symbolic API — zero DataMapper references remain in engine code
- 238 new BDD scenarios total

Closes #197

**Resources covered:** Organization, Location, PractitionerRole, CarePlan, CareTeam, Communication, DiagnosticReport, Goal, Procedure, Condition, AllergyIntolerance, MedicationRequest, Observation, Immunization, ServiceRequest, Consent, Coverage, DocumentReference, RelatedPerson, AuditEvent

**Totals:**
- BDD: 614 scenarios (up from 376)
- Minitest: 2,475
- Total: 3,089, all passing

## Test plan
- [x] All 614 BDD scenarios pass
- [x] All 2,475 minitest pass
- [x] Zero DataMapper references in gateway code
- [x] No ambiguous step definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)