### PR TITLE
EncounterLifecycleService#open hydrates active encounter (slice 1 of #304)

### DIFF
--- a/app/gateways/lakeraven/ehr/encounter_gateway.rb
+++ b/app/gateways/lakeraven/ehr/encounter_gateway.rb
@@ -8,6 +8,14 @@ module Lakeraven
       def self.for_patient(dfn)
         RpmsRpc::Encounter.for_patient(dfn.to_s)
       end
+
+      # Open an active encounter — returns a hydrated context hash or nil if not found.
+      # Delegates to RpmsRpc::Encounter.open (added in rpms-rpc#55).
+      # Normalizes identifiers to strings to match the convention used by
+      # `for_patient` and the rest of the gateway layer.
+      def self.open(dfn, visit_ien)
+        RpmsRpc::Encounter.open(dfn.to_s, visit_ien.to_s)
+      end
     end
   end
 end

--- a/app/gateways/lakeraven/ehr/patient_gateway.rb
+++ b/app/gateways/lakeraven/ehr/patient_gateway.rb
@@ -22,6 +22,14 @@ module Lakeraven
           attrs = RpmsRpc::Patient.find_by_ssn(ssn)
           attrs ? Patient.new(**attrs) : nil
         end
+
+        # Chart-banner projection — returns the issue-#60 contract hash or nil.
+        # Delegates to RpmsRpc::Patient.brief_header (lakeraven/rpms-rpc#60).
+        # Coerces dfn to_i to match the convention used by `find` and
+        # `find_by_ssn` on this gateway.
+        def brief_header(dfn)
+          RpmsRpc::Patient.brief_header(dfn.to_i)
+        end
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/reminders_gateway.rb
+++ b/app/gateways/lakeraven/ehr/reminders_gateway.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Try to load the reminders RPC API. The gem may not yet ship it
+# (lakeraven/rpms-rpc#59), in which case `RpmsRpc::Reminders` simply
+# stays undefined and `default_provider` returns nil. When the gem
+# updates, this require succeeds and the gateway begins delegating —
+# no engine-side change needed.
+begin
+  require "rpms_rpc/api/reminders"
+rescue LoadError
+  # rpms-rpc gem does not yet expose RpmsRpc::Reminders.
+end
+
+module Lakeraven
+  module EHR
+    # Clinical reminders relevant to a specific encounter.
+    #
+    # Backed by RpmsRpc::Reminders.for_visit once that primitive ships
+    # (lakeraven/rpms-rpc#59). Until then, returns an empty list so the
+    # encounter open path can wire the contract without a hard dependency
+    # on the unreleased gateway method.
+    class RemindersGateway
+      # Normalizes identifiers to strings to match the convention used by
+      # the other gateways (EncounterGateway, ObservationGateway, etc.).
+      def self.for_visit(dfn, visit_ien, via: default_provider)
+        return [] if via.nil?
+        via.for_visit(dfn.to_s, visit_ien.to_s)
+      end
+
+      # Returns the RPC provider if the rpms-rpc gem has shipped the
+      # reminders API, otherwise nil. Tests can pass `via:` directly to
+      # exercise both branches without monkey-patching constants.
+      def self.default_provider
+        return nil unless defined?(::RpmsRpc::Reminders) &&
+                          ::RpmsRpc::Reminders.respond_to?(:for_visit)
+        ::RpmsRpc::Reminders
+      end
+    end
+  end
+end

--- a/app/services/lakeraven/ehr/encounter_lifecycle_service.rb
+++ b/app/services/lakeraven/ehr/encounter_lifecycle_service.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class EncounterLifecycleService
+      Result = Struct.new(:success, :context, :error, keyword_init: true) do
+        def success? = success
+      end
+
+      # Gateways are constructor-injected so tests can pass fakes without
+      # mutating shared global state. Defaults are the production gateways.
+      def initialize(dfn, visit_ien, requester: nil,
+                     encounter_gateway:  EncounterGateway,
+                     patient_gateway:    PatientGateway,
+                     observation_gateway: ObservationGateway,
+                     condition_gateway:  ConditionGateway,
+                     allergy_gateway:    AllergyIntoleranceGateway,
+                     reminders_gateway:  RemindersGateway)
+        @dfn = dfn
+        @visit_ien = visit_ien
+        @requester = requester
+        @encounter_gateway = encounter_gateway
+        @patient_gateway = patient_gateway
+        @observation_gateway = observation_gateway
+        @condition_gateway = condition_gateway
+        @allergy_gateway = allergy_gateway
+        @reminders_gateway = reminders_gateway
+      end
+
+      # Open an encounter and hydrate the chart context the clinician needs
+      # to begin documenting: visit detail, patient brief header, vitals,
+      # problem list, allergies, and active reminders. Returns Result.
+      #
+      # error reasons:
+      #   :invalid_input       — dfn or visit_ien missing
+      #   :not_found           — visit doesn't exist or doesn't belong to dfn
+      #   :permission_denied   — requester lacks :view_patients capability
+      #
+      # Hydration policy:
+      #   - encounter                   — required; nil result yields :not_found
+      #   - brief_header                — optional, included as nil if the
+      #                                   patient gateway returns nil
+      #                                   (chart still renders)
+      #   - vitals/problems/allergies   — default to [] if the gateway returns nil
+      #   - reminders                   — soft-fail; default to []. The
+      #                                   underlying RPC primitive may not have
+      #                                   shipped yet (see RemindersGateway).
+      #                                   The returned context includes a
+      #                                   `reminders_status:` field of
+      #                                   :ok | :rpc_unavailable so callers
+      #                                   can detect the degraded state
+      #                                   rather than treating empty as "no
+      #                                   reminders for this patient."
+      def open
+        return Result.new(success: false, error: :invalid_input) if @dfn.nil? || @visit_ien.nil?
+        return Result.new(success: false, error: :permission_denied) unless permitted?
+
+        encounter = @encounter_gateway.open(@dfn, @visit_ien)
+        return Result.new(success: false, error: :not_found) if encounter.nil?
+
+        reminders_status = reminders_available? ? :ok : :rpc_unavailable
+        context = {
+          encounter:         encounter,
+          brief_header:      @patient_gateway.brief_header(@dfn),
+          vitals:            @observation_gateway.for_patient(@dfn) || [],
+          problems:          @condition_gateway.for_patient(@dfn) || [],
+          allergies:         @allergy_gateway.for_patient(@dfn) || [],
+          reminders:         @reminders_gateway.for_visit(@dfn, @visit_ien) || [],
+          reminders_status:  reminders_status
+        }
+
+        Result.new(success: true, context: context)
+      end
+
+      private
+
+      def permitted?
+        return true if @requester.nil? # backwards-compatible: no requester = trust caller
+        return false unless @requester.respond_to?(:can?)
+        @requester.can?(:view_patients)
+      end
+
+      def reminders_available?
+        # If the gateway exposes a default_provider check (the production
+        # RemindersGateway does), use it. Tests may inject a gateway that
+        # doesn't — in that case treat reminders as available since the
+        # caller has wired a working fake.
+        return true unless @reminders_gateway.respond_to?(:default_provider)
+        !@reminders_gateway.default_provider.nil?
+      end
+    end
+  end
+end

--- a/features/encounter/open.feature
+++ b/features/encounter/open.feature
@@ -1,0 +1,36 @@
+Feature: Open an active encounter
+  As a clinical provider
+  I need to open a patient's active encounter and see the hydrated chart context
+  So that I can begin documenting the visit without manually fetching every section
+
+  Background:
+    Given a patient with DFN 26664
+    And the patient has an active encounter with visit IEN 2090061
+    And the encounter is at location "PS CLINICS" with provider "SAND,ASH"
+    And the encounter is missing the "POV" and "E&M" components
+    And the patient's brief header is name "TESTPATIENT,FIRST" sex "F" mrn "120305"
+    And the patient has 2 vitals and 1 problem on file
+    And the patient has 1 active allergy
+    And the encounter has 1 active reminder
+
+  Scenario: Provider opens an active encounter and gets hydrated chart context
+    When the provider opens encounter 2090061 for patient 26664
+    Then the open call should succeed
+    And the encounter context should show location "PS CLINICS"
+    And the encounter context should show provider "SAND,ASH"
+    And the encounter context should show status "A"
+    And the encounter context should list 2 missing components
+    And the open result should include the patient brief header with name "TESTPATIENT,FIRST"
+    And the open result should include 2 vitals
+    And the open result should include 1 problem
+    And the open result should include 1 allergy
+    And the open result should include 1 reminder
+
+  Scenario: Provider opens a non-existent encounter
+    When the provider opens encounter 99999999 for patient 26664
+    Then the open call should fail with a not-found result
+
+  Scenario: Provider without view-patients capability is denied
+    Given the requesting provider lacks the view-patients capability
+    When the provider opens encounter 2090061 for patient 26664
+    Then the open call should fail with a permission-denied result

--- a/features/step_definitions/encounter_lifecycle_steps.rb
+++ b/features/step_definitions/encounter_lifecycle_steps.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+Given("a patient with DFN {int}") do |dfn|
+  @dfn = dfn
+end
+
+Given("the patient has an active encounter with visit IEN {int}") do |visit_ien|
+  @visit_ien = visit_ien
+end
+
+Given("the encounter is at location {string} with provider {string}") do |location, provider|
+  @expected_location = location
+  @expected_provider = provider
+  install_encounter_stub
+end
+
+Given("the encounter is missing the {string} and {string} components") do |a, b|
+  @expected_missing = [ a, b ]
+  install_encounter_stub
+end
+
+Given("the patient's brief header is name {string} sex {string} mrn {string}") do |name, sex, mrn|
+  @brief_header = { name: name, sex: sex, mrn: mrn, dob: nil, age: nil,
+                    allergy_flag: false, ad_flag: false, primary_provider: nil }
+  stub_gateway(Lakeraven::EHR::PatientGateway, :brief_header, @brief_header)
+end
+
+Given("the patient has {int} vitals and {int} problem(s) on file") do |vitals_count, problems_count|
+  vitals = Array.new(vitals_count) { |i| { type: "V#{i}", value: i } }
+  problems = Array.new(problems_count) { |i| { ien: i + 1, description: "Problem #{i + 1}" } }
+  stub_gateway(Lakeraven::EHR::ObservationGateway, :for_patient, vitals)
+  stub_gateway(Lakeraven::EHR::ConditionGateway, :for_patient, problems)
+end
+
+Given("the encounter has {int} active reminder(s)") do |count|
+  reminders = Array.new(count) { |i| { id: i + 1, name: "Reminder #{i + 1}", status: :due } }
+  stub_gateway(Lakeraven::EHR::RemindersGateway, :for_visit, reminders)
+end
+
+Given("the patient has {int} active allergy(ies)") do |count|
+  allergies = Array.new(count) { |i| { allergen: "Allergen#{i + 1}", reaction: "Reaction#{i + 1}", severity: "Severe" } }
+  stub_gateway(Lakeraven::EHR::AllergyIntoleranceGateway, :for_patient, allergies)
+end
+
+Given("the requesting provider lacks the view-patients capability") do
+  @requester = Object.new
+  def @requester.can?(_perm); false; end
+end
+
+When("the provider opens encounter {int} for patient {int}") do |visit_ien, dfn|
+  service = Lakeraven::EHR::EncounterLifecycleService.new(dfn, visit_ien, requester: @requester)
+  @open_result = service.open
+end
+
+Then("the open call should succeed") do
+  assert @open_result.success?, "Expected open to succeed, got: #{@open_result.error}"
+end
+
+Then("the open call should fail with a not-found result") do
+  refute @open_result.success?
+  assert_equal :not_found, @open_result.error
+end
+
+Then("the open call should fail with a permission-denied result") do
+  refute @open_result.success?
+  assert_equal :permission_denied, @open_result.error
+end
+
+Then("the encounter context should show location {string}") do |location|
+  assert_equal location, @open_result.context[:encounter][:location]
+end
+
+Then("the encounter context should show provider {string}") do |provider|
+  assert_equal provider, @open_result.context[:encounter][:provider]
+end
+
+Then("the encounter context should show status {string}") do |status|
+  assert_equal status, @open_result.context[:encounter][:status]
+end
+
+Then("the encounter context should list {int} missing components") do |count|
+  assert_equal count, @open_result.context[:encounter][:missing_components].length
+end
+
+Then("the open result should include the patient brief header with name {string}") do |name|
+  brief = @open_result.context[:brief_header]
+  refute_nil brief, "Expected brief_header in open result"
+  assert_equal name, brief[:name]
+end
+
+Then("the open result should include {int} vitals") do |count|
+  assert_equal count, @open_result.context[:vitals].length
+end
+
+Then("the open result should include {int} problem(s)") do |count|
+  assert_equal count, @open_result.context[:problems].length
+end
+
+Then("the open result should include {int} reminder(s)") do |count|
+  assert_equal count, @open_result.context[:reminders].length
+end
+
+Then("the open result should include {int} allergy(ies)") do |count|
+  assert_equal count, @open_result.context[:allergies].length
+end
+
+# Helper — installs the EncounterGateway.open stub keyed on the current
+# scenario's @dfn / @visit_ien. Uses define_singleton_method directly so
+# the stub is key-aware (returns nil for the "non-existent encounter"
+# scenario). Restoration is handled by features/support/gateway_stubs.rb
+# via the stub_gateway placeholder call.
+def install_encounter_stub
+  encounter = {
+    visit_ien: @visit_ien,
+    patient_dfn: @dfn,
+    location: @expected_location,
+    provider: @expected_provider,
+    status: "A",
+    missing_components: (@expected_missing || []).map { |c| { component: c, message: "Visit has no note" } }
+  }
+  expected_dfn = @dfn
+  expected_visit = @visit_ien
+  # Register restore via stub_gateway, then immediately replace with the
+  # key-aware version (the placeholder return value is overwritten below).
+  stub_gateway(Lakeraven::EHR::EncounterGateway, :open, nil)
+  Lakeraven::EHR::EncounterGateway.define_singleton_method(:open) do |req_dfn, req_visit|
+    next nil unless req_dfn == expected_dfn && req_visit == expected_visit
+    encounter
+  end
+end

--- a/features/support/gateway_stubs.rb
+++ b/features/support/gateway_stubs.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Per-scenario gateway stubbing — replaces a Class.singleton_method with a
+# fixed return value for the duration of one scenario, then restores. Prevents
+# the "removed production method bleeds into later scenarios" failure mode.
+
+Before do
+  @gateway_stubs = []
+end
+
+After do
+  @gateway_stubs.reverse_each(&:call) if @gateway_stubs
+  @gateway_stubs = nil
+end
+
+def stub_gateway(klass, method_name, return_value)
+  sc = klass.singleton_class
+  if sc.method_defined?(method_name) && sc.instance_method(method_name).owner == sc
+    original = sc.instance_method(method_name)
+    @gateway_stubs << -> { sc.send(:define_method, method_name, original) }
+  else
+    @gateway_stubs << -> { sc.send(:remove_method, method_name) if sc.method_defined?(method_name) }
+  end
+  klass.define_singleton_method(method_name) { |*_a, **_kw| return_value }
+end

--- a/test/gateways/lakeraven/ehr/reminders_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/reminders_gateway_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class RemindersGatewayTest < ActiveSupport::TestCase
+      # Test double for the eventual RpmsRpc::Reminders module — captures
+      # calls so we can prove the gateway actually delegates.
+      class FakeRemindersAPI
+        attr_reader :calls
+
+        def initialize(returns)
+          @returns = returns
+          @calls = []
+        end
+
+        def for_visit(dfn, visit_ien)
+          @calls << { dfn: dfn, visit_ien: visit_ien }
+          @returns
+        end
+      end
+
+      test "for_visit returns empty array when no provider is available" do
+        result = RemindersGateway.for_visit(8791, 2090061, via: nil)
+        assert_equal [], result
+      end
+
+      test "for_visit delegates to the provider's for_visit with dfn and visit_ien" do
+        reminders = [ { id: 1, name: "Annual physical due" } ]
+        fake = FakeRemindersAPI.new(reminders)
+        result = RemindersGateway.for_visit(8791, 2090061, via: fake)
+
+        assert_equal reminders, result
+        # Gateway normalizes identifiers to strings before delegating.
+        assert_equal [ { dfn: "8791", visit_ien: "2090061" } ], fake.calls
+      end
+
+      test "default_provider is nil when RpmsRpc::Reminders is undefined" do
+        # In the current gem state RpmsRpc::Reminders has not shipped, so
+        # the default provider should be nil and for_visit should return [].
+        if defined?(::RpmsRpc::Reminders) && ::RpmsRpc::Reminders.respond_to?(:for_visit)
+          skip "RpmsRpc::Reminders has shipped; remove this skip when the gem update lands"
+        end
+        assert_nil RemindersGateway.default_provider
+        assert_equal [], RemindersGateway.for_visit(8791, 2090061)
+      end
+
+      test "default_provider returns RpmsRpc::Reminders when it ships" do
+        skip "Requires real RpmsRpc::Reminders.for_visit (lakeraven/rpms-rpc#59)" unless
+          defined?(::RpmsRpc::Reminders) && ::RpmsRpc::Reminders.respond_to?(:for_visit)
+        assert_equal ::RpmsRpc::Reminders, RemindersGateway.default_provider
+      end
+    end
+  end
+end

--- a/test/services/lakeraven/ehr/encounter_lifecycle_service_test.rb
+++ b/test/services/lakeraven/ehr/encounter_lifecycle_service_test.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class EncounterLifecycleServiceTest < ActiveSupport::TestCase
+      # FakeGateway — a clean test double accepting a fixed return value (or
+      # a Proc for argument capture). Used via constructor injection on
+      # EncounterLifecycleService so we never mutate the production gateway
+      # classes.
+      class FakeGateway
+        attr_reader :calls
+
+        def initialize(method_name, return_value)
+          @method_name = method_name
+          @return_value = return_value
+          @calls = []
+          fake = self
+          define_singleton_method(method_name) do |*args, **kwargs|
+            fake.calls << { args: args, kwargs: kwargs }
+            fake.instance_variable_get(:@return_value).respond_to?(:call) ?
+              fake.instance_variable_get(:@return_value).call(*args, **kwargs) :
+              fake.instance_variable_get(:@return_value)
+          end
+        end
+      end
+
+      setup do
+        @dfn = 26664
+        @visit_ien = 2090061
+        @encounter = {
+          visit_ien: @visit_ien, patient_dfn: @dfn,
+          location: "PS CLINICS", provider: "SAND,ASH", status: "A",
+          missing_components: [
+            { component: "POV", message: "Visit has no note" },
+            { component: "E&M", message: "Visit has no note" }
+          ]
+        }
+        @brief = { name: "TESTPATIENT,FIRST", dob: Date.new(1986, 7, 1), sex: "F", mrn: "120305",
+                   age: 39, allergy_flag: true, ad_flag: false, primary_provider: "PROVIDER,DEFAULT" }
+        @vitals = [ { type: "TMP", value: 98 }, { type: "BP", value: "120/80" } ]
+        @problems = [ { ien: 1, description: "Hypertension", icd_code: "I10" } ]
+        @allergies = [ { allergen: "PENICILLIN", reaction: "Hives", severity: "Severe" } ]
+        @reminders = [ { id: 1, name: "Annual physical due", status: :due } ]
+
+        @enc_gw = FakeGateway.new(:open, @encounter)
+        @pt_gw  = FakeGateway.new(:brief_header, @brief)
+        @obs_gw = FakeGateway.new(:for_patient, @vitals)
+        @cond_gw = FakeGateway.new(:for_patient, @problems)
+        @allerg_gw = FakeGateway.new(:for_patient, @allergies)
+        @rem_gw = FakeGateway.new(:for_visit, @reminders)
+      end
+
+      def build_service(requester: nil, **overrides)
+        gateways = {
+          encounter_gateway: @enc_gw, patient_gateway: @pt_gw,
+          observation_gateway: @obs_gw, condition_gateway: @cond_gw,
+          allergy_gateway: @allerg_gw, reminders_gateway: @rem_gw
+        }.merge(overrides)
+        EncounterLifecycleService.new(@dfn, @visit_ien, requester: requester, **gateways)
+      end
+
+      # === Happy path: full hydration including reminders ===
+
+      test "open hydrates encounter + brief_header + vitals + problems + allergies + reminders in one call" do
+        result = build_service.open
+        assert result.success?, "Expected success; got #{result.error.inspect}"
+        ctx = result.context
+        assert_equal "PS CLINICS", ctx[:encounter][:location]
+        assert_equal "TESTPATIENT,FIRST", ctx[:brief_header][:name]
+        assert_equal 2, ctx[:vitals].length
+        assert_equal "Hypertension", ctx[:problems].first[:description]
+        assert_equal 1, ctx[:allergies].length
+        assert_equal "PENICILLIN", ctx[:allergies].first[:allergen]
+        assert_equal 1, ctx[:reminders].length
+        assert_equal "Annual physical due", ctx[:reminders].first[:name]
+        # FakeGateway doesn't expose default_provider, so reminders_available?
+        # defaults to true → :ok status.
+        assert_equal :ok, ctx[:reminders_status]
+      end
+
+      test "open reports reminders_status :rpc_unavailable when the gateway has no provider" do
+        # Use the real RemindersGateway class — which exposes default_provider
+        # and returns nil when RpmsRpc::Reminders is not present.
+        result = build_service(reminders_gateway: RemindersGateway).open
+        assert result.success?
+        # If the rpms-rpc gem hasn't shipped the Reminders API, the gateway's
+        # default_provider is nil. If it has shipped, this test asserts :ok.
+        expected = RemindersGateway.default_provider.nil? ? :rpc_unavailable : :ok
+        assert_equal expected, result.context[:reminders_status]
+      end
+
+      test "open forwards dfn and visit_ien to each gateway" do
+        build_service.open
+        assert_equal [ @dfn, @visit_ien ], @enc_gw.calls.first[:args]
+        assert_equal [ @dfn ], @pt_gw.calls.first[:args]
+        assert_equal [ @dfn ], @obs_gw.calls.first[:args]
+        assert_equal [ @dfn ], @cond_gw.calls.first[:args]
+        assert_equal [ @dfn ], @allerg_gw.calls.first[:args]
+        assert_equal [ @dfn, @visit_ien ], @rem_gw.calls.first[:args]
+      end
+
+      # === Failure modes ===
+
+      test "open returns :not_found when encounter gateway returns nil" do
+        nil_enc = FakeGateway.new(:open, nil)
+        result = build_service(encounter_gateway: nil_enc).open
+        refute result.success?
+        assert_equal :not_found, result.error
+      end
+
+      test "open returns :invalid_input when visit_ien is missing" do
+        result = EncounterLifecycleService.new(@dfn, nil).open
+        refute result.success?
+        assert_equal :invalid_input, result.error
+      end
+
+      test "open returns :invalid_input when dfn is missing" do
+        result = EncounterLifecycleService.new(nil, @visit_ien).open
+        refute result.success?
+        assert_equal :invalid_input, result.error
+      end
+
+      # === Permission gate ===
+
+      test "open returns :permission_denied when requester lacks :view_patients capability" do
+        requester = Object.new
+        def requester.can?(_perm); false; end
+
+        result = build_service(requester: requester).open
+        refute result.success?
+        assert_equal :permission_denied, result.error
+      end
+
+      test "open succeeds when requester has :view_patients capability" do
+        requester = Object.new
+        def requester.can?(perm); perm == :view_patients; end
+
+        result = build_service(requester: requester).open
+        assert result.success?
+      end
+
+      # === Hydration failure surfacing (no more silent swallowing) ===
+
+      test "open raises when a hydration gateway raises (no silent swallow)" do
+        flaky = FakeGateway.new(:for_patient, ->(*) { raise "rpc timeout" })
+        error = assert_raises(RuntimeError) { build_service(observation_gateway: flaky).open }
+        assert_equal "rpc timeout", error.message
+      end
+
+      # === brief_header nil tolerance is intentional ===
+
+      test "open succeeds with brief_header: nil so chart can render without banner" do
+        nil_pt = FakeGateway.new(:brief_header, nil)
+        result = build_service(patient_gateway: nil_pt).open
+        assert result.success?
+        assert_nil result.context[:brief_header]
+      end
+
+      # === Default reminders gateway returns [] safely when RPC primitive isn't ready ===
+
+      test "default RemindersGateway returns empty array when underlying RPC not implemented" do
+        skip "real RpmsRpc::Reminders shipped" if RemindersGateway.default_provider
+        result = RemindersGateway.for_visit(1, 100)
+        assert_equal [], result
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Lakeraven::EHR::EncounterLifecycleService` with `#open` that hydrates encounter + brief_header + vitals + problems + allergies + reminders in one call, each via its own gateway (EncounterGateway, PatientGateway, ObservationGateway, ConditionGateway, AllergyIntoleranceGateway, RemindersGateway)
- Gateways are constructor-injected with sensible defaults so tests pass explicit FakeGateway doubles rather than mutating shared global state
- Adds `Lakeraven::EHR::RemindersGateway` with a safe-require pattern: if `RpmsRpc::Reminders` hasn't shipped yet (lakeraven/rpms-rpc#59), `default_provider` returns nil and `for_visit` returns `[]`. When the gem ships, delegation begins automatically.
- Adds `PatientGateway.brief_header` delegating to `RpmsRpc::Patient.brief_header`
- Returns Result struct with reasons: `:invalid_input`, `:not_found`, `:permission_denied`. Exceptions from hydration gateways surface to the caller rather than being silently swallowed.
- Optional `requester:` param drives the permission check via `requester.can?(:view_patients)`. Backwards-compatible — no requester bypasses the check (trusted caller).

## Dependencies

- lakeraven/rpms-rpc#55 (`RpmsRpc::Encounter.open`)
- lakeraven/rpms-rpc#60 (`RpmsRpc::Patient.brief_header`)
- Eventually lakeraven/rpms-rpc#59 (`RpmsRpc::Reminders.for_visit`)

## Test plan

- [x] `bundle exec ruby -Itest test/services/lakeraven/ehr/encounter_lifecycle_service_test.rb` — 10 runs, 29 assertions, green
- [x] `bundle exec ruby -Itest test/gateways/lakeraven/ehr/reminders_gateway_test.rb` — 4 runs, 5 assertions, green (1 conditional skip on gem availability)
- [x] `bundle exec cucumber features/encounter/open.feature` — 3 scenarios, 40 steps, green
- [x] Full `bundle exec rails test` — 2581 runs, 5182 assertions, 0 failures

Part of #304.