### PR TITLE
VitalsEntryService bulk save (stacked on #312)

### DIFF
--- a/app/gateways/lakeraven/ehr/vital_gateway.rb
+++ b/app/gateways/lakeraven/ehr/vital_gateway.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rpms_rpc/api/vital"
+
+module Lakeraven
+  module EHR
+    # Write-side gateway for vital signs (template lookup, per-field
+    # validation, bulk save). For reading existing vitals, callers should
+    # use ObservationGateway.for_patient — kept as the single read entry
+    # point to avoid two gateways exposing the same delegation.
+    class VitalGateway
+      # Field metadata for the vital-entry grid at a location.
+      # Delegates to RpmsRpc::Vital.template (added in lakeraven/rpms-rpc#61).
+      def self.template(location_ien)
+        RpmsRpc::Vital.template(location_ien)
+      end
+
+      # Per-field server validation. Returns
+      #   { valid: bool, errors: [{ index:, abbreviation:, value:, error_message: }] }
+      # Delegates to RpmsRpc::Vital.validate.
+      def self.validate(dfn, measurements)
+        RpmsRpc::Vital.validate(dfn, measurements)
+      end
+
+      # Bulk save of measurements against an open visit. provider_duz is
+      # required (matches the underlying RPC contract).
+      # Delegates to RpmsRpc::Vital.add.
+      def self.add(dfn, visit_string, measurements, provider_duz:)
+        RpmsRpc::Vital.add(dfn, visit_string, measurements, provider_duz: provider_duz)
+      end
+    end
+  end
+end

--- a/app/services/lakeraven/ehr/vitals_entry_service.rb
+++ b/app/services/lakeraven/ehr/vitals_entry_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Lakeraven
+  module EHR
+    class VitalsEntryService
+      Result = Struct.new(:success, :measurements, :error, :raw, keyword_init: true) do
+        def success? = success
+      end
+
+      # Gateway is constructor-injected so tests can pass an explicit fake
+      # without mutating shared global state. Default is the production gateway.
+      def initialize(dfn:, visit_string:, measurements:, provider_duz: nil,
+                     gateway: VitalGateway)
+        @dfn = dfn
+        @visit_string = visit_string
+        @measurements = measurements || []
+        @provider_duz = provider_duz
+        @gateway = gateway
+      end
+
+      def save
+        return failure(:invalid_input) if @dfn.nil? || @visit_string.nil?
+        return failure(:no_measurements) if @measurements.empty?
+
+        raw = @gateway.add(@dfn, @visit_string, @measurements, provider_duz: @provider_duz)
+        # Guard against gateway returning nil or a non-hash — surface as
+        # :gateway_error rather than NoMethodError on raw[:success].
+        return failure(:gateway_error, raw: raw) unless raw.is_a?(Hash) && raw[:success]
+
+        # The underlying RPC does not return per-measurement IENs in its
+        # response; the engine treats @measurements (what it submitted and
+        # the gateway confirmed saved via success=true) as the canonical
+        # record of what was recorded.
+        Result.new(success: true, measurements: @measurements, raw: raw)
+      end
+
+      private
+
+      def failure(reason, raw: nil)
+        Result.new(success: false, measurements: [], error: reason, raw: raw)
+      end
+    end
+  end
+end

--- a/features/encounter/vitals_entry.feature
+++ b/features/encounter/vitals_entry.feature
@@ -1,0 +1,28 @@
+Feature: Enter a set of vitals on an open encounter
+  As a clinical provider
+  I need to record vital signs against the patient's open visit
+  So that the encounter has complete clinical documentation
+
+  Background:
+    Given a patient with DFN 8791
+    And an open encounter "492;3260514.09;A;2090059" at location 349
+
+  Scenario: Provider saves a complete vitals set
+    When the provider enters the following vitals:
+      | abbreviation | value   | units |
+      | TMP          | 97      | F     |
+      | PU           | 80      | /min  |
+      | BP           | 130/90  | mmHg  |
+    Then the vitals save should succeed
+    And 3 measurements should be recorded
+    And the gateway should receive a save with 3 measurements
+
+  Scenario: Provider tries to save an empty vitals set
+    When the provider enters no vitals
+    Then the vitals save should fail with :no_measurements
+
+  Scenario: Provider tries to save without a visit
+    When the provider enters the following vitals without a visit context:
+      | abbreviation | value | units |
+      | TMP          | 98    | F     |
+    Then the vitals save should fail with :invalid_input

--- a/features/step_definitions/vitals_entry_steps.rb
+++ b/features/step_definitions/vitals_entry_steps.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# FakeVitalGateway — scenario-scoped, captures calls, returns a fixed
+# success result by default. Passed into VitalsEntryService via the
+# constructor so production VitalGateway is never touched.
+class FakeVitalGateway
+  attr_reader :calls
+
+  def initialize(return_value = { success: true, raw: "0" })
+    @return_value = return_value
+    @calls = []
+  end
+
+  def add(*args, **kwargs)
+    @calls << { args: args, kwargs: kwargs }
+    @return_value
+  end
+end
+
+Given("an open encounter {string} at location {int}") do |visit_string, location_ien|
+  @visit_string = visit_string
+  @location_ien = location_ien
+  @vital_gateway = FakeVitalGateway.new
+end
+
+When("the provider enters the following vitals:") do |table|
+  measurements = table.hashes.map do |row|
+    { abbreviation: row["abbreviation"], value: row["value"], units: row["units"] }
+  end
+  @vitals_result = Lakeraven::EHR::VitalsEntryService.new(
+    dfn: @dfn,
+    visit_string: @visit_string,
+    measurements: measurements,
+    provider_duz: 2843,
+    gateway: @vital_gateway
+  ).save
+end
+
+When("the provider enters no vitals") do
+  @vitals_result = Lakeraven::EHR::VitalsEntryService.new(
+    dfn: @dfn,
+    visit_string: @visit_string,
+    measurements: [],
+    provider_duz: 2843,
+    gateway: @vital_gateway
+  ).save
+end
+
+When("the provider enters the following vitals without a visit context:") do |table|
+  measurements = table.hashes.map do |row|
+    { abbreviation: row["abbreviation"], value: row["value"], units: row["units"] }
+  end
+  @vitals_result = Lakeraven::EHR::VitalsEntryService.new(
+    dfn: @dfn,
+    visit_string: nil,
+    measurements: measurements,
+    provider_duz: 2843,
+    gateway: @vital_gateway
+  ).save
+end
+
+Then("the vitals save should succeed") do
+  assert @vitals_result.success?, "Expected success; got #{@vitals_result.error.inspect}"
+end
+
+Then("the vitals save should fail with {symbol}") do |error_symbol|
+  refute @vitals_result.success?
+  assert_equal error_symbol, @vitals_result.error
+end
+
+Then("{int} measurements should be recorded") do |count|
+  assert_equal count, @vitals_result.measurements.length
+end
+
+Then("the gateway should receive a save with {int} measurements") do |count|
+  call = @vital_gateway.calls.first
+  refute_nil call
+  assert_equal count, call[:args][2].length
+end

--- a/features/support/parameter_types.rb
+++ b/features/support/parameter_types.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+ParameterType(
+  name: "symbol",
+  regexp: /:\w+/,
+  transformer: ->(s) { s[1..].to_sym }
+)

--- a/test/services/lakeraven/ehr/vitals_entry_service_test.rb
+++ b/test/services/lakeraven/ehr/vitals_entry_service_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Lakeraven
+  module EHR
+    class VitalsEntryServiceTest < ActiveSupport::TestCase
+      # FakeGateway — a clean test double that captures every call and
+      # returns a fixed value (or invokes a Proc with the captured args).
+      # Injected via constructor on VitalsEntryService, so the production
+      # VitalGateway class is never mutated.
+      class FakeGateway
+        attr_reader :calls
+
+        def initialize(return_value)
+          @return_value = return_value
+          @calls = []
+        end
+
+        def add(*args, **kwargs)
+          @calls << { args: args, kwargs: kwargs }
+          @return_value.respond_to?(:call) ? @return_value.call(*args, **kwargs) : @return_value
+        end
+      end
+
+      setup do
+        @dfn = 8791
+        @visit_string = "492;3260514.09;A;2090059"
+        @provider_duz = 2843
+        @measurements = [
+          { abbreviation: "TMP", value: 97,       units: "F" },
+          { abbreviation: "PU",  value: 80,       units: "/min" },
+          { abbreviation: "BP",  value: "130/90", units: "mmHg" }
+        ]
+      end
+
+      def build_service(measurements, gateway:, visit_string: @visit_string, dfn: @dfn)
+        VitalsEntryService.new(
+          dfn: dfn, visit_string: visit_string,
+          measurements: measurements, provider_duz: @provider_duz,
+          gateway: gateway
+        )
+      end
+
+      # === Happy path ===
+
+      test "save succeeds with hydrated measurements when gateway returns success" do
+        gw = FakeGateway.new({ success: true, raw: "0" })
+        result = build_service(@measurements, gateway: gw).save
+        assert result.success?, "Expected success; got #{result.error.inspect}"
+        assert_equal 3, result.measurements.length
+      end
+
+      test "save forwards dfn, visit_string, measurements, and provider_duz to the gateway" do
+        gw = FakeGateway.new({ success: true })
+        build_service(@measurements, gateway: gw).save
+        call = gw.calls.first
+        refute_nil call
+        assert_equal @dfn,          call[:args][0]
+        assert_equal @visit_string, call[:args][1]
+        assert_equal @measurements, call[:args][2]
+        assert_equal @provider_duz, call[:kwargs][:provider_duz]
+      end
+
+      # === Validation failures ===
+
+      test "save fails with :no_measurements when measurements is empty" do
+        result = build_service([], gateway: FakeGateway.new({ success: true })).save
+        refute result.success?
+        assert_equal :no_measurements, result.error
+      end
+
+      test "save fails with :invalid_input when visit_string is missing" do
+        result = build_service(@measurements, gateway: FakeGateway.new({ success: true }), visit_string: nil).save
+        refute result.success?
+        assert_equal :invalid_input, result.error
+      end
+
+      test "save fails with :invalid_input when dfn is missing" do
+        result = build_service(@measurements, gateway: FakeGateway.new({ success: true }), dfn: nil).save
+        refute result.success?
+        assert_equal :invalid_input, result.error
+      end
+
+      # === Gateway error surfacing ===
+
+      test "save fails with :gateway_error when gateway returns success=false" do
+        gw = FakeGateway.new({ success: false, raw: "1^bad request" })
+        result = build_service(@measurements, gateway: gw).save
+        refute result.success?
+        assert_equal :gateway_error, result.error
+      end
+
+      test "save fails with :gateway_error when gateway returns nil instead of raising" do
+        gw = FakeGateway.new(nil)
+        result = build_service(@measurements, gateway: gw).save
+        refute result.success?
+        assert_equal :gateway_error, result.error
+      end
+
+      test "save fails with :gateway_error when gateway returns a non-hash" do
+        gw = FakeGateway.new("0")
+        result = build_service(@measurements, gateway: gw).save
+        refute result.success?
+        assert_equal :gateway_error, result.error
+      end
+
+      # === Production VitalGateway is never mutated by tests ===
+
+      test "constructor-injected gateway means production VitalGateway is untouched" do
+        assert VitalGateway.respond_to?(:add)
+        original_owner = VitalGateway.singleton_class.instance_method(:add).owner
+        build_service(@measurements, gateway: FakeGateway.new({ success: true })).save
+        assert_equal original_owner, VitalGateway.singleton_class.instance_method(:add).owner,
+                     "VitalGateway.add ownership must not change"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Lakeraven::EHR::VitalGateway` (`template`, `validate`, `add`) wrapping the new `RpmsRpc::Vital` write-side API
- Adds `Lakeraven::EHR::VitalsEntryService` taking `{dfn, visit_string, measurements, provider_duz, gateway:}` and returning a Result struct with reasons (`:invalid_input`, `:no_measurements`, `:gateway_error`) or success
- Gateway is constructor-injected with a sensible default (`VitalGateway`); tests pass an explicit FakeGateway that captures every call
- Guards against nil/non-hash gateway returns — surfaces as `:gateway_error` instead of raising
- Adds `features/support/parameter_types.rb` defining a reusable `{symbol}` parameter type for failure-mode step assertions

## Dependencies

- Stacked on top of `feature/encounter-lifecycle-open` (PR #312)
- Gateway primitive: lakeraven/rpms-rpc#78 (closes lakeraven/rpms-rpc#61)

## Test plan

- [x] `bundle exec ruby -Itest test/services/lakeraven/ehr/vitals_entry_service_test.rb` — 9 runs, 21 assertions, green
- [x] `bundle exec cucumber features/encounter/vitals_entry.feature` — 3 scenarios, 14 steps, green (includes a "gateway should receive" assertion that proves argument forwarding)
- [x] Full `bundle exec rails test` — green

Closes #314.