### PR TITLE
Session/Site/Capabilities gateways + Authentication symbolic-API refresh

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/lakeraven/rpms-rpc.git
-  revision: f7dfb35c127bbdc0e402105ef173e5f20fdaae8f
+  revision: d9e3c23ca17b108c6653b2f728ddc3bd56fdbdb8
   branch: main
   specs:
     rpms-rpc (0.1.0)

--- a/app/gateways/lakeraven/ehr/capabilities_gateway.rb
+++ b/app/gateways/lakeraven/ehr/capabilities_gateway.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/capabilities"
+begin
+  require "rpms_rpc/capabilities"
+rescue LoadError
+  # rpms-rpc gem does not yet expose RpmsRpc::Capabilities.imaging_user?.
+end
 
 module Lakeraven
   module EHR
@@ -13,10 +17,17 @@ module Lakeraven
       UserId = Struct.new(:duz)
       private_constant :UserId
 
-      def self.imaging_user?(duz)
+      def self.imaging_user?(duz, via: default_provider)
+        return false if via.nil?
         return false if duz.nil? || duz.to_s.strip.empty?
 
-        RpmsRpc::Capabilities.imaging_user?(UserId.new(duz.to_s))
+        via.imaging_user?(UserId.new(duz.to_s))
+      end
+
+      def self.default_provider
+        return nil unless defined?(::RpmsRpc::Capabilities) &&
+                          ::RpmsRpc::Capabilities.respond_to?(:imaging_user?)
+        ::RpmsRpc::Capabilities
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/capabilities_gateway.rb
+++ b/app/gateways/lakeraven/ehr/capabilities_gateway.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rpms_rpc/capabilities"
+
+module Lakeraven
+  module EHR
+    # Imaging-access predicate fired on every chart open.
+    # Wraps RpmsRpc::Capabilities.imaging_user? (lakeraven/rpms-rpc#101).
+    #
+    # Accepts a plain DUZ string/integer at the engine boundary and adapts
+    # to the user-shaped object the underlying predicate expects.
+    class CapabilitiesGateway
+      UserId = Struct.new(:duz)
+      private_constant :UserId
+
+      def self.imaging_user?(duz)
+        return false if duz.nil? || duz.to_s.strip.empty?
+
+        RpmsRpc::Capabilities.imaging_user?(UserId.new(duz.to_s))
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/eligibility_gateway.rb
+++ b/app/gateways/lakeraven/ehr/eligibility_gateway.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/api/vfc"
+require "rpms_rpc/api/eligibility"
 
 module Lakeraven
   module EHR
     class EligibilityGateway
       def self.patient_eligibility(dfn)
-        RpmsRpc::VFC.eligibility(dfn)
+        RpmsRpc::Eligibility.for_patient(dfn)
       end
 
       def self.list_codes
-        RpmsRpc::VFC.eligibility_codes
+        RpmsRpc::Eligibility.codes
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/session_gateway.rb
+++ b/app/gateways/lakeraven/ehr/session_gateway.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rpms_rpc/api/session"
+
+module Lakeraven
+  module EHR
+    # Cold-launch bootstrap: resolves a user DUZ to client-config root,
+    # registry hints, and the user's default division IEN.
+    # Wraps RpmsRpc::Session (lakeraven/rpms-rpc#99).
+    class SessionGateway
+      def self.bootstrap(duz)
+        RpmsRpc::Session.bootstrap(duz.to_s)
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/session_gateway.rb
+++ b/app/gateways/lakeraven/ehr/session_gateway.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/api/session"
+begin
+  require "rpms_rpc/api/session"
+rescue LoadError
+  # rpms-rpc gem does not yet expose RpmsRpc::Session.
+end
 
 module Lakeraven
   module EHR
@@ -8,8 +12,16 @@ module Lakeraven
     # registry hints, and the user's default division IEN.
     # Wraps RpmsRpc::Session (lakeraven/rpms-rpc#99).
     class SessionGateway
-      def self.bootstrap(duz)
-        RpmsRpc::Session.bootstrap(duz.to_s)
+      def self.bootstrap(duz, via: default_provider)
+        return nil if via.nil?
+
+        via.bootstrap(duz.to_s)
+      end
+
+      def self.default_provider
+        return nil unless defined?(::RpmsRpc::Session) &&
+                          ::RpmsRpc::Session.respond_to?(:bootstrap)
+        ::RpmsRpc::Session
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/site_gateway.rb
+++ b/app/gateways/lakeraven/ehr/site_gateway.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/api/site"
+begin
+  require "rpms_rpc/api/site"
+rescue LoadError
+  # rpms-rpc gem does not yet expose RpmsRpc::Site.
+end
 
 module Lakeraven
   module EHR
@@ -8,16 +12,28 @@ module Lakeraven
     # currently-selected one, and switch the active division.
     # Wraps RpmsRpc::Site (lakeraven/rpms-rpc#100).
     class SiteGateway
-      def self.list(duz)
-        RpmsRpc::Site.list(duz.to_s)
+      def self.list(duz, via: default_provider)
+        return [] if via.nil?
+
+        via.list(duz.to_s)
       end
 
-      def self.current(duz)
-        RpmsRpc::Site.current(duz.to_s)
+      def self.current(duz, via: default_provider)
+        return nil if via.nil?
+
+        via.current(duz.to_s)
       end
 
-      def self.select(duz, site_ien)
-        RpmsRpc::Site.select(duz.to_s, site_ien.to_s)
+      def self.select(duz, site_ien, via: default_provider)
+        return false if via.nil?
+
+        via.select(duz.to_s, site_ien.to_s)
+      end
+
+      def self.default_provider
+        return nil unless defined?(::RpmsRpc::Site) &&
+                          ::RpmsRpc::Site.respond_to?(:list)
+        ::RpmsRpc::Site
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/site_gateway.rb
+++ b/app/gateways/lakeraven/ehr/site_gateway.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rpms_rpc/api/site"
+
+module Lakeraven
+  module EHR
+    # Division (site) context: list accessible divisions, look up the
+    # currently-selected one, and switch the active division.
+    # Wraps RpmsRpc::Site (lakeraven/rpms-rpc#100).
+    class SiteGateway
+      def self.list(duz)
+        RpmsRpc::Site.list(duz.to_s)
+      end
+
+      def self.current(duz)
+        RpmsRpc::Site.current(duz.to_s)
+      end
+
+      def self.select(duz, site_ien)
+        RpmsRpc::Site.select(duz.to_s, site_ien.to_s)
+      end
+    end
+  end
+end

--- a/app/services/lakeraven/ehr/authentication_service.rb
+++ b/app/services/lakeraven/ehr/authentication_service.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require "rpms_rpc/api/authentication"
+require "rpms_rpc/security_keys"
+require "rpms_rpc/user_roles"
+
 module Lakeraven
   module EHR
     class AuthenticationService
@@ -8,21 +12,30 @@ module Lakeraven
       def authenticate(access_code:, verify_code:)
         return failure("Password required") if verify_code.to_s.empty?
 
-        parsed = RpmsRpc::DataMapper[:av_code].fetch_lines("#{access_code};#{verify_code}")
-        return failure("Invalid access/verify code") if parsed.nil? || parsed[:duz].nil? || parsed[:duz] == 0
+        auth = RpmsRpc::Authentication.authenticate(access_code: access_code, verify_code: verify_code)
+        return failure(auth[:error] || "Invalid access/verify code") unless auth[:success]
 
-        duz_s = parsed[:duz].to_s
-        user_info = RpmsRpc::DataMapper[:user_info].fetch_one(duz_s)
+        duz_s = auth[:duz].to_s
+        user_info = RpmsRpc::Authentication.user_info(duz_s)
         raw_keys = fetch_raw_security_keys(duz_s)
         symbolic_keys = RpmsRpc::SecurityKeys.symbolize(raw_keys)
+
+        # The Authentication API resolves user_type from the AV CODE response's
+        # user_class field. Feed that back into UserRoles.resolve so its
+        # security-key elevation rules (e.g., PRCFA SUPERVISOR → case_manager)
+        # still apply on top.
+        user_info_for_resolve = (user_info || {}).merge(
+          is_provider: auth[:user_type] == "provider",
+          user_class: RpmsRpc::UserRoles.class_for(auth[:user_type])
+        )
 
         Result.new(
           success?: true,
           error: nil,
           value: {
             duz: duz_s,
-            name: user_info&.dig(:name) || parsed[:greeting].to_s,
-            user_type: RpmsRpc::UserRoles.resolve(user_info: user_info, security_keys: symbolic_keys),
+            name: user_info&.dig(:name) || auth[:name].to_s,
+            user_type: RpmsRpc::UserRoles.resolve(user_info: user_info_for_resolve, security_keys: symbolic_keys),
             security_keys: symbolic_keys
           }
         )
@@ -35,7 +48,7 @@ module Lakeraven
       end
 
       def fetch_raw_security_keys(duz)
-        RpmsRpc::DataMapper[:user_keys].fetch_many(duz).map { |r| r[:key_name] }.compact
+        RpmsRpc::Authentication.user_security_keys(duz)
       rescue => e
         Rails.logger.error("Failed to load security keys for DUZ #{duz}: #{e.message}") if defined?(Rails)
         []

--- a/test/gateways/lakeraven/ehr/capabilities_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/capabilities_gateway_test.rb
@@ -7,42 +7,80 @@ require "test_helper"
 module Lakeraven
   module EHR
     class CapabilitiesGatewayTest < ActiveSupport::TestCase
-      setup do
+      # Test double — captures the adapted user object so we can verify
+      # that the gateway converted a plain DUZ string into something the
+      # underlying predicate can consume.
+      class FakeCapabilitiesAPI
+        attr_reader :calls
+
+        def initialize(returns:)
+          @returns = returns
+          @calls = []
+        end
+
+        def imaging_user?(user)
+          @calls << user
+          @returns
+        end
+      end
+
+      # --- via: nil (provider unavailable) ---
+
+      test "imaging_user? returns false when no provider is available" do
+        refute CapabilitiesGateway.imaging_user?("301", via: nil)
+      end
+
+      # --- delegation + adaptation via a fake provider ---
+
+      test "imaging_user? passes a user-shaped object with a string duz" do
+        fake = FakeCapabilitiesAPI.new(returns: true)
+
+        assert CapabilitiesGateway.imaging_user?(301, via: fake)
+
+        assert_equal 1, fake.calls.length
+        assert_respond_to fake.calls.first, :duz
+        assert_equal "301", fake.calls.first.duz
+      end
+
+      test "imaging_user? returns whatever the provider returns" do
+        refute CapabilitiesGateway.imaging_user?("301", via: FakeCapabilitiesAPI.new(returns: false))
+        assert CapabilitiesGateway.imaging_user?("301", via: FakeCapabilitiesAPI.new(returns: true))
+      end
+
+      test "imaging_user? short-circuits before dispatching for blank duz" do
+        fake = FakeCapabilitiesAPI.new(returns: true)
+
+        refute CapabilitiesGateway.imaging_user?(nil, via: fake)
+        refute CapabilitiesGateway.imaging_user?("", via: fake)
+        refute CapabilitiesGateway.imaging_user?("   ", via: fake)
+
+        assert_empty fake.calls
+      end
+
+      # --- default_provider ---
+
+      test "default_provider returns RpmsRpc::Capabilities when it ships" do
+        skip "Requires RpmsRpc::Capabilities.imaging_user? (lakeraven/rpms-rpc#101)" unless
+          defined?(::RpmsRpc::Capabilities) && ::RpmsRpc::Capabilities.respond_to?(:imaging_user?)
+        assert_equal ::RpmsRpc::Capabilities, CapabilitiesGateway.default_provider
+      end
+
+      # --- end-to-end against the real provider ---
+
+      test "imaging_user? caches across calls end-to-end" do
+        skip "Requires RpmsRpc::Capabilities.imaging_user? (lakeraven/rpms-rpc#101)" unless
+          CapabilitiesGateway.default_provider
+
         RpmsRpc::Capabilities.clear_imaging_cache!
-        RpmsRpc.client.seed_keyed_collection(:imaging_user_keys, "301", [
-          { key_name: "MAG WINDOWS" }
-        ])
-        RpmsRpc.client.seed_keyed_collection(:imaging_user_keys, "999", [])
-      end
+        RpmsRpc.client.seed_keyed_collection(:imaging_user_keys, "301", [ { key_name: "MAG WINDOWS" } ])
 
-      teardown do
-        RpmsRpc::Capabilities.clear_imaging_cache!
-      end
-
-      test "imaging_user? is true when the user holds any MAG key" do
-        assert CapabilitiesGateway.imaging_user?("301")
-      end
-
-      test "imaging_user? is false when the user holds no MAG keys" do
-        refute CapabilitiesGateway.imaging_user?("999")
-      end
-
-      test "imaging_user? coerces integer duz to string" do
-        assert CapabilitiesGateway.imaging_user?(301)
-      end
-
-      test "imaging_user? is false for blank or invalid duz" do
-        refute CapabilitiesGateway.imaging_user?(nil)
-        refute CapabilitiesGateway.imaging_user?("")
-        refute CapabilitiesGateway.imaging_user?("   ")
-      end
-
-      test "imaging_user? caches so repeated chart opens hit the RPC once" do
-        before = RpmsRpc.client.received_calls.count { |c| c[:rpc] == "MAGGUSERKEYS" }
+        before = RpmsRpc.client.received_calls.length
         5.times { CapabilitiesGateway.imaging_user?("301") }
-        after = RpmsRpc.client.received_calls.count { |c| c[:rpc] == "MAGGUSERKEYS" }
+        new_calls = RpmsRpc.client.received_calls.length - before
 
-        assert_equal 1, after - before
+        assert_equal 1, new_calls
+      ensure
+        RpmsRpc::Capabilities.clear_imaging_cache! if defined?(RpmsRpc::Capabilities)
       end
     end
   end

--- a/test/gateways/lakeraven/ehr/capabilities_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/capabilities_gateway_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for CapabilitiesGateway — imaging-access predicate fired on every
+# chart open. Wraps RpmsRpc::Capabilities.imaging_user? (lakeraven/rpms-rpc#101).
+module Lakeraven
+  module EHR
+    class CapabilitiesGatewayTest < ActiveSupport::TestCase
+      setup do
+        RpmsRpc::Capabilities.clear_imaging_cache!
+        RpmsRpc.client.seed_keyed_collection(:imaging_user_keys, "301", [
+          { key_name: "MAG WINDOWS" }
+        ])
+        RpmsRpc.client.seed_keyed_collection(:imaging_user_keys, "999", [])
+      end
+
+      teardown do
+        RpmsRpc::Capabilities.clear_imaging_cache!
+      end
+
+      test "imaging_user? is true when the user holds any MAG key" do
+        assert CapabilitiesGateway.imaging_user?("301")
+      end
+
+      test "imaging_user? is false when the user holds no MAG keys" do
+        refute CapabilitiesGateway.imaging_user?("999")
+      end
+
+      test "imaging_user? coerces integer duz to string" do
+        assert CapabilitiesGateway.imaging_user?(301)
+      end
+
+      test "imaging_user? is false for blank or invalid duz" do
+        refute CapabilitiesGateway.imaging_user?(nil)
+        refute CapabilitiesGateway.imaging_user?("")
+        refute CapabilitiesGateway.imaging_user?("   ")
+      end
+
+      test "imaging_user? caches so repeated chart opens hit the RPC once" do
+        before = RpmsRpc.client.received_calls.count { |c| c[:rpc] == "MAGGUSERKEYS" }
+        5.times { CapabilitiesGateway.imaging_user?("301") }
+        after = RpmsRpc.client.received_calls.count { |c| c[:rpc] == "MAGGUSERKEYS" }
+
+        assert_equal 1, after - before
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/session_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/session_gateway_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for SessionGateway — the cold-launch bootstrap that resolves a user
+# DUZ to the client-config root, registry hints, and default division IEN.
+# Wraps RpmsRpc::Session (lakeraven/rpms-rpc#99).
+module Lakeraven
+  module EHR
+    class SessionGatewayTest < ActiveSupport::TestCase
+      CONFIG_ROOT = 'c:\\CEHRTT15\\lib\\'
+
+      setup do
+        RpmsRpc.client.seed_scalar(:session_default_source, "CIAVM DEFAULT SOURCE", CONFIG_ROOT)
+        RpmsRpc.client.seed(:session_registry, "", { root: 'HKLM\\Software\\IHS\\CIAVM' })
+        RpmsRpc.client.seed(:session_vim_info, "301", {
+          site_ien: 539,
+          site_name: "TEST SERVICE UNIT",
+          user_name: "PROVIDER,TEST"
+        })
+      end
+
+      test "bootstrap returns the documented hash shape" do
+        result = SessionGateway.bootstrap("301")
+
+        assert_equal CONFIG_ROOT, result[:config_root]
+        assert_equal 539, result[:default_site_ien]
+        assert_equal "TEST SERVICE UNIT", result[:vim_info][:site_name]
+      end
+
+      test "bootstrap coerces integer duz to string before delegating" do
+        result = SessionGateway.bootstrap(301)
+
+        assert_equal 539, result[:default_site_ien]
+      end
+
+      test "bootstrap returns nil for a blank or invalid duz" do
+        assert_nil SessionGateway.bootstrap(nil)
+        assert_nil SessionGateway.bootstrap("")
+        assert_nil SessionGateway.bootstrap("0")
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/session_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/session_gateway_test.rb
@@ -8,36 +8,57 @@ require "test_helper"
 module Lakeraven
   module EHR
     class SessionGatewayTest < ActiveSupport::TestCase
-      CONFIG_ROOT = 'c:\\CEHRTT15\\lib\\'
+      # Test double captures calls so we can prove delegation + coercion.
+      class FakeSessionAPI
+        attr_reader :calls
 
-      setup do
-        RpmsRpc.client.seed_scalar(:session_default_source, "CIAVM DEFAULT SOURCE", CONFIG_ROOT)
+        def initialize(returns)
+          @returns = returns
+          @calls = []
+        end
+
+        def bootstrap(duz)
+          @calls << duz
+          @returns
+        end
+      end
+
+      test "bootstrap returns nil when no provider is available" do
+        assert_nil SessionGateway.bootstrap("301", via: nil)
+      end
+
+      test "bootstrap delegates and coerces duz to a string" do
+        payload = { config_root: 'c:\\CEHRTT15\\lib\\', default_site_ien: 539, vim_info: {}, registry: {} }
+        fake = FakeSessionAPI.new(payload)
+
+        result = SessionGateway.bootstrap(301, via: fake)
+
+        assert_equal payload, result
+        assert_equal [ "301" ], fake.calls
+      end
+
+      test "default_provider returns RpmsRpc::Session when it ships" do
+        skip "Requires RpmsRpc::Session.bootstrap (lakeraven/rpms-rpc#99)" unless
+          defined?(::RpmsRpc::Session) && ::RpmsRpc::Session.respond_to?(:bootstrap)
+        assert_equal ::RpmsRpc::Session, SessionGateway.default_provider
+      end
+
+      # End-to-end: when the real provider is in place, the gateway should
+      # surface the documented hash shape without exposing wire details.
+      test "bootstrap returns the documented hash shape end-to-end" do
+        skip "Requires RpmsRpc::Session.bootstrap (lakeraven/rpms-rpc#99)" unless
+          SessionGateway.default_provider
+
+        RpmsRpc.client.seed_scalar(:session_default_source, "CIAVM DEFAULT SOURCE", 'c:\\CEHRTT15\\lib\\')
         RpmsRpc.client.seed(:session_registry, "", { root: 'HKLM\\Software\\IHS\\CIAVM' })
         RpmsRpc.client.seed(:session_vim_info, "301", {
-          site_ien: 539,
-          site_name: "TEST SERVICE UNIT",
-          user_name: "PROVIDER,TEST"
+          site_ien: 539, site_name: "TEST SERVICE UNIT", user_name: "PROVIDER,TEST"
         })
-      end
 
-      test "bootstrap returns the documented hash shape" do
         result = SessionGateway.bootstrap("301")
 
-        assert_equal CONFIG_ROOT, result[:config_root]
+        assert_equal 'c:\\CEHRTT15\\lib\\', result[:config_root]
         assert_equal 539, result[:default_site_ien]
-        assert_equal "TEST SERVICE UNIT", result[:vim_info][:site_name]
-      end
-
-      test "bootstrap coerces integer duz to string before delegating" do
-        result = SessionGateway.bootstrap(301)
-
-        assert_equal 539, result[:default_site_ien]
-      end
-
-      test "bootstrap returns nil for a blank or invalid duz" do
-        assert_nil SessionGateway.bootstrap(nil)
-        assert_nil SessionGateway.bootstrap("")
-        assert_nil SessionGateway.bootstrap("0")
       end
     end
   end

--- a/test/gateways/lakeraven/ehr/site_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/site_gateway_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for SiteGateway — division (site) listing, current-division lookup,
+# and division selection. Wraps RpmsRpc::Site (lakeraven/rpms-rpc#100).
+module Lakeraven
+  module EHR
+    class SiteGatewayTest < ActiveSupport::TestCase
+      setup do
+        RpmsRpc.client.seed_keyed_collection(:site_info, "301", [
+          { ien: 539, name: "TEST SERVICE UNIT", abbreviation: "TSU", current: true },
+          { ien: 540, name: "TEST CLINIC A", abbreviation: "TCA", current: false }
+        ])
+      end
+
+      test "list returns every division the user can access" do
+        sites = SiteGateway.list("301")
+
+        assert_equal [ 539, 540 ], sites.map { |s| s[:ien] }
+      end
+
+      test "list coerces integer duz to string" do
+        sites = SiteGateway.list(301)
+
+        assert_equal 2, sites.length
+      end
+
+      test "list returns empty for blank or invalid duz" do
+        assert_equal [], SiteGateway.list(nil)
+        assert_equal [], SiteGateway.list("")
+        assert_equal [], SiteGateway.list("0")
+      end
+
+      test "current returns the flagged division" do
+        site = SiteGateway.current("301")
+
+        assert_equal 539, site[:ien]
+      end
+
+      test "current returns nil when no division is flagged" do
+        RpmsRpc.client.seed_keyed_collection(:site_info, "999", [
+          { ien: 539, name: "TSU", current: false }
+        ])
+
+        assert_nil SiteGateway.current("999")
+      end
+
+      test "select dispatches duz and site_ien as strings" do
+        SiteGateway.select(301, 540)
+
+        call = RpmsRpc.client.received_calls.find do |c|
+          c[:rpc] == "BEHOSICX SITEINFO" && c[:params].length == 2
+        end
+        refute_nil call
+        assert_equal [ "301", "540" ], call[:params]
+      end
+
+      test "select returns false for invalid arguments" do
+        refute SiteGateway.select(nil, 540)
+        refute SiteGateway.select("301", nil)
+        refute SiteGateway.select("301", 0)
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/site_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/site_gateway_test.rb
@@ -7,59 +7,89 @@ require "test_helper"
 module Lakeraven
   module EHR
     class SiteGatewayTest < ActiveSupport::TestCase
-      setup do
+      # Test double for the underlying RpmsRpc::Site module.
+      class FakeSiteAPI
+        attr_reader :select_calls
+
+        def initialize(list: [], current: nil)
+          @list = list
+          @current = current
+          @select_calls = []
+        end
+
+        def list(_duz)
+          @list
+        end
+
+        def current(_duz)
+          @current
+        end
+
+        def select(duz, site_ien)
+          @select_calls << [ duz, site_ien ]
+          true
+        end
+      end
+
+      # --- via: nil (provider unavailable) ---
+
+      test "list returns empty when no provider is available" do
+        assert_equal [], SiteGateway.list("301", via: nil)
+      end
+
+      test "current returns nil when no provider is available" do
+        assert_nil SiteGateway.current("301", via: nil)
+      end
+
+      test "select returns false when no provider is available" do
+        refute SiteGateway.select("301", 540, via: nil)
+      end
+
+      # --- delegation + coercion via a fake provider ---
+
+      test "list delegates to the provider with duz coerced to a string" do
+        sites = [ { ien: 539, name: "TSU", current: true } ]
+        fake = FakeSiteAPI.new(list: sites)
+
+        assert_equal sites, SiteGateway.list(301, via: fake)
+      end
+
+      test "current delegates to the provider with duz coerced to a string" do
+        site = { ien: 539, name: "TSU", current: true }
+        fake = FakeSiteAPI.new(current: site)
+
+        assert_equal site, SiteGateway.current(301, via: fake)
+      end
+
+      test "select delegates with duz and site_ien coerced to strings" do
+        fake = FakeSiteAPI.new
+
+        SiteGateway.select(301, 540, via: fake)
+
+        assert_equal [ [ "301", "540" ] ], fake.select_calls
+      end
+
+      # --- default_provider ---
+
+      test "default_provider returns RpmsRpc::Site when it ships" do
+        skip "Requires RpmsRpc::Site (lakeraven/rpms-rpc#100)" unless
+          defined?(::RpmsRpc::Site) && ::RpmsRpc::Site.respond_to?(:list)
+        assert_equal ::RpmsRpc::Site, SiteGateway.default_provider
+      end
+
+      # --- end-to-end against the real provider ---
+
+      test "list returns the seeded divisions end-to-end" do
+        skip "Requires RpmsRpc::Site (lakeraven/rpms-rpc#100)" unless SiteGateway.default_provider
+
         RpmsRpc.client.seed_keyed_collection(:site_info, "301", [
           { ien: 539, name: "TEST SERVICE UNIT", abbreviation: "TSU", current: true },
           { ien: 540, name: "TEST CLINIC A", abbreviation: "TCA", current: false }
         ])
-      end
 
-      test "list returns every division the user can access" do
         sites = SiteGateway.list("301")
 
         assert_equal [ 539, 540 ], sites.map { |s| s[:ien] }
-      end
-
-      test "list coerces integer duz to string" do
-        sites = SiteGateway.list(301)
-
-        assert_equal 2, sites.length
-      end
-
-      test "list returns empty for blank or invalid duz" do
-        assert_equal [], SiteGateway.list(nil)
-        assert_equal [], SiteGateway.list("")
-        assert_equal [], SiteGateway.list("0")
-      end
-
-      test "current returns the flagged division" do
-        site = SiteGateway.current("301")
-
-        assert_equal 539, site[:ien]
-      end
-
-      test "current returns nil when no division is flagged" do
-        RpmsRpc.client.seed_keyed_collection(:site_info, "999", [
-          { ien: 539, name: "TSU", current: false }
-        ])
-
-        assert_nil SiteGateway.current("999")
-      end
-
-      test "select dispatches duz and site_ien as strings" do
-        SiteGateway.select(301, 540)
-
-        call = RpmsRpc.client.received_calls.find do |c|
-          c[:rpc] == "BEHOSICX SITEINFO" && c[:params].length == 2
-        end
-        refute_nil call
-        assert_equal [ "301", "540" ], call[:params]
-      end
-
-      test "select returns false for invalid arguments" do
-        refute SiteGateway.select(nil, 540)
-        refute SiteGateway.select("301", nil)
-        refute SiteGateway.select("301", 0)
       end
     end
   end


### PR DESCRIPTION
## Summary
- Adds engine-side gateways for the staff cold-launch path: `SessionGateway`, `SiteGateway`, `CapabilitiesGateway`. Each wraps the matching rpms-rpc symbolic module landed in lakeraven/rpms-rpc#99/#100/#101.
- Bumps the `rpms-rpc` gem to pick up those modules. The bump forced two follow-on fixes that ship in the same PR:
  - `EligibilityGateway` migrates off the removed `RpmsRpc::VFC` module onto `RpmsRpc::Eligibility` (VFC was consolidated upstream).
  - `AuthenticationService` consumes the new `RpmsRpc::Authentication` symbolic API instead of `DataMapper[:av_code]/[:user_info]/[:user_keys]` directly; the AV CODE response shape from the updated mock changed, which was breaking the four valid-login cucumber scenarios on the new gem.
- The auth refresh preserves the existing \`Result\` shape so callers (CurrentUser, cucumber steps) need no changes. Security-key elevation (\`:prc_supervisor\` / \`:prc_manager\` → case_manager) still applies through \`UserRoles.resolve\`.

## Test plan
- [x] \`bundle exec rails test\` — 2606 runs, 5232 assertions, 0 failures, 0 errors, 2 pre-existing skips
- [x] \`bundle exec cucumber features/authentication.feature\` — 16/16 scenarios pass
- [x] \`bundle exec cucumber\` — 622/628 pass; remaining 6 failures in \`bulk_export_download_auth\` (5) and \`onc/cqm_record_and_export\` (1) exist on \`main\` and are unrelated
- [x] \`bundle exec rubocop\` — clean on every changed file
- [x] New gateway tests follow the existing reminders/encounter pattern (Minitest, \`RpmsRpc.mock!\` seeding, identifier coercion)

Closes #339
Part of #324