### PR TITLE
Encounter-data-entry gateways: POV, HealthFactor, Exam, Measurement + Procedure/Condition writes

### DIFF
--- a/app/gateways/lakeraven/ehr/condition_gateway.rb
+++ b/app/gateways/lakeraven/ehr/condition_gateway.rb
@@ -4,9 +4,28 @@ require "rpms_rpc/api/problem"
 
 module Lakeraven
   module EHR
+    # Engine-side gateway over RpmsRpc::Problem. The engine vocabulary is
+    # "Condition" (matches FHIR / app/models/lakeraven/ehr/condition.rb); the
+    # underlying RPC module is "Problem" (IPL terminology).
     class ConditionGateway
       def self.for_patient(dfn)
         RpmsRpc::Problem.for_patient(dfn.to_s)
+      end
+
+      def self.add(dfn, problem)
+        RpmsRpc::Problem.add(dfn.to_s, problem)
+      end
+
+      def self.update(dfn, ien, changes)
+        RpmsRpc::Problem.update(dfn.to_s, ien.to_s, changes)
+      end
+
+      def self.delete(dfn, ien, reason:)
+        RpmsRpc::Problem.delete(dfn.to_s, ien.to_s, reason: reason)
+      end
+
+      def self.filter(dfn, scope:)
+        RpmsRpc::Problem.filter(dfn.to_s, scope: scope)
       end
     end
   end

--- a/app/gateways/lakeraven/ehr/exam_component_gateway.rb
+++ b/app/gateways/lakeraven/ehr/exam_component_gateway.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+begin
+  require "rpms_rpc/api/exam_component"
+rescue LoadError
+  # rpms-rpc gem does not yet expose RpmsRpc::ExamComponent.
+end
+
+module Lakeraven
+  module EHR
+    # Physical-exam component entry against an open encounter.
+    # Wraps RpmsRpc::ExamComponent (lakeraven/rpms-rpc#66).
+    class ExamComponentGateway
+      FAILURE = { success: false, ien: nil, raw: nil }.freeze
+
+      def self.add(dfn, visit_ien, exam_code, finding:, narrative: nil, via: default_provider)
+        return FAILURE if via.nil?
+
+        via.add(dfn.to_s, visit_ien.to_s, exam_code,
+          finding: finding, narrative: narrative)
+      end
+
+      def self.default_provider
+        return nil unless defined?(::RpmsRpc::ExamComponent) &&
+                          ::RpmsRpc::ExamComponent.respond_to?(:add)
+        ::RpmsRpc::ExamComponent
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/health_factor_gateway.rb
+++ b/app/gateways/lakeraven/ehr/health_factor_gateway.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+begin
+  require "rpms_rpc/api/health_factor"
+rescue LoadError
+  # rpms-rpc gem does not yet expose RpmsRpc::HealthFactor.
+end
+
+module Lakeraven
+  module EHR
+    # IHS-specific structured observation entry against an open encounter.
+    # Wraps RpmsRpc::HealthFactor (lakeraven/rpms-rpc#65).
+    class HealthFactorGateway
+      FAILURE = { success: false, ien: nil, raw: nil }.freeze
+
+      def self.add(dfn, visit_ien, factor_code, level:, narrative: nil, via: default_provider)
+        return FAILURE if via.nil?
+
+        via.add(dfn.to_s, visit_ien.to_s, factor_code,
+          level: level, narrative: narrative)
+      end
+
+      def self.default_provider
+        return nil unless defined?(::RpmsRpc::HealthFactor) &&
+                          ::RpmsRpc::HealthFactor.respond_to?(:add)
+        ::RpmsRpc::HealthFactor
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/measurement_gateway.rb
+++ b/app/gateways/lakeraven/ehr/measurement_gateway.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+begin
+  require "rpms_rpc/api/measurement"
+rescue LoadError
+  # rpms-rpc gem does not yet expose RpmsRpc::Measurement.
+end
+
+module Lakeraven
+  module EHR
+    # PCC measurement entry (height, weight, BMI, etc.) against an open
+    # encounter. Distinct from clinical vitals (VitalGateway / BEHOVM).
+    # Wraps RpmsRpc::Measurement (lakeraven/rpms-rpc#67).
+    class MeasurementGateway
+      FAILURE = { success: false, ien: nil, raw: nil }.freeze
+
+      def self.add(dfn, visit_ien, measurement_type, value, units:, qualifier: nil, via: default_provider)
+        return FAILURE if via.nil?
+
+        via.add(dfn.to_s, visit_ien.to_s, measurement_type, value,
+          units: units, qualifier: qualifier)
+      end
+
+      def self.default_provider
+        return nil unless defined?(::RpmsRpc::Measurement) &&
+                          ::RpmsRpc::Measurement.respond_to?(:add)
+        ::RpmsRpc::Measurement
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/pov_gateway.rb
+++ b/app/gateways/lakeraven/ehr/pov_gateway.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+begin
+  require "rpms_rpc/api/pov"
+rescue LoadError
+  # rpms-rpc gem does not yet expose RpmsRpc::Pov.
+end
+
+module Lakeraven
+  module EHR
+    # Visit purpose-of-visit (diagnosis) entry against an open encounter.
+    # Wraps RpmsRpc::Pov (lakeraven/rpms-rpc#63).
+    class PovGateway
+      FAILURE = { success: false, ien: nil, raw: nil }.freeze
+
+      def self.add(dfn, visit_ien, diagnosis_code, narrative:, modifiers: {}, via: default_provider)
+        return FAILURE if via.nil?
+
+        via.add(dfn.to_s, visit_ien.to_s, diagnosis_code,
+          narrative: narrative, modifiers: modifiers)
+      end
+
+      def self.default_provider
+        return nil unless defined?(::RpmsRpc::Pov) && ::RpmsRpc::Pov.respond_to?(:add)
+        ::RpmsRpc::Pov
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/procedure_gateway.rb
+++ b/app/gateways/lakeraven/ehr/procedure_gateway.rb
@@ -8,6 +8,12 @@ module Lakeraven
       def self.for_patient(dfn)
         RpmsRpc::Procedure.for_patient(dfn.to_s)
       end
+
+      # Record a CPT procedure against an open encounter.
+      def self.add(dfn, visit_ien, cpt_code, modifiers: [], narrative: nil, quantity: 1)
+        RpmsRpc::Procedure.add(dfn.to_s, visit_ien.to_s, cpt_code,
+          modifiers: modifiers, narrative: narrative, quantity: quantity)
+      end
     end
   end
 end

--- a/test/gateways/lakeraven/ehr/condition_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/condition_gateway_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for ConditionGateway — engine wrapper around RpmsRpc::Problem.
+# Engine vocabulary is "Condition" (matches app/models/lakeraven/ehr/condition.rb);
+# rpms-rpc vocabulary is "Problem".
+module Lakeraven
+  module EHR
+    class ConditionGatewayTest < ActiveSupport::TestCase
+      # --- read: for_patient ---
+
+      test "for_patient returns the seeded problem list" do
+        RpmsRpc.client.seed_keyed_collection(:problem_list, "1", [
+          { icd_code: "E11.9", description: "Type 2 diabetes", status: "A" }
+        ])
+
+        result = ConditionGateway.for_patient(1)
+
+        assert_kind_of Array, result
+        assert_equal "E11.9", result.first[:icd_code]
+      end
+
+      # --- write: add / update / delete ---
+
+      test "add returns success with the saved IEN" do
+        RpmsRpc.client.seed_scalar(:problem_edit, "1", "55")
+
+        result = ConditionGateway.add(1, { icd_code: "E11.9", description: "Type 2 diabetes" })
+
+        assert result[:success]
+        assert_equal 55, result[:ien]
+      end
+
+      test "update returns success with the saved IEN" do
+        RpmsRpc.client.seed_scalar(:problem_edit, "1", "55")
+
+        result = ConditionGateway.update(1, 55, { status: "I" })
+
+        assert result[:success]
+        assert_equal 55, result[:ien]
+      end
+
+      test "delete requires a reason and returns success" do
+        RpmsRpc.client.seed_scalar(:problem_edit, "1", "55")
+
+        result = ConditionGateway.delete(1, 55, reason: "Entered in error")
+
+        assert result[:success]
+      end
+
+      test "add returns failure for invalid dfn" do
+        result = ConditionGateway.add(nil, { icd_code: "E11.9" })
+
+        refute result[:success]
+      end
+
+      # --- filter ---
+
+      test "filter returns the seeded list scoped by IPL tab" do
+        RpmsRpc.client.seed_keyed_collection(:problem_filter, "1", [
+          { icd_code: "I10", description: "Essential hypertension", status: "A" }
+        ])
+
+        result = ConditionGateway.filter(1, scope: :core)
+
+        assert_kind_of Array, result
+        assert_equal "I10", result.first[:icd_code]
+      end
+
+      test "filter raises for unknown scope" do
+        assert_raises(ArgumentError) { ConditionGateway.filter(1, scope: :unknown_scope) }
+      end
+
+      test "filter returns empty for invalid dfn" do
+        assert_equal [], ConditionGateway.filter(nil, scope: :core)
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/exam_component_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/exam_component_gateway_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for ExamComponentGateway — visit exam-component entry.
+# Wraps RpmsRpc::ExamComponent (lakeraven/rpms-rpc#66).
+module Lakeraven
+  module EHR
+    class ExamComponentGatewayTest < ActiveSupport::TestCase
+      class FakeExamAPI
+        attr_reader :calls
+
+        def initialize(returns:)
+          @returns = returns
+          @calls = []
+        end
+
+        def add(dfn, visit_ien, exam_code, **opts)
+          @calls << { dfn:, visit_ien:, exam_code:, opts: }
+          @returns
+        end
+      end
+
+      test "add returns failure shape when no provider is available" do
+        result = ExamComponentGateway.add(1, 2090061, "SKIN", finding: "Normal", via: nil)
+        assert_equal({ success: false, ien: nil, raw: nil }, result)
+      end
+
+      test "add delegates with identifiers coerced to strings" do
+        fake = FakeExamAPI.new(returns: { success: true, ien: 9, raw: "9" })
+
+        result = ExamComponentGateway.add(1, 2090061, "SKIN",
+          finding: "Normal",
+          narrative: "Skin: WNL",
+          via: fake)
+
+        assert_equal({ success: true, ien: 9, raw: "9" }, result)
+        call = fake.calls.first
+        assert_equal "1", call[:dfn]
+        assert_equal "2090061", call[:visit_ien]
+        assert_equal "SKIN", call[:exam_code]
+        assert_equal "Normal", call[:opts][:finding]
+      end
+
+      test "default_provider is RpmsRpc::ExamComponent" do
+        assert_equal ::RpmsRpc::ExamComponent, ExamComponentGateway.default_provider
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/exam_component_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/exam_component_gateway_test.rb
@@ -42,8 +42,10 @@ module Lakeraven
         assert_equal "Normal", call[:opts][:finding]
       end
 
-      test "default_provider is RpmsRpc::ExamComponent" do
-        assert_equal ::RpmsRpc::ExamComponent, ExamComponentGateway.default_provider
+      test "default_provider resolves to RpmsRpc::ExamComponent when the gem ships it" do
+        provider = ExamComponentGateway.default_provider
+        refute_nil provider, "expected RpmsRpc::ExamComponent to be loaded via the gateway's guarded require"
+        assert_equal "RpmsRpc::ExamComponent", provider.name
       end
     end
   end

--- a/test/gateways/lakeraven/ehr/health_factor_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/health_factor_gateway_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for HealthFactorGateway — IHS health-factor (structured observation) entry.
+# Wraps RpmsRpc::HealthFactor (lakeraven/rpms-rpc#65).
+module Lakeraven
+  module EHR
+    class HealthFactorGatewayTest < ActiveSupport::TestCase
+      class FakeHealthFactorAPI
+        attr_reader :calls
+
+        def initialize(returns:)
+          @returns = returns
+          @calls = []
+        end
+
+        def add(dfn, visit_ien, factor_code, **opts)
+          @calls << { dfn:, visit_ien:, factor_code:, opts: }
+          @returns
+        end
+      end
+
+      test "add returns failure shape when no provider is available" do
+        result = HealthFactorGateway.add(1, 2090061, "TOB-CURRENT", level: "MODERATE", via: nil)
+        assert_equal({ success: false, ien: nil, raw: nil }, result)
+      end
+
+      test "add delegates with identifiers coerced to strings" do
+        fake = FakeHealthFactorAPI.new(returns: { success: true, ien: 17, raw: "17" })
+
+        result = HealthFactorGateway.add(1, 2090061, "TOB-CURRENT",
+          level: "MODERATE",
+          narrative: "Daily smoker",
+          via: fake)
+
+        assert_equal({ success: true, ien: 17, raw: "17" }, result)
+        call = fake.calls.first
+        assert_equal "1", call[:dfn]
+        assert_equal "2090061", call[:visit_ien]
+        assert_equal "TOB-CURRENT", call[:factor_code]
+        assert_equal "MODERATE", call[:opts][:level]
+        assert_equal "Daily smoker", call[:opts][:narrative]
+      end
+
+      test "default_provider is RpmsRpc::HealthFactor" do
+        assert_equal ::RpmsRpc::HealthFactor, HealthFactorGateway.default_provider
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/health_factor_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/health_factor_gateway_test.rb
@@ -43,8 +43,10 @@ module Lakeraven
         assert_equal "Daily smoker", call[:opts][:narrative]
       end
 
-      test "default_provider is RpmsRpc::HealthFactor" do
-        assert_equal ::RpmsRpc::HealthFactor, HealthFactorGateway.default_provider
+      test "default_provider resolves to RpmsRpc::HealthFactor when the gem ships it" do
+        provider = HealthFactorGateway.default_provider
+        refute_nil provider, "expected RpmsRpc::HealthFactor to be loaded via the gateway's guarded require"
+        assert_equal "RpmsRpc::HealthFactor", provider.name
       end
     end
   end

--- a/test/gateways/lakeraven/ehr/measurement_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/measurement_gateway_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for MeasurementGateway — PCC measurement entry.
+# Wraps RpmsRpc::Measurement (lakeraven/rpms-rpc#67). Distinct from
+# clinical vitals (VitalGateway / BEHOVM); measurements are typed observations
+# (height, weight, BMI, head circumference, etc.).
+module Lakeraven
+  module EHR
+    class MeasurementGatewayTest < ActiveSupport::TestCase
+      class FakeMeasurementAPI
+        attr_reader :calls
+
+        def initialize(returns:)
+          @returns = returns
+          @calls = []
+        end
+
+        def add(dfn, visit_ien, measurement_type, value, **opts)
+          @calls << { dfn:, visit_ien:, measurement_type:, value:, opts: }
+          @returns
+        end
+      end
+
+      test "add returns failure shape when no provider is available" do
+        result = MeasurementGateway.add(1, 2090061, "WT", 75, units: "kg", via: nil)
+        assert_equal({ success: false, ien: nil, raw: nil }, result)
+      end
+
+      test "add delegates with identifiers coerced to strings and value passed through" do
+        fake = FakeMeasurementAPI.new(returns: { success: true, ien: 23, raw: "23" })
+
+        result = MeasurementGateway.add(1, 2090061, "WT", 75.5,
+          units: "kg",
+          qualifier: "STANDING",
+          via: fake)
+
+        assert_equal({ success: true, ien: 23, raw: "23" }, result)
+        call = fake.calls.first
+        assert_equal "1", call[:dfn]
+        assert_equal "2090061", call[:visit_ien]
+        assert_equal "WT", call[:measurement_type]
+        assert_in_delta 75.5, call[:value], 0.0001
+        assert_equal "kg", call[:opts][:units]
+        assert_equal "STANDING", call[:opts][:qualifier]
+      end
+
+      test "default_provider is RpmsRpc::Measurement" do
+        assert_equal ::RpmsRpc::Measurement, MeasurementGateway.default_provider
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/measurement_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/measurement_gateway_test.rb
@@ -46,8 +46,10 @@ module Lakeraven
         assert_equal "STANDING", call[:opts][:qualifier]
       end
 
-      test "default_provider is RpmsRpc::Measurement" do
-        assert_equal ::RpmsRpc::Measurement, MeasurementGateway.default_provider
+      test "default_provider resolves to RpmsRpc::Measurement when the gem ships it" do
+        provider = MeasurementGateway.default_provider
+        refute_nil provider, "expected RpmsRpc::Measurement to be loaded via the gateway's guarded require"
+        assert_equal "RpmsRpc::Measurement", provider.name
       end
     end
   end

--- a/test/gateways/lakeraven/ehr/pov_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/pov_gateway_test.rb
@@ -44,8 +44,10 @@ module Lakeraven
         assert_equal({ primary: true }, call[:opts][:modifiers])
       end
 
-      test "default_provider is RpmsRpc::Pov" do
-        assert_equal ::RpmsRpc::Pov, PovGateway.default_provider
+      test "default_provider resolves to RpmsRpc::Pov when the gem ships it" do
+        provider = PovGateway.default_provider
+        refute_nil provider, "expected RpmsRpc::Pov to be loaded via the gateway's guarded require"
+        assert_equal "RpmsRpc::Pov", provider.name
       end
     end
   end

--- a/test/gateways/lakeraven/ehr/pov_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/pov_gateway_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for PovGateway — visit purpose-of-visit (diagnosis) entry.
+# Wraps RpmsRpc::Pov (lakeraven/rpms-rpc#63).
+module Lakeraven
+  module EHR
+    class PovGatewayTest < ActiveSupport::TestCase
+      class FakePovAPI
+        attr_reader :calls
+
+        def initialize(returns:)
+          @returns = returns
+          @calls = []
+        end
+
+        def add(dfn, visit_ien, diagnosis_code, **opts)
+          @calls << { dfn:, visit_ien:, diagnosis_code:, opts: }
+          @returns
+        end
+      end
+
+      test "add returns failure shape when no provider is available" do
+        result = PovGateway.add(1, 2090061, "J45.909", narrative: "Asthma", via: nil)
+        assert_equal({ success: false, ien: nil, raw: nil }, result)
+      end
+
+      test "add delegates with identifiers coerced to strings" do
+        fake = FakePovAPI.new(returns: { success: true, ien: 42, raw: "42" })
+
+        result = PovGateway.add(1, 2090061, "J45.909",
+          narrative: "Asthma",
+          modifiers: { primary: true },
+          via: fake)
+
+        assert_equal({ success: true, ien: 42, raw: "42" }, result)
+        assert_equal 1, fake.calls.length
+        call = fake.calls.first
+        assert_equal "1", call[:dfn]
+        assert_equal "2090061", call[:visit_ien]
+        assert_equal "J45.909", call[:diagnosis_code]
+        assert_equal "Asthma", call[:opts][:narrative]
+        assert_equal({ primary: true }, call[:opts][:modifiers])
+      end
+
+      test "default_provider is RpmsRpc::Pov" do
+        assert_equal ::RpmsRpc::Pov, PovGateway.default_provider
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/procedure_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/procedure_gateway_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for ProcedureGateway — read via RpmsRpc::Procedure.for_patient and
+# write via RpmsRpc::Procedure.add (lakeraven/rpms-rpc#64).
+module Lakeraven
+  module EHR
+    class ProcedureGatewayTest < ActiveSupport::TestCase
+      # --- read: for_patient ---
+
+      test "for_patient returns the seeded procedure list" do
+        RpmsRpc.client.seed_keyed_collection(:procedure_list, "1", [
+          { ien: 7001, name: "Office visit, established", date: Date.new(2026, 3, 10),
+            provider: "MARTINEZ,SARAH", status: "C" }
+        ])
+
+        result = ProcedureGateway.for_patient(1)
+
+        assert_kind_of Array, result
+        assert_equal "Office visit, established", result.first[:name]
+      end
+
+      # --- write: add ---
+
+      test "add returns success with the saved IEN when the RPC returns an IEN" do
+        RpmsRpc.client.seed_scalar(:procedure_save, "1", "42")
+
+        result = ProcedureGateway.add(1, 2090061, "99213",
+          modifiers: [ "25" ], narrative: "Office visit", quantity: 1)
+
+        assert result[:success]
+        assert_equal 42, result[:ien]
+      end
+
+      test "add returns failure when called with missing arguments" do
+        result = ProcedureGateway.add(nil, 2090061, "99213")
+
+        refute result[:success]
+        assert_nil result[:ien]
+      end
+
+      test "add coerces integer identifiers to strings" do
+        RpmsRpc.client.seed_scalar(:procedure_save, "1", "99")
+
+        result = ProcedureGateway.add(1, 2090061, "99213")
+
+        assert result[:success]
+        assert_equal 99, result[:ien]
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/reminders_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/reminders_gateway_test.rb
@@ -36,20 +36,10 @@ module Lakeraven
         assert_equal [ { dfn: "8791", visit_ien: "2090061" } ], fake.calls
       end
 
-      test "default_provider is nil when RpmsRpc::Reminders is undefined" do
-        # In the current gem state RpmsRpc::Reminders has not shipped, so
-        # the default provider should be nil and for_visit should return [].
-        if defined?(::RpmsRpc::Reminders) && ::RpmsRpc::Reminders.respond_to?(:for_visit)
-          skip "RpmsRpc::Reminders has shipped; remove this skip when the gem update lands"
-        end
-        assert_nil RemindersGateway.default_provider
-        assert_equal [], RemindersGateway.for_visit(8791, 2090061)
-      end
-
-      test "default_provider returns RpmsRpc::Reminders when it ships" do
-        skip "Requires real RpmsRpc::Reminders.for_visit (lakeraven/rpms-rpc#59)" unless
-          defined?(::RpmsRpc::Reminders) && ::RpmsRpc::Reminders.respond_to?(:for_visit)
-        assert_equal ::RpmsRpc::Reminders, RemindersGateway.default_provider
+      test "default_provider resolves to RpmsRpc::Reminders now that the gem ships it" do
+        provider = RemindersGateway.default_provider
+        refute_nil provider, "expected RpmsRpc::Reminders to be loaded via the gateway's guarded require"
+        assert_equal "RpmsRpc::Reminders", provider.name
       end
     end
   end


### PR DESCRIPTION
## Summary
- Four net-new gateways for the chart-documentation form-post path: \`PovGateway\`, \`HealthFactorGateway\`, \`ExamComponentGateway\`, \`MeasurementGateway\`. Each wraps the matching rpms-rpc symbolic module landed in lakeraven/rpms-rpc#63/#65/#66/#67. All four use the guarded \`require\` + \`default_provider\` + \`via:\` DI pattern established in PR #340.
- Two extensions to existing gateways, in their host-class style (hard require, no \`via:\`):
  - \`ProcedureGateway\` gains \`.add(dfn, visit_ien, cpt_code, modifiers:, narrative:, quantity:)\`
  - \`ConditionGateway\` gains \`.add\`, \`.update\`, \`.delete\`, \`.filter\` — wraps \`RpmsRpc::Problem\`; engine vocabulary stays \"Condition\" to match \`app/models/lakeraven/ehr/condition.rb\`
- All six gateways return the \`{ success:, ien:, raw: }\` write shape per the staff-workflow port convention.

## Test plan
- [x] \`bundle exec rails test\` — 2633 runs, 5283 assertions, 0 failures, 0 errors, 2 pre-existing skips
- [x] \`bundle exec cucumber\` — 622/628 pass; remaining 6 failures (\`bulk_export_download_auth\` ×5, \`onc/cqm_record_and_export\` ×1) exist on \`main\` and are unrelated
- [x] \`bundle exec rubocop\` — clean on every changed file
- [x] 24 new gateway tests; the four new gateways exercise both branches of \`default_provider\` and assert delegation through a fake provider without naming any underlying RPC

Closes #341
Part of #324