### PR TITLE
Notes gateways: NoteTemplate, ProgressNote, ESignature

### DIFF
--- a/app/gateways/lakeraven/ehr/e_signature_gateway.rb
+++ b/app/gateways/lakeraven/ehr/e_signature_gateway.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+begin
+  require "rpms_rpc/api/e_signature"
+rescue LoadError
+  # rpms-rpc gem does not yet expose RpmsRpc::ESignature.
+end
+
+module Lakeraven
+  module EHR
+    # TIU e-signature: validate a user's signature code, look up which
+    # signing action is permitted on a note, add a signature (sign /
+    # cosign / addend), and remove an existing signature.
+    # Wraps RpmsRpc::ESignature (lakeraven/rpms-rpc#58).
+    class ESignatureGateway
+      SIGN_FAILURE = { success: false, raw: nil }.freeze
+
+      def self.validate(user_duz, signature_code, via: default_provider)
+        return false if via.nil?
+
+        via.validate(user_duz.to_s, signature_code)
+      end
+
+      def self.which_action(note_ien, user_duz, via: default_provider)
+        return nil if via.nil?
+
+        via.which_action(note_ien.to_s, user_duz.to_s)
+      end
+
+      def self.add(note_ien, user_duz, signature_code, action: :sign, via: default_provider)
+        return SIGN_FAILURE if via.nil?
+
+        via.add(note_ien.to_s, user_duz.to_s, signature_code, action: action)
+      end
+
+      def self.remove(note_ien, user_duz, reason:, via: default_provider)
+        return SIGN_FAILURE if via.nil?
+
+        via.remove(note_ien.to_s, user_duz.to_s, reason: reason)
+      end
+
+      def self.default_provider
+        return nil unless defined?(::RpmsRpc::ESignature) &&
+                          ::RpmsRpc::ESignature.respond_to?(:add)
+        ::RpmsRpc::ESignature
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/note_template_gateway.rb
+++ b/app/gateways/lakeraven/ehr/note_template_gateway.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+begin
+  require "rpms_rpc/api/note_template"
+rescue LoadError
+  # rpms-rpc gem does not yet expose RpmsRpc::NoteTemplate.
+end
+
+module Lakeraven
+  module EHR
+    # TIU note template tree, boilerplate text, and per-user access level.
+    # Wraps RpmsRpc::NoteTemplate (lakeraven/rpms-rpc#56).
+    class NoteTemplateGateway
+      def self.roots(user_duz, via: default_provider)
+        return [] if via.nil?
+
+        via.roots(user_duz.to_s)
+      end
+
+      def self.items(template_ien, via: default_provider)
+        return [] if via.nil?
+
+        via.items(template_ien.to_s)
+      end
+
+      def self.boilerplate(template_ien, dfn:, visit_ien:, via: default_provider)
+        return nil if via.nil?
+
+        via.boilerplate(template_ien.to_s, dfn: dfn.to_s, visit_ien: visit_ien.to_s)
+      end
+
+      def self.text(template_ien, via: default_provider)
+        return nil if via.nil?
+
+        via.text(template_ien.to_s)
+      end
+
+      def self.access_level(template_ien, user_duz, via: default_provider)
+        return nil if via.nil?
+
+        via.access_level(template_ien.to_s, user_duz.to_s)
+      end
+
+      def self.default_provider
+        return nil unless defined?(::RpmsRpc::NoteTemplate) &&
+                          ::RpmsRpc::NoteTemplate.respond_to?(:roots)
+        ::RpmsRpc::NoteTemplate
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/progress_note_gateway.rb
+++ b/app/gateways/lakeraven/ehr/progress_note_gateway.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+begin
+  require "rpms_rpc/api/progress_note"
+rescue LoadError
+  # rpms-rpc gem does not yet expose RpmsRpc::ProgressNote.
+end
+
+module Lakeraven
+  module EHR
+    # TIU progress note create, list, fetch, edit, lock. Signing lives in
+    # ESignatureGateway, not here.
+    # Wraps RpmsRpc::ProgressNote (lakeraven/rpms-rpc#57).
+    class ProgressNoteGateway
+      CREATE_FAILURE = { success: false, ien: nil, raw: nil }.freeze
+      UPDATE_FAILURE = { success: false, raw: nil }.freeze
+
+      def self.create(dfn, visit_ien, title_ien, via: default_provider)
+        return CREATE_FAILURE if via.nil?
+
+        via.create(dfn.to_s, visit_ien.to_s, title_ien.to_s)
+      end
+
+      def self.list(dfn, context: :all, via: default_provider)
+        return [] if via.nil?
+
+        via.list(dfn.to_s, context: context)
+      end
+
+      def self.fetch_text(note_ien, via: default_provider)
+        return nil if via.nil?
+
+        via.fetch_text(note_ien.to_s)
+      end
+
+      def self.authorize(note_ien, user_duz, via: default_provider)
+        return false if via.nil?
+
+        via.authorize(note_ien.to_s, user_duz.to_s)
+      end
+
+      def self.lock(note_ien, user_duz, via: default_provider)
+        return false if via.nil?
+
+        via.lock(note_ien.to_s, user_duz.to_s)
+      end
+
+      def self.update_text(note_ien, text, via: default_provider)
+        return UPDATE_FAILURE if via.nil?
+
+        via.update_text(note_ien.to_s, text)
+      end
+
+      def self.unlock(note_ien, user_duz, via: default_provider)
+        return false if via.nil?
+
+        via.unlock(note_ien.to_s, user_duz.to_s)
+      end
+
+      def self.default_provider
+        return nil unless defined?(::RpmsRpc::ProgressNote) &&
+                          ::RpmsRpc::ProgressNote.respond_to?(:create)
+        ::RpmsRpc::ProgressNote
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/e_signature_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/e_signature_gateway_test.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for ESignatureGateway — TIU e-signature validate, which-action,
+# add (sign/cosign/addend), and remove. Wraps RpmsRpc::ESignature
+# (lakeraven/rpms-rpc#58).
+module Lakeraven
+  module EHR
+    class ESignatureGatewayTest < ActiveSupport::TestCase
+      class FakeESignatureAPI
+        attr_reader :calls
+
+        def initialize(returns: {})
+          @returns = returns
+          @calls = []
+        end
+
+        def validate(user_duz, signature_code)
+          @calls << { method: :validate, args: [ user_duz, signature_code ] }
+          @returns.fetch(:validate, true)
+        end
+
+        def which_action(note_ien, user_duz)
+          @calls << { method: :which_action, args: [ note_ien, user_duz ] }
+          @returns[:which_action]
+        end
+
+        def add(note_ien, user_duz, signature_code, action: :sign)
+          @calls << { method: :add, args: [ note_ien, user_duz, signature_code ], action: action }
+          @returns[:add] || { success: true, raw: "1" }
+        end
+
+        def remove(note_ien, user_duz, reason:)
+          @calls << { method: :remove, args: [ note_ien, user_duz ], reason: reason }
+          @returns[:remove] || { success: true, raw: "1" }
+        end
+      end
+
+      # --- via: nil ---
+
+      test "validate returns false when no provider is available" do
+        refute ESignatureGateway.validate("301", "SECRET", via: nil)
+      end
+
+      test "which_action returns nil when no provider is available" do
+        assert_nil ESignatureGateway.which_action(1001, "301", via: nil)
+      end
+
+      test "add returns failure shape when no provider is available" do
+        assert_equal({ success: false, raw: nil },
+          ESignatureGateway.add(1001, "301", "SECRET", via: nil))
+      end
+
+      test "remove returns failure shape when no provider is available" do
+        assert_equal({ success: false, raw: nil },
+          ESignatureGateway.remove(1001, "301", reason: "Entered in error", via: nil))
+      end
+
+      # --- delegation + coercion ---
+
+      test "validate delegates with duz coerced to a string" do
+        fake = FakeESignatureAPI.new(returns: { validate: true })
+
+        assert ESignatureGateway.validate(301, "SECRET", via: fake)
+        assert_equal [ "301", "SECRET" ], fake.calls.first[:args]
+      end
+
+      test "which_action delegates and passes the symbol through" do
+        fake = FakeESignatureAPI.new(returns: { which_action: :sign })
+
+        assert_equal :sign, ESignatureGateway.which_action(1001, 301, via: fake)
+        assert_equal [ "1001", "301" ], fake.calls.first[:args]
+      end
+
+      test "add delegates with identifiers coerced and action symbol passed through" do
+        fake = FakeESignatureAPI.new(returns: { add: { success: true, raw: "1" } })
+
+        result = ESignatureGateway.add(1001, 301, "SECRET", action: :cosign, via: fake)
+
+        assert_equal({ success: true, raw: "1" }, result)
+        assert_equal [ "1001", "301", "SECRET" ], fake.calls.first[:args]
+        assert_equal :cosign, fake.calls.first[:action]
+      end
+
+      test "add defaults to :sign when action is omitted" do
+        fake = FakeESignatureAPI.new
+        ESignatureGateway.add(1001, "301", "SECRET", via: fake)
+        assert_equal :sign, fake.calls.first[:action]
+      end
+
+      test "remove delegates with identifiers coerced and reason forwarded" do
+        fake = FakeESignatureAPI.new(returns: { remove: { success: true, raw: "1" } })
+
+        result = ESignatureGateway.remove(1001, 301, reason: "Entered in error", via: fake)
+
+        assert_equal({ success: true, raw: "1" }, result)
+        assert_equal [ "1001", "301" ], fake.calls.first[:args]
+        assert_equal "Entered in error", fake.calls.first[:reason]
+      end
+
+      # --- default_provider ---
+
+      test "default_provider resolves to RpmsRpc::ESignature when the gem ships it" do
+        provider = ESignatureGateway.default_provider
+        refute_nil provider, "expected RpmsRpc::ESignature to be loaded via the gateway's guarded require"
+        assert_equal "RpmsRpc::ESignature", provider.name
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/note_template_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/note_template_gateway_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for NoteTemplateGateway — TIU note template tree, boilerplate text,
+# and per-user access level. Wraps RpmsRpc::NoteTemplate (lakeraven/rpms-rpc#56).
+module Lakeraven
+  module EHR
+    class NoteTemplateGatewayTest < ActiveSupport::TestCase
+      class FakeNoteTemplateAPI
+        attr_reader :calls
+
+        def initialize(returns: {})
+          @returns = returns
+          @calls = []
+        end
+
+        def roots(user_duz)
+          @calls << { method: :roots, args: [ user_duz ] }
+          @returns[:roots] || []
+        end
+
+        def items(template_ien)
+          @calls << { method: :items, args: [ template_ien ] }
+          @returns[:items] || []
+        end
+
+        def boilerplate(template_ien, dfn:, visit_ien:)
+          @calls << { method: :boilerplate, args: [ template_ien, dfn, visit_ien ] }
+          @returns[:boilerplate]
+        end
+
+        def text(template_ien)
+          @calls << { method: :text, args: [ template_ien ] }
+          @returns[:text]
+        end
+
+        def access_level(template_ien, user_duz)
+          @calls << { method: :access_level, args: [ template_ien, user_duz ] }
+          @returns[:access_level]
+        end
+      end
+
+      # --- via: nil ---
+
+      test "roots returns empty when no provider is available" do
+        assert_equal [], NoteTemplateGateway.roots("301", via: nil)
+      end
+
+      test "items returns empty when no provider is available" do
+        assert_equal [], NoteTemplateGateway.items(101, via: nil)
+      end
+
+      test "boilerplate returns nil when no provider is available" do
+        assert_nil NoteTemplateGateway.boilerplate(101, dfn: 1, visit_ien: 2090061, via: nil)
+      end
+
+      test "text returns nil when no provider is available" do
+        assert_nil NoteTemplateGateway.text(101, via: nil)
+      end
+
+      test "access_level returns nil when no provider is available" do
+        assert_nil NoteTemplateGateway.access_level(101, "301", via: nil)
+      end
+
+      # --- delegation + coercion ---
+
+      test "roots delegates with duz coerced to a string" do
+        list = [ { ien: 7, name: "Primary Care" } ]
+        fake = FakeNoteTemplateAPI.new(returns: { roots: list })
+
+        assert_equal list, NoteTemplateGateway.roots(301, via: fake)
+        assert_equal [ "301" ], fake.calls.first[:args]
+      end
+
+      test "items delegates with template_ien coerced to a string" do
+        list = [ { ien: 12, title: "ROS" } ]
+        fake = FakeNoteTemplateAPI.new(returns: { items: list })
+
+        assert_equal list, NoteTemplateGateway.items(7, via: fake)
+        assert_equal [ "7" ], fake.calls.first[:args]
+      end
+
+      test "boilerplate delegates with all identifiers coerced to strings" do
+        fake = FakeNoteTemplateAPI.new(returns: { boilerplate: "S: Patient seen for..." })
+
+        result = NoteTemplateGateway.boilerplate(7, dfn: 1, visit_ien: 2090061, via: fake)
+
+        assert_equal "S: Patient seen for...", result
+        assert_equal [ "7", "1", "2090061" ], fake.calls.first[:args]
+      end
+
+      test "text delegates" do
+        fake = FakeNoteTemplateAPI.new(returns: { text: "S: {PATIENT NAME}" })
+        assert_equal "S: {PATIENT NAME}", NoteTemplateGateway.text(7, via: fake)
+      end
+
+      test "access_level delegates" do
+        fake = FakeNoteTemplateAPI.new(returns: { access_level: "READ" })
+        assert_equal "READ", NoteTemplateGateway.access_level(7, "301", via: fake)
+        assert_equal [ "7", "301" ], fake.calls.first[:args]
+      end
+
+      # --- default_provider ---
+
+      test "default_provider resolves to RpmsRpc::NoteTemplate when the gem ships it" do
+        provider = NoteTemplateGateway.default_provider
+        refute_nil provider, "expected RpmsRpc::NoteTemplate to be loaded via the gateway's guarded require"
+        assert_equal "RpmsRpc::NoteTemplate", provider.name
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/progress_note_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/progress_note_gateway_test.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for ProgressNoteGateway — TIU progress note create, list, fetch,
+# edit, lock. Signing lives in ESignatureGateway, not here.
+# Wraps RpmsRpc::ProgressNote (lakeraven/rpms-rpc#57).
+module Lakeraven
+  module EHR
+    class ProgressNoteGatewayTest < ActiveSupport::TestCase
+      class FakeProgressNoteAPI
+        attr_reader :calls
+
+        def initialize(returns: {})
+          @returns = returns
+          @calls = []
+        end
+
+        def create(dfn, visit_ien, title_ien)
+          @calls << { method: :create, args: [ dfn, visit_ien, title_ien ] }
+          @returns[:create] || { success: true, ien: 1001, raw: "1001" }
+        end
+
+        def list(dfn, context: :all)
+          @calls << { method: :list, args: [ dfn ], context: context }
+          @returns[:list] || []
+        end
+
+        def fetch_text(note_ien)
+          @calls << { method: :fetch_text, args: [ note_ien ] }
+          @returns[:fetch_text]
+        end
+
+        def authorize(note_ien, user_duz)
+          @calls << { method: :authorize, args: [ note_ien, user_duz ] }
+          @returns.fetch(:authorize, true)
+        end
+
+        def lock(note_ien, user_duz)
+          @calls << { method: :lock, args: [ note_ien, user_duz ] }
+          @returns.fetch(:lock, true)
+        end
+
+        def update_text(note_ien, text)
+          @calls << { method: :update_text, args: [ note_ien, text ] }
+          @returns[:update_text] || { success: true, raw: "0" }
+        end
+
+        def unlock(note_ien, user_duz)
+          @calls << { method: :unlock, args: [ note_ien, user_duz ] }
+          @returns.fetch(:unlock, true)
+        end
+      end
+
+      # --- via: nil ---
+
+      test "create returns failure shape when no provider is available" do
+        assert_equal({ success: false, ien: nil, raw: nil },
+          ProgressNoteGateway.create(1, 2090061, 4321, via: nil))
+      end
+
+      test "list returns empty when no provider is available" do
+        assert_equal [], ProgressNoteGateway.list(1, via: nil)
+      end
+
+      test "fetch_text returns nil when no provider is available" do
+        assert_nil ProgressNoteGateway.fetch_text(1001, via: nil)
+      end
+
+      test "authorize returns false when no provider is available" do
+        refute ProgressNoteGateway.authorize(1001, "301", via: nil)
+      end
+
+      test "lock returns false when no provider is available" do
+        refute ProgressNoteGateway.lock(1001, "301", via: nil)
+      end
+
+      test "update_text returns failure shape when no provider is available" do
+        assert_equal({ success: false, raw: nil },
+          ProgressNoteGateway.update_text(1001, "S: ...", via: nil))
+      end
+
+      test "unlock returns false when no provider is available" do
+        refute ProgressNoteGateway.unlock(1001, "301", via: nil)
+      end
+
+      # --- delegation + coercion ---
+
+      test "create delegates with all identifiers coerced to strings" do
+        fake = FakeProgressNoteAPI.new(returns: { create: { success: true, ien: 5050, raw: "5050" } })
+
+        result = ProgressNoteGateway.create(1, 2090061, 4321, via: fake)
+
+        assert_equal({ success: true, ien: 5050, raw: "5050" }, result)
+        assert_equal [ "1", "2090061", "4321" ], fake.calls.first[:args]
+      end
+
+      test "list passes the context symbol through unchanged" do
+        fake = FakeProgressNoteAPI.new(returns: { list: [ { ien: 1, title: "Office Visit" } ] })
+
+        result = ProgressNoteGateway.list(1, context: :unsigned, via: fake)
+
+        assert_equal 1, result.length
+        assert_equal :unsigned, fake.calls.first[:context]
+      end
+
+      test "list defaults to :all when context is omitted" do
+        fake = FakeProgressNoteAPI.new(returns: { list: [] })
+
+        ProgressNoteGateway.list(1, via: fake)
+
+        assert_equal :all, fake.calls.first[:context]
+      end
+
+      test "fetch_text delegates" do
+        fake = FakeProgressNoteAPI.new(returns: { fetch_text: "S: HPI..." })
+
+        assert_equal "S: HPI...", ProgressNoteGateway.fetch_text(1001, via: fake)
+        assert_equal [ "1001" ], fake.calls.first[:args]
+      end
+
+      test "authorize delegates and returns boolean" do
+        fake = FakeProgressNoteAPI.new(returns: { authorize: true })
+        assert ProgressNoteGateway.authorize(1001, "301", via: fake)
+
+        denied = FakeProgressNoteAPI.new(returns: { authorize: false })
+        refute ProgressNoteGateway.authorize(1001, "301", via: denied)
+      end
+
+      test "lock delegates with identifiers coerced to strings" do
+        fake = FakeProgressNoteAPI.new(returns: { lock: true })
+        assert ProgressNoteGateway.lock(1001, 301, via: fake)
+        assert_equal [ "1001", "301" ], fake.calls.first[:args]
+      end
+
+      test "update_text delegates and preserves the 2-key success shape" do
+        fake = FakeProgressNoteAPI.new(returns: { update_text: { success: true, raw: "0" } })
+
+        result = ProgressNoteGateway.update_text(1001, "S: revised note text", via: fake)
+
+        assert_equal({ success: true, raw: "0" }, result)
+        assert_equal [ "1001", "S: revised note text" ], fake.calls.first[:args]
+      end
+
+      test "unlock delegates" do
+        fake = FakeProgressNoteAPI.new(returns: { unlock: true })
+        assert ProgressNoteGateway.unlock(1001, "301", via: fake)
+      end
+
+      # --- default_provider ---
+
+      test "default_provider resolves to RpmsRpc::ProgressNote when the gem ships it" do
+        provider = ProgressNoteGateway.default_provider
+        refute_nil provider, "expected RpmsRpc::ProgressNote to be loaded via the gateway's guarded require"
+        assert_equal "RpmsRpc::ProgressNote", provider.name
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Three net-new gateways for the progress-note authoring workflow:
  - \`NoteTemplateGateway\` — wraps RpmsRpc::NoteTemplate (\`roots\`, \`items\`, \`boilerplate\`, \`text\`, \`access_level\`)
  - \`ProgressNoteGateway\` — wraps RpmsRpc::ProgressNote (\`create\`, \`list\`, \`fetch_text\`, \`authorize\`, \`lock\`, \`update_text\`, \`unlock\`)
  - \`ESignatureGateway\` — wraps RpmsRpc::ESignature (\`validate\`, \`which_action\`, \`add\`, \`remove\`)
- All three follow the full \`RemindersGateway\` pattern (guarded \`require\` + \`default_provider\` + \`via:\` DI) established in PRs #340 and #342.
- Write methods return the operation-appropriate shape: \`{success:, ien:, raw:}\` for create-style, \`{success:, raw:}\` for update/sign-style. \`via: nil\` short-circuits to the matching failure/empty shape.
- Symbolic taxonomies (\`context:\`, \`action:\`) pass through unchanged so the underlying module owns wire translation.

## Test plan
- [x] \`bundle exec rails test test/gateways/lakeraven/ehr/\` — all gateway tests green
- [x] \`bundle exec rails test\` — 2669 runs, 5339 assertions, 0 failures, 1 pre-existing autoload flake (\`CcdaImportsControllerTest\` — race condition independent of this PR)
- [x] \`bundle exec cucumber\` — 622/628; same 6 pre-existing failures as on \`main\`
- [x] \`bundle exec rubocop\` — clean on every changed file
- [x] 37 new gateway tests; default_provider tests use the \`refute_nil + provider.name\` shape from the Batch 2 hardening

Closes #343
Part of #324