### PR TITLE
Orders & messaging gateways: Order, Symptom, Image, Notifications, ImmunizationRefusal + Referral.create

### DIFF
--- a/app/gateways/lakeraven/ehr/image_gateway.rb
+++ b/app/gateways/lakeraven/ehr/image_gateway.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+begin
+  require "rpms_rpc/api/image"
+rescue LoadError
+  # rpms-rpc gem does not yet expose RpmsRpc::Image.
+end
+
+module Lakeraven
+  module EHR
+    # Imaging-study list and viewer-launch handoff. The viewer is a
+    # desktop component external to RPMS; the gateway issues a token
+    # the front-end hands off to whatever viewer is configured.
+    # Wraps RpmsRpc::Image (lakeraven/rpms-rpc#75).
+    class ImageGateway
+      DEFAULT_TTL_SECONDS = 300
+
+      def self.exams_for_patient(dfn, via: default_provider)
+        return [] if via.nil?
+
+        via.exams_for_patient(dfn.to_s)
+      end
+
+      def self.launch_token(dfn, study_ien, ttl_seconds: DEFAULT_TTL_SECONDS, via: default_provider)
+        return nil if via.nil?
+
+        via.launch_token(dfn.to_s, study_ien.to_s, ttl_seconds: ttl_seconds)
+      end
+
+      def self.default_provider
+        return nil unless defined?(::RpmsRpc::Image) &&
+                          ::RpmsRpc::Image.respond_to?(:launch_token)
+        ::RpmsRpc::Image
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/immunization_refusal_gateway.rb
+++ b/app/gateways/lakeraven/ehr/immunization_refusal_gateway.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+begin
+  require "rpms_rpc/api/immunization_refusal"
+rescue LoadError
+  # rpms-rpc gem does not yet expose RpmsRpc::ImmunizationRefusal.
+end
+
+module Lakeraven
+  module EHR
+    # Records a patient's refusal of an immunization on the open encounter.
+    # Distinct from ImmunizationGateway (read-only).
+    # Wraps RpmsRpc::ImmunizationRefusal (lakeraven/rpms-rpc#76).
+    class ImmunizationRefusalGateway
+      FAILURE = { success: false, ien: nil, raw: nil }.freeze
+
+      def self.record(dfn, vaccine_code, reason_code:, narrative: nil, via: default_provider)
+        return FAILURE if via.nil?
+
+        via.record(dfn.to_s, vaccine_code,
+          reason_code: reason_code, narrative: narrative)
+      end
+
+      def self.default_provider
+        return nil unless defined?(::RpmsRpc::ImmunizationRefusal) &&
+                          ::RpmsRpc::ImmunizationRefusal.respond_to?(:record)
+        ::RpmsRpc::ImmunizationRefusal
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/notifications_gateway.rb
+++ b/app/gateways/lakeraven/ehr/notifications_gateway.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+begin
+  require "rpms_rpc/api/notifications"
+rescue LoadError
+  # rpms-rpc gem does not yet expose RpmsRpc::Notifications.
+end
+
+module Lakeraven
+  module EHR
+    # Clinician alert inbox — fires at login and on patient open.
+    # Wraps RpmsRpc::Notifications (lakeraven/rpms-rpc#74).
+    class NotificationsGateway
+      MARK_READ_FAILURE = { success: false, raw: nil }.freeze
+
+      def self.inbox(user_duz, unread: nil, via: default_provider)
+        return [] if via.nil?
+
+        via.inbox(user_duz.to_s, unread: unread)
+      end
+
+      def self.mark_read(notification_ien, user_duz, via: default_provider)
+        return MARK_READ_FAILURE if via.nil?
+
+        via.mark_read(notification_ien.to_s, user_duz.to_s)
+      end
+
+      def self.default_provider
+        return nil unless defined?(::RpmsRpc::Notifications) &&
+                          ::RpmsRpc::Notifications.respond_to?(:inbox)
+        ::RpmsRpc::Notifications
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/order_gateway.rb
+++ b/app/gateways/lakeraven/ehr/order_gateway.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+begin
+  require "rpms_rpc/api/order"
+rescue LoadError
+  # rpms-rpc gem does not yet expose RpmsRpc::Order.
+end
+
+module Lakeraven
+  module EHR
+    # Clinical-order list APIs — a user's unsigned queue, or a patient's
+    # chart filtered by status and view.
+    # Wraps RpmsRpc::Order (lakeraven/rpms-rpc#68).
+    class OrderGateway
+      def self.unsigned_for_user(user_duz, via: default_provider)
+        return [] if via.nil?
+
+        via.unsigned_for_user(user_duz.to_s)
+      end
+
+      def self.list(dfn, status: :all, view: :default, via: default_provider)
+        return [] if via.nil?
+
+        via.list(dfn.to_s, status: status, view: view)
+      end
+
+      def self.default_provider
+        return nil unless defined?(::RpmsRpc::Order) &&
+                          ::RpmsRpc::Order.respond_to?(:list)
+        ::RpmsRpc::Order
+      end
+    end
+  end
+end

--- a/app/gateways/lakeraven/ehr/service_request_gateway.rb
+++ b/app/gateways/lakeraven/ehr/service_request_gateway.rb
@@ -11,6 +11,10 @@ module Lakeraven
         RpmsRpc::Referral.for_patient(dfn.to_s)
       end
 
+      def self.create(dfn, params)
+        RpmsRpc::Referral.create(dfn.to_s, params)
+      end
+
       def self.delete(ien, reason: nil)
         referral = find_referral(ien)
         return { success: false, error: "Referral not found", ien: ien } unless referral

--- a/app/gateways/lakeraven/ehr/symptom_gateway.rb
+++ b/app/gateways/lakeraven/ehr/symptom_gateway.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+begin
+  require "rpms_rpc/api/symptom"
+rescue LoadError
+  # rpms-rpc gem does not yet expose RpmsRpc::Symptom.
+end
+
+module Lakeraven
+  module EHR
+    # Allergy-symptom catalog lookup, driving the order-entry
+    # allergy-precheck UI.
+    # Wraps RpmsRpc::Symptom (lakeraven/rpms-rpc#73).
+    class SymptomGateway
+      def self.search(query, via: default_provider)
+        return [] if via.nil?
+
+        via.search(query.to_s)
+      end
+
+      def self.defaults(via: default_provider)
+        return [] if via.nil?
+
+        via.defaults
+      end
+
+      def self.default_provider
+        return nil unless defined?(::RpmsRpc::Symptom) &&
+                          ::RpmsRpc::Symptom.respond_to?(:search)
+        ::RpmsRpc::Symptom
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/image_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/image_gateway_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for ImageGateway — imaging-study list and viewer-launch handoff.
+# Wraps RpmsRpc::Image (lakeraven/rpms-rpc#75).
+module Lakeraven
+  module EHR
+    class ImageGatewayTest < ActiveSupport::TestCase
+      class FakeImageAPI
+        attr_reader :calls
+
+        def initialize(returns: {})
+          @returns = returns
+          @calls = []
+        end
+
+        def exams_for_patient(dfn)
+          @calls << { method: :exams_for_patient, args: [ dfn ] }
+          @returns[:exams_for_patient] || []
+        end
+
+        def launch_token(dfn, study_ien, ttl_seconds: 300)
+          @calls << { method: :launch_token, args: [ dfn, study_ien ], ttl_seconds: ttl_seconds }
+          @returns[:launch_token]
+        end
+      end
+
+      # --- via: nil ---
+
+      test "exams_for_patient returns empty when no provider is available" do
+        assert_equal [], ImageGateway.exams_for_patient(1, via: nil)
+      end
+
+      test "launch_token returns nil when no provider is available" do
+        assert_nil ImageGateway.launch_token(1, 555, via: nil)
+      end
+
+      # --- delegation + coercion ---
+
+      test "exams_for_patient delegates with dfn coerced to a string" do
+        exams = [ { ien: 1, modality: "CT" } ]
+        fake = FakeImageAPI.new(returns: { exams_for_patient: exams })
+
+        assert_equal exams, ImageGateway.exams_for_patient(1, via: fake)
+        assert_equal [ "1" ], fake.calls.first[:args]
+      end
+
+      test "launch_token delegates identifiers as strings and passes ttl through" do
+        token = { token: "abc123", viewer_url: nil, expires_at: Time.now + 600 }
+        fake = FakeImageAPI.new(returns: { launch_token: token })
+
+        result = ImageGateway.launch_token(1, 555, ttl_seconds: 600, via: fake)
+
+        assert_equal token, result
+        assert_equal [ "1", "555" ], fake.calls.first[:args]
+        assert_equal 600, fake.calls.first[:ttl_seconds]
+      end
+
+      test "launch_token defaults ttl_seconds when omitted" do
+        fake = FakeImageAPI.new(returns: { launch_token: { token: "t", viewer_url: nil, expires_at: nil } })
+
+        ImageGateway.launch_token(1, 555, via: fake)
+
+        assert_equal 300, fake.calls.first[:ttl_seconds]
+      end
+
+      # --- default_provider ---
+
+      test "default_provider resolves to RpmsRpc::Image when the gem ships it" do
+        provider = ImageGateway.default_provider
+        refute_nil provider, "expected RpmsRpc::Image to be loaded via the gateway's guarded require"
+        assert_equal "RpmsRpc::Image", provider.name
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/immunization_refusal_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/immunization_refusal_gateway_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for ImmunizationRefusalGateway — records a patient's refusal of
+# an immunization on the open encounter. Distinct from ImmunizationGateway
+# (read-only).
+# Wraps RpmsRpc::ImmunizationRefusal (lakeraven/rpms-rpc#76).
+module Lakeraven
+  module EHR
+    class ImmunizationRefusalGatewayTest < ActiveSupport::TestCase
+      class FakeRefusalAPI
+        attr_reader :calls
+
+        def initialize(returns: {})
+          @returns = returns
+          @calls = []
+        end
+
+        def record(dfn, vaccine_code, reason_code:, narrative: nil)
+          @calls << { method: :record, args: [ dfn, vaccine_code ],
+                      reason_code: reason_code, narrative: narrative }
+          @returns[:record] || { success: true, ien: 1, raw: "1" }
+        end
+      end
+
+      # --- via: nil ---
+
+      test "record returns failure shape when no provider is available" do
+        result = ImmunizationRefusalGateway.record(1, "MMR",
+          reason_code: :parental, via: nil)
+
+        assert_equal({ success: false, ien: nil, raw: nil }, result)
+      end
+
+      # --- delegation ---
+
+      test "record delegates with dfn coerced and reason_code symbol passed through" do
+        fake = FakeRefusalAPI.new(returns: { record: { success: true, ien: 17, raw: "17" } })
+
+        result = ImmunizationRefusalGateway.record(1, "MMR",
+          reason_code: :religious, narrative: "Family declines",
+          via: fake)
+
+        assert_equal({ success: true, ien: 17, raw: "17" }, result)
+        assert_equal [ "1", "MMR" ], fake.calls.first[:args]
+        assert_equal :religious, fake.calls.first[:reason_code]
+        assert_equal "Family declines", fake.calls.first[:narrative]
+      end
+
+      # --- default_provider ---
+
+      test "default_provider resolves to RpmsRpc::ImmunizationRefusal when the gem ships it" do
+        provider = ImmunizationRefusalGateway.default_provider
+        refute_nil provider, "expected RpmsRpc::ImmunizationRefusal to be loaded via the gateway's guarded require"
+        assert_equal "RpmsRpc::ImmunizationRefusal", provider.name
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/notifications_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/notifications_gateway_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for NotificationsGateway — clinician alert inbox.
+# Wraps RpmsRpc::Notifications (lakeraven/rpms-rpc#74).
+module Lakeraven
+  module EHR
+    class NotificationsGatewayTest < ActiveSupport::TestCase
+      class FakeNotificationsAPI
+        attr_reader :calls
+
+        def initialize(returns: {})
+          @returns = returns
+          @calls = []
+        end
+
+        def inbox(user_duz, unread: nil)
+          @calls << { method: :inbox, args: [ user_duz ], unread: unread }
+          @returns[:inbox] || []
+        end
+
+        def mark_read(notification_ien, user_duz)
+          @calls << { method: :mark_read, args: [ notification_ien, user_duz ] }
+          @returns[:mark_read] || { success: true, raw: "0" }
+        end
+      end
+
+      # --- via: nil ---
+
+      test "inbox returns empty when no provider is available" do
+        assert_equal [], NotificationsGateway.inbox("301", via: nil)
+      end
+
+      test "mark_read returns failure shape when no provider is available" do
+        assert_equal({ success: false, raw: nil },
+          NotificationsGateway.mark_read(1001, "301", via: nil))
+      end
+
+      # --- delegation ---
+
+      test "inbox delegates with duz coerced and unread filter passed through" do
+        items = [ { ien: 1, message: "Lab result ready" } ]
+        fake = FakeNotificationsAPI.new(returns: { inbox: items })
+
+        result = NotificationsGateway.inbox(301, unread: true, via: fake)
+
+        assert_equal items, result
+        assert_equal [ "301" ], fake.calls.first[:args]
+        assert_equal true, fake.calls.first[:unread]
+      end
+
+      test "inbox defaults unread to nil when omitted" do
+        fake = FakeNotificationsAPI.new(returns: { inbox: [] })
+
+        NotificationsGateway.inbox("301", via: fake)
+
+        assert_nil fake.calls.first[:unread]
+      end
+
+      test "mark_read delegates with identifiers coerced to strings" do
+        fake = FakeNotificationsAPI.new(returns: { mark_read: { success: true, raw: "0" } })
+
+        result = NotificationsGateway.mark_read(1001, 301, via: fake)
+
+        assert_equal({ success: true, raw: "0" }, result)
+        assert_equal [ "1001", "301" ], fake.calls.first[:args]
+      end
+
+      # --- default_provider ---
+
+      test "default_provider resolves to RpmsRpc::Notifications when the gem ships it" do
+        provider = NotificationsGateway.default_provider
+        refute_nil provider, "expected RpmsRpc::Notifications to be loaded via the gateway's guarded require"
+        assert_equal "RpmsRpc::Notifications", provider.name
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/order_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/order_gateway_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for OrderGateway — clinical-order list APIs.
+# Wraps RpmsRpc::Order (lakeraven/rpms-rpc#68).
+module Lakeraven
+  module EHR
+    class OrderGatewayTest < ActiveSupport::TestCase
+      class FakeOrderAPI
+        attr_reader :calls
+
+        def initialize(returns: {})
+          @returns = returns
+          @calls = []
+        end
+
+        def unsigned_for_user(user_duz)
+          @calls << { method: :unsigned_for_user, args: [ user_duz ] }
+          @returns[:unsigned_for_user] || []
+        end
+
+        def list(dfn, status: :all, view: :default)
+          @calls << { method: :list, args: [ dfn ], status: status, view: view }
+          @returns[:list] || []
+        end
+      end
+
+      # --- via: nil ---
+
+      test "unsigned_for_user returns empty when no provider is available" do
+        assert_equal [], OrderGateway.unsigned_for_user("301", via: nil)
+      end
+
+      test "list returns empty when no provider is available" do
+        assert_equal [], OrderGateway.list(1, via: nil)
+      end
+
+      # --- delegation + coercion ---
+
+      test "unsigned_for_user delegates with duz coerced to a string" do
+        orders = [ { ien: 1, type: "LAB" } ]
+        fake = FakeOrderAPI.new(returns: { unsigned_for_user: orders })
+
+        assert_equal orders, OrderGateway.unsigned_for_user(301, via: fake)
+        assert_equal [ "301" ], fake.calls.first[:args]
+      end
+
+      test "list delegates with dfn coerced and symbolic taxonomies passed through" do
+        orders = [ { ien: 1, status: "A" } ]
+        fake = FakeOrderAPI.new(returns: { list: orders })
+
+        result = OrderGateway.list(1, status: :pending, view: :active, via: fake)
+
+        assert_equal orders, result
+        assert_equal [ "1" ], fake.calls.first[:args]
+        assert_equal :pending, fake.calls.first[:status]
+        assert_equal :active, fake.calls.first[:view]
+      end
+
+      test "list defaults to status: :all and view: :default when omitted" do
+        fake = FakeOrderAPI.new(returns: { list: [] })
+
+        OrderGateway.list(1, via: fake)
+
+        assert_equal :all, fake.calls.first[:status]
+        assert_equal :default, fake.calls.first[:view]
+      end
+
+      # --- default_provider ---
+
+      test "default_provider resolves to RpmsRpc::Order when the gem ships it" do
+        provider = OrderGateway.default_provider
+        refute_nil provider, "expected RpmsRpc::Order to be loaded via the gateway's guarded require"
+        assert_equal "RpmsRpc::Order", provider.name
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/service_request_gateway_create_test.rb
+++ b/test/gateways/lakeraven/ehr/service_request_gateway_create_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for ServiceRequestGateway#create — referral create via BGOREF SET.
+# Sits alongside the existing for_patient/delete/cancel tests.
+module Lakeraven
+  module EHR
+    class ServiceRequestGatewayCreateTest < ActiveSupport::TestCase
+      test "create returns success with the saved IEN when the RPC returns an IEN" do
+        RpmsRpc.client.seed_scalar(:referral_create, "1", "5050")
+
+        result = ServiceRequestGateway.create(1, {
+          provider_ien: 99999,
+          specialty: "Cardiology",
+          reason: "Chest pain workup",
+          priority: "ROUTINE",
+          requested_date: Date.new(2026, 6, 1)
+        })
+
+        assert result[:success]
+        assert_equal 5050, result[:ien]
+      end
+
+      test "create coerces an integer dfn to a string" do
+        RpmsRpc.client.seed_scalar(:referral_create, "1", "5051")
+
+        result = ServiceRequestGateway.create(1, { specialty: "Cardiology" })
+
+        assert result[:success]
+        assert_equal 5051, result[:ien]
+      end
+
+      test "create returns failure for nil dfn" do
+        result = ServiceRequestGateway.create(nil, { specialty: "Cardiology" })
+
+        refute result[:success]
+        assert_nil result[:ien]
+      end
+
+      test "create raises ArgumentError when params is not a Hash" do
+        assert_raises(ArgumentError) { ServiceRequestGateway.create(1, "not a hash") }
+      end
+    end
+  end
+end

--- a/test/gateways/lakeraven/ehr/symptom_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/symptom_gateway_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Tests for SymptomGateway — allergy-symptom catalog lookup for the
+# order-entry allergy-precheck UI.
+# Wraps RpmsRpc::Symptom (lakeraven/rpms-rpc#73).
+module Lakeraven
+  module EHR
+    class SymptomGatewayTest < ActiveSupport::TestCase
+      class FakeSymptomAPI
+        attr_reader :calls
+
+        def initialize(returns: {})
+          @returns = returns
+          @calls = []
+        end
+
+        def search(query)
+          @calls << { method: :search, args: [ query ] }
+          @returns[:search] || []
+        end
+
+        def defaults
+          @calls << { method: :defaults, args: [] }
+          @returns[:defaults] || []
+        end
+      end
+
+      # --- via: nil ---
+
+      test "search returns empty when no provider is available" do
+        assert_equal [], SymptomGateway.search("rash", via: nil)
+      end
+
+      test "defaults returns empty when no provider is available" do
+        assert_equal [], SymptomGateway.defaults(via: nil)
+      end
+
+      # --- delegation ---
+
+      test "search delegates with the query coerced to a string" do
+        list = [ { ien: 1, name: "Rash" } ]
+        fake = FakeSymptomAPI.new(returns: { search: list })
+
+        assert_equal list, SymptomGateway.search(:rash, via: fake)
+        assert_equal [ "rash" ], fake.calls.first[:args]
+      end
+
+      test "defaults delegates without arguments" do
+        list = [ { ien: 1, name: "Anaphylaxis" } ]
+        fake = FakeSymptomAPI.new(returns: { defaults: list })
+
+        assert_equal list, SymptomGateway.defaults(via: fake)
+      end
+
+      # --- default_provider ---
+
+      test "default_provider resolves to RpmsRpc::Symptom when the gem ships it" do
+        provider = SymptomGateway.default_provider
+        refute_nil provider, "expected RpmsRpc::Symptom to be loaded via the gateway's guarded require"
+        assert_equal "RpmsRpc::Symptom", provider.name
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Five net-new gateways for the order-entry / allergy-precheck / image-viewer-handoff / alert-inbox path. All five follow the full RemindersGateway pattern (guarded require + default_provider + via: DI) established in PRs #340, #342, #344:
  - \`OrderGateway\` — wraps RpmsRpc::Order (unsigned_for_user, list with status:/view: taxonomies)
  - \`SymptomGateway\` — wraps RpmsRpc::Symptom (search, defaults)
  - \`ImageGateway\` — wraps RpmsRpc::Image (exams_for_patient, launch_token with ttl_seconds:)
  - \`NotificationsGateway\` — wraps RpmsRpc::Notifications (inbox with unread: filter, mark_read)
  - \`ImmunizationRefusalGateway\` — wraps RpmsRpc::ImmunizationRefusal (record with reason_code: taxonomy)
- One extension in host-class style (hard require, no via:):
  - \`ServiceRequestGateway.create\` — wraps RpmsRpc::Referral.create, sits alongside the existing for_patient/delete/cancel methods

\`ImmunizationRefusalGateway\` is a separate gateway from the existing \`ImmunizationGateway\` to mirror the rpms-rpc separation — Immunization is read-only, refusal is a distinct BGOREP write. The existing \`ImmunizationGateway\` still delegates to RpmsRpc::Allergy with a TODO migration; that's a separate cleanup PR.

## Test plan
- [x] \`bundle exec rails test\` — 2699 runs, 5406 assertions, 0 failures, 0 errors, 1 pre-existing skip
- [x] \`bundle exec cucumber\` — 622/628; same 6 pre-existing failures as on \`main\`
- [x] \`bundle exec rubocop\` — clean on every changed file
- [x] 30 new tests across the 6 files; the 5 new gateways use FakeProvider doubles + via: injection; the ServiceRequestGateway.create test uses the host class's existing RpmsRpc.client.seed_* pattern

Closes #345
Part of #324