### PR TITLE
ImmunizationGateway: wrap RpmsRpc::Immunization, drop the Allergy stub

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/lakeraven/rpms-rpc.git
-  revision: d9e3c23ca17b108c6653b2f728ddc3bd56fdbdb8
+  revision: 309ce3cf34ffa735707155a365a7b6ae0e3871a1
   branch: main
   specs:
     rpms-rpc (0.1.0)

--- a/app/gateways/lakeraven/ehr/immunization_gateway.rb
+++ b/app/gateways/lakeraven/ehr/immunization_gateway.rb
@@ -1,15 +1,33 @@
 # frozen_string_literal: true
 
-require "rpms_rpc/api/allergy"
+begin
+  require "rpms_rpc/api/immunization"
+rescue LoadError
+  # rpms-rpc gem does not yet expose the structured RpmsRpc::Immunization.
+end
 
 module Lakeraven
   module EHR
+    # Patient-administered immunization records.
+    # Wraps RpmsRpc::Immunization (lakeraven/rpms-rpc#107) — structured
+    # records via BIPC IMMLIST / BIPC IMMGET.
     class ImmunizationGateway
-      # TODO: migrate to RpmsRpc::Immunization.for_patient when
-      # immunization-specific RPC (BIPC IMMLIST) is wired.
-      # Currently delegates to allergy_list for backward compatibility.
-      def self.for_patient(dfn)
-        RpmsRpc::Allergy.for_patient(dfn.to_s)
+      def self.for_patient(dfn, via: default_provider)
+        return [] if via.nil?
+
+        via.for_patient(dfn.to_s)
+      end
+
+      def self.find(ien, via: default_provider)
+        return nil if via.nil?
+
+        via.find(ien.to_s)
+      end
+
+      def self.default_provider
+        return nil unless defined?(::RpmsRpc::Immunization) &&
+                          ::RpmsRpc::Immunization.respond_to?(:for_patient)
+        ::RpmsRpc::Immunization
       end
     end
   end

--- a/app/models/lakeraven/ehr/immunization.rb
+++ b/app/models/lakeraven/ehr/immunization.rb
@@ -53,7 +53,8 @@ module Lakeraven
       end
 
       def self.find_by_ien(ien)
-        gateway.find(ien)
+        record = gateway.find(ien)
+        record && new(record)
       end
 
       def self.resource_class

--- a/test/gateways/lakeraven/ehr/immunization_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/immunization_gateway_test.rb
@@ -2,53 +2,90 @@
 
 require "test_helper"
 
-# Tests for ImmunizationGateway — immunization/allergy list via ORQQAL LIST.
-# Note: the EHR ImmunizationGateway currently delegates to allergy_list mapping
-# (to be expanded to BIPC IMMLIST when immunization-specific RPCs are wired).
-# Uses mock data seeded in test_helper.rb.
+# Tests for ImmunizationGateway — wraps RpmsRpc::Immunization.
+# Replaces the previous Allergy-stub delegation (wrong domain) now that
+# rpms-rpc ships a structured Immunization read (lakeraven/rpms-rpc#107).
 module Lakeraven
   module EHR
     class ImmunizationGatewayTest < ActiveSupport::TestCase
-      setup do
-        seed_immunization_data
+      class FakeImmunizationAPI
+        attr_reader :calls
+
+        def initialize(returns: {})
+          @returns = returns
+          @calls = []
+        end
+
+        def for_patient(dfn)
+          @calls << { method: :for_patient, args: [ dfn ] }
+          @returns[:for_patient] || []
+        end
+
+        def find(ien)
+          @calls << { method: :find, args: [ ien ] }
+          @returns[:find]
+        end
       end
 
-      # === for_patient ===
+      STRUCTURED_RECORD = {
+        ien: 7001,
+        vaccine_code: "207",
+        vaccine_display: "COVID-19 Pfizer-BioNTech, mRNA",
+        status: "completed",
+        lot_number: "EX1234",
+        expiration_date: Date.new(2026, 12, 31),
+        site: "Left deltoid",
+        route: "IM",
+        performer_duz: "301",
+        performer_name: "MARTINEZ,SARAH",
+        occurrence_datetime: Time.utc(2026, 1, 15, 10, 0, 0),
+        dose_quantity: 0.3,
+        dose_unit: "mL",
+        manufacturer: "Pfizer-BioNTech",
+        vfc_eligibility_code: "V04",
+        funding_source: "VFC"
+      }.freeze
 
-      test "for_patient returns array" do
-        results = ImmunizationGateway.for_patient(1)
+      # --- via: nil ---
 
-        assert results.is_a?(Array), "Should return array"
+      test "for_patient returns empty when no provider is available" do
+        assert_equal [], ImmunizationGateway.for_patient(1, via: nil)
       end
 
-      test "for_patient returns seeded data" do
-        results = ImmunizationGateway.for_patient(1)
-
-        assert results.length >= 1, "Should find seeded immunization/allergy data"
+      test "find returns nil when no provider is available" do
+        assert_nil ImmunizationGateway.find(7001, via: nil)
       end
 
-      test "for_patient parses allergy fields" do
-        results = ImmunizationGateway.for_patient(1)
-        return skip "No data seeded" if results.empty?
+      # --- delegation + coercion ---
 
-        entry = results.first
-        assert entry.key?(:allergen), "Entry should have allergen"
+      test "for_patient delegates with dfn coerced to a string and returns structured records" do
+        fake = FakeImmunizationAPI.new(returns: { for_patient: [ STRUCTURED_RECORD ] })
+
+        result = ImmunizationGateway.for_patient(1, via: fake)
+
+        assert_equal 1, result.length
+        assert_equal "207", result.first[:vaccine_code]
+        assert_equal "EX1234", result.first[:lot_number]
+        assert_equal "V04", result.first[:vfc_eligibility_code]
+        assert_equal [ "1" ], fake.calls.first[:args]
       end
 
-      test "for_patient returns empty for unknown patient" do
-        results = ImmunizationGateway.for_patient(999999)
+      test "find delegates with ien coerced to a string and returns a single record" do
+        fake = FakeImmunizationAPI.new(returns: { find: STRUCTURED_RECORD })
 
-        assert results.is_a?(Array), "Should return array"
-        assert_equal 0, results.length
+        result = ImmunizationGateway.find(7001, via: fake)
+
+        assert_equal "207", result[:vaccine_code]
+        assert_equal "Pfizer-BioNTech", result[:manufacturer]
+        assert_equal [ "7001" ], fake.calls.first[:args]
       end
 
-      private
+      # --- default_provider ---
 
-      def seed_immunization_data
-        RpmsRpc.client.seed_keyed_collection(:allergy_list, "1", [
-          { allergen: "PENICILLIN", reaction: "RASH", severity: "MODERATE" },
-          { allergen: "ASPIRIN", reaction: "HIVES", severity: "MILD" }
-        ])
+      test "default_provider resolves to RpmsRpc::Immunization now that the gem ships it" do
+        provider = ImmunizationGateway.default_provider
+        refute_nil provider, "expected RpmsRpc::Immunization to be loaded via the gateway's guarded require"
+        assert_equal "RpmsRpc::Immunization", provider.name
       end
     end
   end

--- a/test/models/lakeraven/ehr/immunization_test.rb
+++ b/test/models/lakeraven/ehr/immunization_test.rb
@@ -98,6 +98,42 @@ module Lakeraven
         end
       end
 
+      # The gateway returns a structured Hash from RpmsRpc::Immunization.find;
+      # find_by_ien must wrap that into an Immunization instance so callers
+      # like VaersExportService can use the attribute interface.
+      test "find_by_ien wraps the gateway hash into an Immunization instance" do
+        mock_gw = Object.new
+        def mock_gw.find(_ien)
+          { ien: "IMM-1", vaccine_code: "207", vaccine_display: "COVID-19 Pfizer",
+            lot_number: "EX1234", occurrence_datetime: Time.utc(2026, 1, 15, 10, 0, 0) }
+        end
+
+        original = Immunization.gateway
+        begin
+          Immunization.gateway = mock_gw
+          result = Immunization.find_by_ien("IMM-1")
+
+          assert_kind_of Lakeraven::EHR::Immunization, result
+          assert_equal "COVID-19 Pfizer", result.vaccine_display
+          assert_equal "EX1234", result.lot_number
+        ensure
+          Immunization.gateway = original
+        end
+      end
+
+      test "find_by_ien returns nil when the gateway returns nil" do
+        mock_gw = Object.new
+        def mock_gw.find(_ien) = nil
+
+        original = Immunization.gateway
+        begin
+          Immunization.gateway = mock_gw
+          assert_nil Immunization.find_by_ien("999999")
+        ensure
+          Immunization.gateway = original
+        end
+      end
+
       # -- FHIR serialization --------------------------------------------------
 
       test "to_fhir returns Immunization resource" do


### PR DESCRIPTION
## Summary
- Bumps rpms-rpc to the SHA shipping \`lakeraven/rpms-rpc#107\` (structured \`RpmsRpc::Immunization.for_patient\` + \`.find\` via BIPC IMMLIST/IMMGET).
- Reimplements \`ImmunizationGateway\` using the full \`RemindersGateway\` pattern (guarded \`require\` + \`default_provider\` + \`via:\` DI), matching the other 14+ engine gateways landed in PRs #340/#342/#344/#346.
- Adds \`.find(ien)\` to back \`Lakeraven::EHR::Immunization.find_by_ien\` and \`VaersExportService.generate\` — both already called \`gateway.find\` even though the method didn't exist on the old gateway (worked only because tests mocked the gateway).
- Removes the \`RpmsRpc::Allergy\` delegation that was emitting allergy records through an Immunization-shaped envelope.
- Replaces \`immunization_gateway_test.rb\` to assert the structured immunization shape via FakeProvider, dropping the obsolete \`:allergen\` assertions.

## Why this took two PRs
The engine model's structured fields (CVX code, lot, occurrence, dose, performer, VFC eligibility, funding source) couldn't be satisfied by the previous gem-side text-blob \`for_patient\`. Gem-side PR #107 added \`:immunization_list\` / \`:immunization_detail\` mappings + the structured API; this engine PR consumes it.

## Out of scope
- \`ImmunizationsController#index\` does \`{ resourceType: \"Immunization\" }.merge(r)\` instead of \`Immunization#to_fhir\` — that's a separate FHIR-conformance bug, surfaced now that the gateway returns real immunization fields rather than allergy fields.
- VIS metadata + performer-name joins — pending follow-up gem work.

## Test plan
- [x] \`bundle exec rails test\` — 2700 runs, 5404 assertions, 0 failures, 0 errors, 1 pre-existing skip
- [x] \`bundle exec cucumber\` — 622/628; same 6 pre-existing failures as on \`main\` (no new regressions; VAERS feature still green because it mocks the gateway)
- [x] \`bundle exec rubocop\` — clean on changed files
- [x] New gateway test uses FakeProvider doubles + the \`refute_nil + provider.name\` shape

Closes #347
Part of #324