### PR TITLE
ImmunizationsController#index: render via Immunization#to_fhir

### DIFF
--- a/app/controllers/lakeraven/ehr/immunizations_controller.rb
+++ b/app/controllers/lakeraven/ehr/immunizations_controller.rb
@@ -7,8 +7,7 @@ module Lakeraven
 
       def index
         dfn = params[:patient].to_s.delete_prefix("Patient/")
-        results = Immunization.for_patient(dfn)
-        render_bundle(results.map { |r| { resourceType: "Immunization" }.merge(r) })
+        render_bundle(Immunization.for_patient(dfn).map(&:to_fhir))
       end
 
       private

--- a/app/models/lakeraven/ehr/immunization.rb
+++ b/app/models/lakeraven/ehr/immunization.rb
@@ -49,7 +49,8 @@ module Lakeraven
       end
 
       def self.for_patient(dfn)
-        gateway.for_patient(dfn)
+        dfn_s = dfn.to_s
+        Array(gateway.for_patient(dfn_s)).map { |record| new(record.merge(patient_dfn: dfn_s)) }
       end
 
       def self.find_by_ien(ien)

--- a/test/controllers/lakeraven/ehr/immunizations_controller_test.rb
+++ b/test/controllers/lakeraven/ehr/immunizations_controller_test.rb
@@ -53,6 +53,41 @@ module Lakeraven
         get "/lakeraven-ehr/Immunization", params: { patient: "1" }
         assert_response :unauthorized
       end
+
+      # Entries should be proper FHIR resources from Immunization#to_fhir,
+      # not raw gateway hashes merged into a thin envelope.
+      test "entries render as FHIR-conformant Immunization resources" do
+        RpmsRpc.client.seed_keyed_collection(:immunization_list, "1", [
+          { ien: 7001, vaccine_code: "207", vaccine_display: "COVID-19 Pfizer-BioNTech, mRNA",
+            status: "completed", lot_number: "EX1234",
+            occurrence_datetime: Time.utc(2026, 1, 15, 10, 0, 0),
+            site: "Left deltoid", route: "IM", performer_duz: "301",
+            dose_quantity: 0.3, dose_unit: "mL", manufacturer: "Pfizer-BioNTech",
+            vfc_eligibility_code: "V04", funding_source: "VFC" }
+        ])
+
+        get "/lakeraven-ehr/Immunization", params: { patient: "1" }, headers: @headers
+        assert_response :ok
+
+        body = JSON.parse(response.body)
+        assert body["entry"].is_a?(Array), "bundle should have entries"
+        assert_equal 1, body["entry"].length, "expected one seeded immunization to render"
+
+        resource = body["entry"].first["resource"]
+
+        # FHIR-conformant key names from Immunization#to_fhir
+        assert_equal "Immunization", resource["resourceType"]
+        assert_equal "completed", resource["status"]
+        assert_equal "Patient/1", resource.dig("patient", "reference")
+        assert_equal "207", resource.dig("vaccineCode", "coding", 0, "code")
+        assert_equal "EX1234", resource["lotNumber"]
+        assert_includes resource["occurrenceDateTime"].to_s, "2026-01-15"
+
+        # Raw snake-case wire keys must not leak through into the FHIR envelope
+        refute resource.key?("vaccine_code"), "should not leak raw :vaccine_code key"
+        refute resource.key?("lot_number"), "should not leak raw :lot_number key"
+        refute resource.key?("occurrence_datetime"), "should not leak raw :occurrence_datetime key"
+      end
     end
   end
 end

--- a/test/models/lakeraven/ehr/immunization_test.rb
+++ b/test/models/lakeraven/ehr/immunization_test.rb
@@ -81,10 +81,14 @@ module Lakeraven
         assert_equal ImmunizationGateway, Immunization.gateway
       end
 
-      test "for_patient delegates to gateway" do
+      # The gateway returns Array of structured Hashes from
+      # RpmsRpc::Immunization.for_patient; the model class method wraps
+      # each into an Immunization instance and injects patient_dfn from
+      # the caller's argument (the wire hash doesn't carry it).
+      test "for_patient wraps each gateway hash into an Immunization instance with patient_dfn injected" do
         mock_gw = Object.new
         def mock_gw.for_patient(_dfn)
-          [ Lakeraven::EHR::Immunization.new(ien: "99", patient_dfn: "1", vaccine_display: "MOCK") ]
+          [ { ien: 99, vaccine_code: "207", vaccine_display: "MOCK" } ]
         end
 
         original = Immunization.gateway
@@ -92,7 +96,9 @@ module Lakeraven
           Immunization.gateway = mock_gw
           results = Immunization.for_patient(1)
           assert_equal 1, results.length
+          assert_kind_of Lakeraven::EHR::Immunization, results.first
           assert_equal "MOCK", results.first.vaccine_display
+          assert_equal "1", results.first.patient_dfn
         ensure
           Immunization.gateway = original
         end


### PR DESCRIPTION
## Summary
- \`Immunization.for_patient(dfn)\` wraps each gateway hash into an \`Immunization\` model instance and injects \`patient_dfn\` from the caller's argument (the wire hash doesn't carry it). Symmetric with what \`find_by_ien\` does after #348.
- \`ImmunizationsController#index\` calls \`.map(&:to_fhir)\` instead of \`.map { |r| { resourceType: \"Immunization\" }.merge(r) }\` — bundle entries are now proper FHIR \`Immunization\` resources with \`vaccineCode.coding\`, \`occurrenceDateTime\` ISO8601, \`patient.reference\`, etc. No more snake-case wire keys leaking through.
- Existing \`for_patient delegates to gateway\` model test updated to stub with a structured Hash (matching what the gateway actually returns) and assert the wrap + patient_dfn injection.
- Added a controller integration test that seeds \`:immunization_list\`, hits the FHIR endpoint, and asserts FHIR-conformant key names while refute-ing any raw snake_case key in the envelope.

## Why this was a follow-up
Surfaced by the Allergy→Immunization migration in #348. The old gateway returned allergy hashes, which the controller's \`.merge\` also leaked — same shape bug, different domain. With #348 the gateway returns real immunization fields, so the controller's leak is now visible (and now testable, hence this PR's failing-test → green flow).

## Test plan
- [x] \`bundle exec rails test\` — 2703 runs, 5421 assertions, 0 failures, 0 errors, 2 pre-existing skips
- [x] \`bundle exec cucumber\` — 622/628 (same 6 pre-existing failures)
- [x] \`bundle exec rubocop\` — clean on all 4 changed files
- [x] New controller test exercises FHIR-conformant key names and absence of raw wire keys

Closes #349
Part of #324