### PR TITLE
AuthenticationService: switch to UserRoles.resolve(user_class:) kwarg

### DIFF
--- a/app/services/lakeraven/ehr/authentication_service.rb
+++ b/app/services/lakeraven/ehr/authentication_service.rb
@@ -20,14 +20,11 @@ module Lakeraven
         raw_keys = fetch_raw_security_keys(duz_s)
         symbolic_keys = RpmsRpc::SecurityKeys.symbolize(raw_keys)
 
-        # The Authentication API resolves user_type from the AV CODE response's
-        # user_class field. Feed that back into UserRoles.resolve so its
-        # security-key elevation rules (e.g., PRCFA SUPERVISOR → case_manager)
-        # still apply on top.
-        user_info_for_resolve = (user_info || {}).merge(
-          is_provider: auth[:user_type] == "provider",
-          user_class: RpmsRpc::UserRoles.class_for(auth[:user_type])
-        )
+        # Authentication already resolved user_type from the AV CODE response's
+        # user_class. Round-trip back to the user_class short code so
+        # UserRoles.resolve's security-key elevation rules (e.g.,
+        # PRCFA SUPERVISOR → case_manager) still apply on top.
+        user_class = RpmsRpc::UserRoles.class_for(auth[:user_type])
 
         Result.new(
           success?: true,
@@ -35,7 +32,7 @@ module Lakeraven
           value: {
             duz: duz_s,
             name: user_info&.dig(:name) || auth[:name].to_s,
-            user_type: RpmsRpc::UserRoles.resolve(user_info: user_info_for_resolve, security_keys: symbolic_keys),
+            user_type: RpmsRpc::UserRoles.resolve(user_class: user_class, security_keys: symbolic_keys),
             security_keys: symbolic_keys
           }
         )


### PR DESCRIPTION
## Summary

Companion to **rpms-rpc PR #123** (https://github.com/lakeraven/rpms-rpc/pull/123). `RpmsRpc::UserRoles.resolve`'s signature changed there — the `user_info:` kwarg is gone, replaced by `user_class:` which takes the auth-class short code directly. The Gemfile here pins `rpms-rpc` to `branch: main`, so the moment that PR merges this app's bundle stops loading until this PR lands.

## What changed

- Drop the `user_info_for_resolve` hash construction in `Lakeraven::EHR::AuthenticationService#authenticate`
- Call `RpmsRpc::UserRoles.resolve(user_class: ..., security_keys: ...)` with `RpmsRpc::UserRoles.class_for(auth[:user_type])` as the new arg

## Why the round-trip

`auth[:user_type]` is the role string ("provider", "nurse", etc.) that `Authentication.authenticate` already resolved from the AV CODE response. We convert it back to the user_class number so `UserRoles.resolve`'s security-key elevation rules (e.g., PRCFA SUPERVISOR → case_manager) can still apply on top. Same logic as before, just with the new kwarg name.

## Result contract

`Result.value[:user_type]` is unchanged — only internal wiring shifts. Cucumber feature steps that assert on `@current_user.user_type` continue to pass.

## Coordination

Must merge atomically (or within seconds) of rpms-rpc PR #123, since this app tracks rpms-rpc main. Sequence:
1. CI + reviews on both PRs
2. Merge rpms-rpc PR #123
3. Immediately merge this PR