### PR TITLE
le-lnd: catch up 26 tests to rpms-rpc mapping reality

### DIFF
--- a/app/models/lakeraven/ehr/patient.rb
+++ b/app/models/lakeraven/ehr/patient.rb
@@ -38,6 +38,13 @@ module Lakeraven
       attribute :service_area, :string
       attribute :coverage_type, :string
 
+      # From ORWPT ID INFO — IHS single-letter race code (e.g. "I" =
+      # American Indian/Alaska Native) and the current site IEN. Distinct
+      # from `:race` which holds the long-form string and currently isn't
+      # populated by any RPC mapped to this codebase.
+      attribute :race_code, :string
+      attribute :site_ien, :integer
+
       # SOGI data elements (USCDI v3 / ONC 170.315(a)(15))
       attribute :sexual_orientation, :string
       attribute :gender_identity, :string

--- a/test/controllers/lakeraven/ehr/patients_controller_test.rb
+++ b/test/controllers/lakeraven/ehr/patients_controller_test.rb
@@ -32,7 +32,6 @@ module Lakeraven
       end
 
       test "response includes name family and given" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
         get "/lakeraven-ehr/Patient/1", headers: @headers
         body = JSON.parse(response.body)
         assert_equal "Anderson", body["name"].first["family"]
@@ -40,7 +39,6 @@ module Lakeraven
       end
 
       test "response includes gender and birthDate" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
         get "/lakeraven-ehr/Patient/1", headers: @headers
         body = JSON.parse(response.body)
         assert_equal "female", body["gender"]
@@ -48,7 +46,6 @@ module Lakeraven
       end
 
       test "response includes SSN identifier" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
         get "/lakeraven-ehr/Patient/1", headers: @headers
         body = JSON.parse(response.body)
         ssn_id = body["identifier"].find { |id| id["system"]&.include?("ssn") }

--- a/test/controllers/lakeraven/ehr/practitioners_controller_test.rb
+++ b/test/controllers/lakeraven/ehr/practitioners_controller_test.rb
@@ -24,12 +24,14 @@ module Lakeraven
         assert_equal "MARTINEZ", body["name"].first["family"]
       end
 
-      test "response includes NPI identifier" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
+      test "response excludes NPI identifier when source RPC cannot surface it" do
+        # ORWU USERINFO doesn't return NPI; until BHDPTRPC or equivalent is
+        # installed (rpms-rpc rr-6jr), the controller emits no NPI identifier.
         get "/lakeraven-ehr/Practitioner/101", headers: @headers
         body = JSON.parse(response.body)
-        npi_id = body["identifier"].find { |id| id["system"]&.include?("npi") }
-        assert_equal "1234567890", npi_id["value"]
+        identifiers = body["identifier"] || []
+        npi_id = identifiers.find { |id| id["system"]&.include?("npi") && id["value"].present? }
+        assert_nil npi_id
       end
 
       test "unknown IEN returns 404 OperationOutcome" do

--- a/test/gateways/lakeraven/ehr/patient_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/patient_gateway_test.rb
@@ -11,7 +11,6 @@ module Lakeraven
       # === find ===
 
       test "find returns patient by DFN" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
         patient = PatientGateway.find(1)
 
         assert_not_nil patient, "Should find patient"
@@ -23,19 +22,16 @@ module Lakeraven
         assert_equal 45, patient.age
       end
 
-      test "find merges extended demographics from patient_id_info" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
+      test "find merges identifier fields from patient_id_info" do
+        # ORWPT ID INFO surfaces race_code and site_ien on top of
+        # patient_select. Extended demographics (full race string,
+        # address, phone, tribal_enrollment_number, service_area,
+        # coverage_type) come from BHDPTRPC — not installed on staging
+        # (rpms-rpc rr-6jr).
         patient = PatientGateway.find(1)
 
-        assert_equal "AMERICAN INDIAN", patient.race
-        assert_equal "123 Main St", patient.address_line1
-        assert_equal "Anchorage", patient.city
-        assert_equal "AK", patient.state
-        assert_equal "99501", patient.zip_code
-        assert_equal "907-555-1234", patient.phone
-        assert_equal "ANLC-12345", patient.tribal_enrollment_number
-        assert_equal "Anchorage", patient.service_area
-        assert_equal "IHS", patient.coverage_type
+        assert_equal "I", patient.race_code
+        assert_equal 7819, patient.site_ien
       end
 
       test "find returns nil for invalid DFN" do
@@ -44,15 +40,14 @@ module Lakeraven
         assert_nil patient, "Should return nil for non-existent patient"
       end
 
-      test "find returns patient without extended demographics when unavailable" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
+      test "find returns patient with only core demographics when no extended source available" do
         patient = PatientGateway.find(2)
 
         assert_not_nil patient
         assert_equal "MOUSE,MICKEY M", patient.name
         assert_equal "M", patient.sex
-        # Extended fields come from patient_id_info seed for DFN 2
-        assert_equal "AMERICAN INDIAN", patient.race
+        # The long-form :race string comes from BHDPTRPC; not surfaced.
+        assert_nil patient.race
       end
 
       # === search ===
@@ -119,7 +114,6 @@ module Lakeraven
       end
 
       test "patient from gateway has synced composite fields" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
         patient = PatientGateway.find(1)
 
         assert_equal patient.dob, patient.born_on, "born_on should sync with dob"

--- a/test/gateways/lakeraven/ehr/practitioner_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/practitioner_gateway_test.rb
@@ -10,31 +10,24 @@ module Lakeraven
     class PractitionerGatewayTest < ActiveSupport::TestCase
       # === find ===
 
-      test "find returns practitioner by IEN" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
+      test "find returns practitioner by IEN when IEN matches session user" do
+        # ORWU USERINFO returns the AUTHENTICATED session user only.
+        # name + ien are surfaceable; title, service_section, specialty,
+        # npi, dea_number, phone, provider_class come from a different
+        # RPC not currently mapped (see rpms-rpc rr-fyf for the rationale).
         practitioner = PractitionerGateway.find(101)
 
         assert_not_nil practitioner, "Should find practitioner"
         assert_instance_of Practitioner, practitioner
         assert_equal 101, practitioner.ien
         assert_equal "MARTINEZ,SARAH", practitioner.name
-        assert_equal "MD", practitioner.title
-        assert_equal "Internal Medicine", practitioner.service_section
-        assert_equal "Cardiology", practitioner.specialty
-        assert_equal "1234567890", practitioner.npi
-        assert_equal "AM1234563", practitioner.dea_number
-        assert_equal "907-555-9999", practitioner.phone
-        assert_equal "Physician", practitioner.provider_class
       end
 
-      test "find returns second practitioner" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
+      test "find returns nil for IEN that does not match session user" do
+        # ORWU USERINFO can't look up arbitrary IENs — see rpms-rpc rr-fyf.
         practitioner = PractitionerGateway.find(102)
 
-        assert_not_nil practitioner
-        assert_equal "CHEN,JAMES", practitioner.name
-        assert_equal "DO", practitioner.title
-        assert_equal "Orthopedic Surgery", practitioner.specialty
+        assert_nil practitioner
       end
 
       test "find returns nil for invalid IEN" do
@@ -82,13 +75,14 @@ module Lakeraven
         assert practitioner.persisted?, "Practitioner with IEN should be persisted"
       end
 
-      test "practitioner can_prescribe_controlled reflects DEA presence" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
-        with_dea = PractitionerGateway.find(101)
-        assert with_dea.can_prescribe_controlled?, "Practitioner with DEA should be able to prescribe"
+      test "can_prescribe_controlled reflects DEA presence on the model" do
+        # Verified at the model level — the gateway can't surface a
+        # practitioner's DEA number from ORWU USERINFO (see rr-fyf).
+        with_dea = Practitioner.new(ien: 101, name: "MARTINEZ,SARAH", dea_number: "AM1234563")
+        assert with_dea.can_prescribe_controlled?
 
-        without_dea = PractitionerGateway.find(102)
-        refute without_dea.can_prescribe_controlled?, "Practitioner without DEA should not be able to prescribe"
+        without_dea = Practitioner.new(ien: 102, name: "CHEN,JAMES", dea_number: nil)
+        refute without_dea.can_prescribe_controlled?
       end
     end
   end

--- a/test/gateways/lakeraven/ehr/site_gateway_test.rb
+++ b/test/gateways/lakeraven/ehr/site_gateway_test.rb
@@ -79,18 +79,22 @@ module Lakeraven
 
       # --- end-to-end against the real provider ---
 
-      test "list returns the seeded divisions end-to-end" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
+      test "list returns the authenticated user's single current site end-to-end" do
+        # BEHOSICX SITEINFO is single-site / no-param on the live broker
+        # (see rpms-rpc rr-5tm); the prior multi-site fixture pattern no
+        # longer reflects reality. RpmsRpc::Site.list wraps the single
+        # current site in a one-element Array for backward compat.
         skip "Requires RpmsRpc::Site (lakeraven/rpms-rpc#100)" unless SiteGateway.default_provider
 
-        RpmsRpc.client.seed_keyed_collection(:site_info, "301", [
-          { ien: 539, name: "TEST SERVICE UNIT", abbreviation: "TSU", current: true },
-          { ien: 540, name: "TEST CLINIC A", abbreviation: "TCA", current: false }
-        ])
+        RpmsRpc.client.seed_lines(:site_info, "", {
+          domain: "RPMS.LAKERAVEN.COM", name: "TEST SERVICE UNIT",
+          abbreviation: "TSU", state: "AK", address: "1 Test St",
+          city: "TestCity", zip: "99501", ien: 539
+        })
 
         sites = SiteGateway.list("301")
 
-        assert_equal [ 539, 540 ], sites.map { |s| s[:ien] }
+        assert_equal [ 539 ], sites.map { |s| s[:ien] }
       end
     end
   end

--- a/test/models/lakeraven/ehr/patient_test.rb
+++ b/test/models/lakeraven/ehr/patient_test.rb
@@ -9,7 +9,6 @@ module Lakeraven
       # -- find_by_dfn -----------------------------------------------------------
 
       test "find_by_dfn returns a Patient for a known DFN" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
         patient = Patient.find_by_dfn(1)
         assert_not_nil patient
         assert_kind_of Patient, patient
@@ -30,14 +29,15 @@ module Lakeraven
         assert_nil Patient.find_by_dfn(nil)
       end
 
-      test "find_by_dfn merges extended demographics" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
+      test "find_by_dfn merges identifier fields from patient_id_info" do
+        # ORWPT ID INFO contributes the IHS race code and current site IEN
+        # to the merged patient hash; extended demographics (full race
+        # string, address, phone, tribal_enrollment_number) require
+        # BHDPTRPC NEWPERSON/PATIENT which isn't installed on staging
+        # (tracked as rr-6jr in rpms-rpc).
         patient = Patient.find_by_dfn(1)
-        assert_equal "AMERICAN INDIAN", patient.race
-        assert_equal "123 Main St", patient.address_line1
-        assert_equal "AK", patient.state
-        assert_equal "907-555-1234", patient.phone
-        assert_equal "ANLC-12345", patient.tribal_enrollment_number
+        assert_equal "I", patient.race_code
+        assert_equal 7819, patient.site_ien
       end
 
       # -- find (raises) --------------------------------------------------------
@@ -140,8 +140,8 @@ module Lakeraven
       # -- to_fhir ---------------------------------------------------------------
 
       test "to_fhir returns a FHIR Patient hash" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
-        patient = Patient.find_by_dfn(1)
+        patient = Patient.new(dfn: 1, name: "Anderson,Alice", sex: "F",
+                              dob: Date.new(1980, 5, 15), ssn: "111-11-1111")
         fhir = patient.to_fhir
 
         assert_equal "Patient", fhir[:resourceType]
@@ -161,8 +161,7 @@ module Lakeraven
       end
 
       test "to_fhir includes SSN identifier" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
-        patient = Patient.find_by_dfn(1)
+        patient = Patient.new(dfn: 1, name: "Anderson,Alice", ssn: "111-11-1111")
         fhir = patient.to_fhir
 
         ssn_id = fhir[:identifier].find { |id| id[:system]&.include?("ssn") }
@@ -170,16 +169,16 @@ module Lakeraven
       end
 
       test "to_fhir includes birthDate" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
-        patient = Patient.find_by_dfn(1)
+        patient = Patient.new(dfn: 1, name: "Anderson,Alice", dob: Date.new(1980, 5, 15))
         fhir = patient.to_fhir
 
         assert_equal "1980-05-15", fhir[:birthDate]
       end
 
       test "to_fhir includes address" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
-        patient = Patient.find_by_dfn(1)
+        patient = Patient.new(dfn: 1, name: "Anderson,Alice",
+                              address_line1: "123 Main St", city: "Anchorage",
+                              state: "AK", zip_code: "99501")
         fhir = patient.to_fhir
 
         addr = fhir[:address]&.first
@@ -188,8 +187,7 @@ module Lakeraven
       end
 
       test "to_fhir includes telecom" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
-        patient = Patient.find_by_dfn(1)
+        patient = Patient.new(dfn: 1, name: "Anderson,Alice", phone: "907-555-1234")
         fhir = patient.to_fhir
 
         telecom = fhir[:telecom]&.first
@@ -197,8 +195,7 @@ module Lakeraven
       end
 
       test "to_fhir includes race extension" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
-        patient = Patient.find_by_dfn(1)
+        patient = Patient.new(dfn: 1, name: "Anderson,Alice", race: "American Indian or Alaska Native")
         fhir = patient.to_fhir
 
         race_ext = fhir[:extension]&.find { |e| e[:url]&.include?("race") }
@@ -337,8 +334,9 @@ module Lakeraven
       end
 
       test "to_fhir supports US Core Patient profile requirements" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
-        patient = Patient.find_by_dfn(1)
+        patient = Patient.new(dfn: 1, name: "Anderson,Alice", sex: "F",
+                              dob: Date.new(1980, 5, 15), ssn: "111-11-1111",
+                              race: "American Indian or Alaska Native")
         fhir = patient.to_fhir
 
         assert fhir[:identifier]&.any?, "US Core requires identifier"
@@ -372,7 +370,6 @@ module Lakeraven
       # =========================================================================
 
       test "find delegates to PatientRepository" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
         patient = Patient.find(1)
 
         assert_instance_of Patient, patient
@@ -500,7 +497,6 @@ module Lakeraven
       end
 
       test "find via repository returns patient" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
         found = Patient.find(1)
         assert_equal 1, found.dfn
         assert_equal "Anderson,Alice", found.name

--- a/test/repositories/lakeraven/ehr/patient_repository_test.rb
+++ b/test/repositories/lakeraven/ehr/patient_repository_test.rb
@@ -10,7 +10,6 @@ module Lakeraven
       # =============================================================================
 
       test "find returns Patient for known DFN" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
         patient = PatientRepository.find(1)
 
         assert_instance_of Patient, patient
@@ -27,21 +26,19 @@ module Lakeraven
         assert_nil PatientRepository.find("")
       end
 
-      test "find merges extended demographics" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
+      test "find merges identifier fields from patient_id_info" do
+        # ORWPT ID INFO contributes race_code + site_ien on top of
+        # patient_select. The long-form :race string, address, city,
+        # phone, tribal_enrollment_number, service_area, coverage_type
+        # all come from BHDPTRPC, which is uninstalled on staging
+        # (rpms-rpc rr-6jr).
         patient = PatientRepository.find(1)
 
-        assert_equal "AMERICAN INDIAN", patient.race
-        assert_equal "123 Main St", patient.address_line1
-        assert_equal "Anchorage", patient.city
-      end
-
-      test "find includes tribal enrollment data" do
-        skip "le-lnd: pending lakeraven-ehr catch-up with rpms-rpc PR #121/#122/#124 mapping fixes"
-        patient = PatientRepository.find(1)
-
-        assert_equal "ANLC-12345", patient.tribal_enrollment_number
-        assert_equal "Anchorage", patient.service_area
+        assert_equal "I", patient.race_code
+        assert_equal 7819, patient.site_ien
+        assert_nil patient.race
+        assert_nil patient.address_line1
+        assert_nil patient.tribal_enrollment_number
       end
 
       # =============================================================================

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,14 +17,24 @@ RpmsRpc.mock! do |m|
   m.seed(:patient_select, "2", { name: "MOUSE,MICKEY M", sex: "M", dob: Date.parse("2010-02-14"), ssn: "000009999", age: 16 })
   m.seed(:patient_select, "3", { name: "DOE,JANE", sex: "F", dob: Date.parse("1990-12-25"), ssn: "555667777", age: 35 })
 
-  m.seed(:patient_id_info, "1", { race: "AMERICAN INDIAN", address_line1: "123 Main St", city: "Anchorage", state: "AK",
-                                   zip_code: "99501", phone: "907-555-1234", tribal_enrollment_number: "ANLC-12345",
-                                   service_area: "Anchorage", coverage_type: "IHS" })
-  m.seed(:patient_id_info, "2", { race: "AMERICAN INDIAN", address_line1: "456 Disney Ave", city: "Orlando", state: "FL",
-                                   zip_code: "32801", phone: "555-5678", tribal_enrollment_number: "NN-67890",
-                                   service_area: "Arizona", coverage_type: "IHS/Medicaid" })
-  m.seed(:patient_id_info, "3", { race: "AMERICAN INDIAN", tribal_enrollment_number: "CNO-24680",
-                                   service_area: "Oklahoma", coverage_type: "IHS" })
+  # patient_id_info now returns the identifier projection from ORWPT ID INFO
+  # (SSN/DOB/sex/race_code/site_ien/name) — not the extended demographics
+  # that the prior mapping hallucinated. Address, phone, tribal enrollment,
+  # service_area, coverage_type aren't surfaceable until BHDPTRPC is
+  # installed on staging (rr-6jr). Tests that need those fields construct
+  # Patient.new(...) directly rather than going through the gateway.
+  m.seed(:patient_id_info, "1", {
+    ssn: "111-11-1111", dob: Date.parse("1980-05-15"), sex: "F",
+    race_code: "I", site_ien: 7819, name: "Anderson,Alice"
+  })
+  m.seed(:patient_id_info, "2", {
+    ssn: "000009999", dob: Date.parse("2010-02-14"), sex: "M",
+    race_code: "I", site_ien: 7819, name: "MOUSE,MICKEY M"
+  })
+  m.seed(:patient_id_info, "3", {
+    ssn: "555667777", dob: Date.parse("1990-12-25"), sex: "F",
+    race_code: "I", site_ien: 7819, name: "DOE,JANE"
+  })
 
   m.seed(:patient_ssn, "111-11-1111", { dfn: 1, name: "Anderson,Alice", ssn: "111-11-1111" })
 


### PR DESCRIPTION
## Summary

Closes le-lnd. The 26 tests PR #354 skipped asserted on fields the corrected rpms-rpc mappings no longer populate (`race`/`address`/`phone`/`tribal_enrollment_number` etc. on Patient, `title`/`npi`/`specialty`/`dea_number` etc. on Practitioner, and a multi-site `Site.list` shape that the real RPC doesn't return). Each test rewritten in the spirit of the bd's three resolution paths.

## Approach per file

- **`patient_test.rb` (11 tests)** — All `to_fhir` / serialization tests construct `Patient.new(...)` directly with the data they're testing. `find_by_dfn merges extended demographics` rewritten as `find_by_dfn merges identifier fields from patient_id_info` — asserts `race_code` + `site_ien` (the new ORWPT ID INFO surface).
- **`patient_gateway_test.rb` (4)** — Same pattern. The "without extended demographics" test now asserts `:race` is `nil` (long-form race comes from BHDPTRPC, not on staging).
- **`patient_repository_test.rb` (3)** — Two old skipped tests merged into one that asserts both what IS surfaced (`race_code`, `site_ien`) and what ISN'T (`race`, `address_line1`, `tribal_enrollment_number`).
- **`patients_controller_test.rb` (4)** — Unskipped; tests already pass with the updated `test_helper.rb` patient_id_info seed.
- **`practitioner_gateway_test.rb` (3)** — `find returns second practitioner` rewritten to assert `nil` (ORWU USERINFO returns only the session user, rpms-rpc rr-fyf). DEA-presence test moved to model-level via `Practitioner.new(...)`.
- **`practitioners_controller_test.rb` (1)** — NPI assertion inverted to verify the controller emits no NPI identifier until source RPC arrives.
- **`site_gateway_test.rb` (1)** — Rewritten for single-site `BEHOSICX SITEINFO` shape (rpms-rpc rr-5tm).

## Model changes

`Patient` gains `:race_code` (`:string`) and `:site_ien` (`:integer`) attributes — the new ORWPT ID INFO surface. `:race` (long-form string) stays declared but unpopulated until BHDPTRPC is installed (rpms-rpc rr-6jr).

## test_helper

`patient_id_info` seeds rewritten to use the new mapping field names (`ssn`/`dob`/`sex`/`race_code`/`site_ien`/`name`) so the gateway returns parseable data. SSN format normalized to dashed `111-11-1111` so the merge with `patient_select` doesn't change the value seen by `to_fhir` consumers.

## Test plan

- [x] Full suite: `bundle exec rails test` — **2704 runs, 5401 assertions, 0 failures, 0 errors, 1 skip** (pre-existing, unrelated)
- [x] Lint: `bundle exec rubocop app test` — 405 files inspected, 0 offenses

## Linked

- Closes le-lnd
- Related: rpms-rpc rr-6jr (BHDPTRPC install — would unblock the dropped Patient demographics)
- Related: rpms-rpc rr-fyf (UserManagement.find / Practitioner.find session-user limitation)
- Related: rpms-rpc rr-5tm (Site.list single-record shape)