### PR TITLE
Drop fallback guards for shipped rpms-rpc gem APIs

### DIFF
--- a/app/gateways/lakeraven/ehr/capabilities_gateway.rb
+++ b/app/gateways/lakeraven/ehr/capabilities_gateway.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-begin
-  require "rpms_rpc/capabilities"
-rescue LoadError
-  # rpms-rpc gem does not yet expose RpmsRpc::Capabilities.imaging_user?.
-end
+require "rpms_rpc/capabilities"
 
 module Lakeraven
   module EHR
     # Imaging-access predicate fired on every chart open.
-    # Wraps RpmsRpc::Capabilities.imaging_user? (lakeraven/rpms-rpc#101).
+    # Wraps RpmsRpc::Capabilities.imaging_user? 
     #
     # Accepts a plain DUZ string/integer at the engine boundary and adapts
     # to the user-shaped object the underlying predicate expects.
@@ -25,8 +21,6 @@ module Lakeraven
       end
 
       def self.default_provider
-        return nil unless defined?(::RpmsRpc::Capabilities) &&
-                          ::RpmsRpc::Capabilities.respond_to?(:imaging_user?)
         ::RpmsRpc::Capabilities
       end
     end

--- a/app/gateways/lakeraven/ehr/capabilities_gateway.rb
+++ b/app/gateways/lakeraven/ehr/capabilities_gateway.rb
@@ -5,7 +5,7 @@ require "rpms_rpc/capabilities"
 module Lakeraven
   module EHR
     # Imaging-access predicate fired on every chart open.
-    # Wraps RpmsRpc::Capabilities.imaging_user? 
+    # Wraps RpmsRpc::Capabilities.imaging_user?
     #
     # Accepts a plain DUZ string/integer at the engine boundary and adapts
     # to the user-shaped object the underlying predicate expects.

--- a/app/gateways/lakeraven/ehr/e_signature_gateway.rb
+++ b/app/gateways/lakeraven/ehr/e_signature_gateway.rb
@@ -7,7 +7,7 @@ module Lakeraven
     # TIU e-signature: validate a user's signature code, look up which
     # signing action is permitted on a note, add a signature (sign /
     # cosign / addend), and remove an existing signature.
-    # Wraps RpmsRpc::ESignature 
+    # Wraps RpmsRpc::ESignature
     class ESignatureGateway
       SIGN_FAILURE = { success: false, raw: nil }.freeze
 

--- a/app/gateways/lakeraven/ehr/e_signature_gateway.rb
+++ b/app/gateways/lakeraven/ehr/e_signature_gateway.rb
@@ -1,17 +1,13 @@
 # frozen_string_literal: true
 
-begin
-  require "rpms_rpc/api/e_signature"
-rescue LoadError
-  # rpms-rpc gem does not yet expose RpmsRpc::ESignature.
-end
+require "rpms_rpc/api/e_signature"
 
 module Lakeraven
   module EHR
     # TIU e-signature: validate a user's signature code, look up which
     # signing action is permitted on a note, add a signature (sign /
     # cosign / addend), and remove an existing signature.
-    # Wraps RpmsRpc::ESignature (lakeraven/rpms-rpc#58).
+    # Wraps RpmsRpc::ESignature 
     class ESignatureGateway
       SIGN_FAILURE = { success: false, raw: nil }.freeze
 
@@ -40,8 +36,6 @@ module Lakeraven
       end
 
       def self.default_provider
-        return nil unless defined?(::RpmsRpc::ESignature) &&
-                          ::RpmsRpc::ESignature.respond_to?(:add)
         ::RpmsRpc::ESignature
       end
     end

--- a/app/gateways/lakeraven/ehr/exam_component_gateway.rb
+++ b/app/gateways/lakeraven/ehr/exam_component_gateway.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-begin
-  require "rpms_rpc/api/exam_component"
-rescue LoadError
-  # rpms-rpc gem does not yet expose RpmsRpc::ExamComponent.
-end
+require "rpms_rpc/api/exam_component"
 
 module Lakeraven
   module EHR
     # Physical-exam component entry against an open encounter.
-    # Wraps RpmsRpc::ExamComponent (lakeraven/rpms-rpc#66).
+    # Wraps RpmsRpc::ExamComponent 
     class ExamComponentGateway
       FAILURE = { success: false, ien: nil, raw: nil }.freeze
 
@@ -21,8 +17,6 @@ module Lakeraven
       end
 
       def self.default_provider
-        return nil unless defined?(::RpmsRpc::ExamComponent) &&
-                          ::RpmsRpc::ExamComponent.respond_to?(:add)
         ::RpmsRpc::ExamComponent
       end
     end

--- a/app/gateways/lakeraven/ehr/exam_component_gateway.rb
+++ b/app/gateways/lakeraven/ehr/exam_component_gateway.rb
@@ -5,7 +5,7 @@ require "rpms_rpc/api/exam_component"
 module Lakeraven
   module EHR
     # Physical-exam component entry against an open encounter.
-    # Wraps RpmsRpc::ExamComponent 
+    # Wraps RpmsRpc::ExamComponent
     class ExamComponentGateway
       FAILURE = { success: false, ien: nil, raw: nil }.freeze
 

--- a/app/gateways/lakeraven/ehr/health_factor_gateway.rb
+++ b/app/gateways/lakeraven/ehr/health_factor_gateway.rb
@@ -5,7 +5,7 @@ require "rpms_rpc/api/health_factor"
 module Lakeraven
   module EHR
     # IHS-specific structured observation entry against an open encounter.
-    # Wraps RpmsRpc::HealthFactor 
+    # Wraps RpmsRpc::HealthFactor
     class HealthFactorGateway
       FAILURE = { success: false, ien: nil, raw: nil }.freeze
 

--- a/app/gateways/lakeraven/ehr/health_factor_gateway.rb
+++ b/app/gateways/lakeraven/ehr/health_factor_gateway.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-begin
-  require "rpms_rpc/api/health_factor"
-rescue LoadError
-  # rpms-rpc gem does not yet expose RpmsRpc::HealthFactor.
-end
+require "rpms_rpc/api/health_factor"
 
 module Lakeraven
   module EHR
     # IHS-specific structured observation entry against an open encounter.
-    # Wraps RpmsRpc::HealthFactor (lakeraven/rpms-rpc#65).
+    # Wraps RpmsRpc::HealthFactor 
     class HealthFactorGateway
       FAILURE = { success: false, ien: nil, raw: nil }.freeze
 
@@ -21,8 +17,6 @@ module Lakeraven
       end
 
       def self.default_provider
-        return nil unless defined?(::RpmsRpc::HealthFactor) &&
-                          ::RpmsRpc::HealthFactor.respond_to?(:add)
         ::RpmsRpc::HealthFactor
       end
     end

--- a/app/gateways/lakeraven/ehr/image_gateway.rb
+++ b/app/gateways/lakeraven/ehr/image_gateway.rb
@@ -7,7 +7,7 @@ module Lakeraven
     # Imaging-study list and viewer-launch handoff. The viewer is a
     # desktop component external to RPMS; the gateway issues a token
     # the front-end hands off to whatever viewer is configured.
-    # Wraps RpmsRpc::Image 
+    # Wraps RpmsRpc::Image
     class ImageGateway
       DEFAULT_TTL_SECONDS = 300
 

--- a/app/gateways/lakeraven/ehr/image_gateway.rb
+++ b/app/gateways/lakeraven/ehr/image_gateway.rb
@@ -1,17 +1,13 @@
 # frozen_string_literal: true
 
-begin
-  require "rpms_rpc/api/image"
-rescue LoadError
-  # rpms-rpc gem does not yet expose RpmsRpc::Image.
-end
+require "rpms_rpc/api/image"
 
 module Lakeraven
   module EHR
     # Imaging-study list and viewer-launch handoff. The viewer is a
     # desktop component external to RPMS; the gateway issues a token
     # the front-end hands off to whatever viewer is configured.
-    # Wraps RpmsRpc::Image (lakeraven/rpms-rpc#75).
+    # Wraps RpmsRpc::Image 
     class ImageGateway
       DEFAULT_TTL_SECONDS = 300
 
@@ -28,8 +24,6 @@ module Lakeraven
       end
 
       def self.default_provider
-        return nil unless defined?(::RpmsRpc::Image) &&
-                          ::RpmsRpc::Image.respond_to?(:launch_token)
         ::RpmsRpc::Image
       end
     end

--- a/app/gateways/lakeraven/ehr/immunization_gateway.rb
+++ b/app/gateways/lakeraven/ehr/immunization_gateway.rb
@@ -5,8 +5,7 @@ require "rpms_rpc/api/immunization"
 module Lakeraven
   module EHR
     # Patient-administered immunization records.
-    # Wraps RpmsRpc::Immunization (lakeraven/rpms-rpc#107) — structured
-    # records via BIPC IMMLIST / BIPC IMMGET.
+    # Wraps RpmsRpc::Immunization — structured records via BIPC IMMLIST / BIPC IMMGET.
     class ImmunizationGateway
       def self.for_patient(dfn, via: default_provider)
         return [] if via.nil?

--- a/app/gateways/lakeraven/ehr/immunization_gateway.rb
+++ b/app/gateways/lakeraven/ehr/immunization_gateway.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-begin
-  require "rpms_rpc/api/immunization"
-rescue LoadError
-  # rpms-rpc gem does not yet expose the structured RpmsRpc::Immunization.
-end
+require "rpms_rpc/api/immunization"
 
 module Lakeraven
   module EHR
@@ -25,8 +21,6 @@ module Lakeraven
       end
 
       def self.default_provider
-        return nil unless defined?(::RpmsRpc::Immunization) &&
-                          ::RpmsRpc::Immunization.respond_to?(:for_patient)
         ::RpmsRpc::Immunization
       end
     end

--- a/app/gateways/lakeraven/ehr/immunization_refusal_gateway.rb
+++ b/app/gateways/lakeraven/ehr/immunization_refusal_gateway.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
-begin
-  require "rpms_rpc/api/immunization_refusal"
-rescue LoadError
-  # rpms-rpc gem does not yet expose RpmsRpc::ImmunizationRefusal.
-end
+require "rpms_rpc/api/immunization_refusal"
 
 module Lakeraven
   module EHR
     # Records a patient's refusal of an immunization on the open encounter.
     # Distinct from ImmunizationGateway (read-only).
-    # Wraps RpmsRpc::ImmunizationRefusal (lakeraven/rpms-rpc#76).
+    # Wraps RpmsRpc::ImmunizationRefusal 
     class ImmunizationRefusalGateway
       FAILURE = { success: false, ien: nil, raw: nil }.freeze
 
@@ -22,8 +18,6 @@ module Lakeraven
       end
 
       def self.default_provider
-        return nil unless defined?(::RpmsRpc::ImmunizationRefusal) &&
-                          ::RpmsRpc::ImmunizationRefusal.respond_to?(:record)
         ::RpmsRpc::ImmunizationRefusal
       end
     end

--- a/app/gateways/lakeraven/ehr/immunization_refusal_gateway.rb
+++ b/app/gateways/lakeraven/ehr/immunization_refusal_gateway.rb
@@ -6,7 +6,7 @@ module Lakeraven
   module EHR
     # Records a patient's refusal of an immunization on the open encounter.
     # Distinct from ImmunizationGateway (read-only).
-    # Wraps RpmsRpc::ImmunizationRefusal 
+    # Wraps RpmsRpc::ImmunizationRefusal
     class ImmunizationRefusalGateway
       FAILURE = { success: false, ien: nil, raw: nil }.freeze
 

--- a/app/gateways/lakeraven/ehr/measurement_gateway.rb
+++ b/app/gateways/lakeraven/ehr/measurement_gateway.rb
@@ -6,7 +6,7 @@ module Lakeraven
   module EHR
     # PCC measurement entry (height, weight, BMI, etc.) against an open
     # encounter. Distinct from clinical vitals (VitalGateway / BEHOVM).
-    # Wraps RpmsRpc::Measurement 
+    # Wraps RpmsRpc::Measurement
     class MeasurementGateway
       FAILURE = { success: false, ien: nil, raw: nil }.freeze
 

--- a/app/gateways/lakeraven/ehr/measurement_gateway.rb
+++ b/app/gateways/lakeraven/ehr/measurement_gateway.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
-begin
-  require "rpms_rpc/api/measurement"
-rescue LoadError
-  # rpms-rpc gem does not yet expose RpmsRpc::Measurement.
-end
+require "rpms_rpc/api/measurement"
 
 module Lakeraven
   module EHR
     # PCC measurement entry (height, weight, BMI, etc.) against an open
     # encounter. Distinct from clinical vitals (VitalGateway / BEHOVM).
-    # Wraps RpmsRpc::Measurement (lakeraven/rpms-rpc#67).
+    # Wraps RpmsRpc::Measurement 
     class MeasurementGateway
       FAILURE = { success: false, ien: nil, raw: nil }.freeze
 
@@ -22,8 +18,6 @@ module Lakeraven
       end
 
       def self.default_provider
-        return nil unless defined?(::RpmsRpc::Measurement) &&
-                          ::RpmsRpc::Measurement.respond_to?(:add)
         ::RpmsRpc::Measurement
       end
     end

--- a/app/gateways/lakeraven/ehr/note_template_gateway.rb
+++ b/app/gateways/lakeraven/ehr/note_template_gateway.rb
@@ -5,7 +5,7 @@ require "rpms_rpc/api/note_template"
 module Lakeraven
   module EHR
     # TIU note template tree, boilerplate text, and per-user access level.
-    # Wraps RpmsRpc::NoteTemplate 
+    # Wraps RpmsRpc::NoteTemplate
     class NoteTemplateGateway
       def self.roots(user_duz, via: default_provider)
         return [] if via.nil?

--- a/app/gateways/lakeraven/ehr/note_template_gateway.rb
+++ b/app/gateways/lakeraven/ehr/note_template_gateway.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-begin
-  require "rpms_rpc/api/note_template"
-rescue LoadError
-  # rpms-rpc gem does not yet expose RpmsRpc::NoteTemplate.
-end
+require "rpms_rpc/api/note_template"
 
 module Lakeraven
   module EHR
     # TIU note template tree, boilerplate text, and per-user access level.
-    # Wraps RpmsRpc::NoteTemplate (lakeraven/rpms-rpc#56).
+    # Wraps RpmsRpc::NoteTemplate 
     class NoteTemplateGateway
       def self.roots(user_duz, via: default_provider)
         return [] if via.nil?
@@ -42,8 +38,6 @@ module Lakeraven
       end
 
       def self.default_provider
-        return nil unless defined?(::RpmsRpc::NoteTemplate) &&
-                          ::RpmsRpc::NoteTemplate.respond_to?(:roots)
         ::RpmsRpc::NoteTemplate
       end
     end

--- a/app/gateways/lakeraven/ehr/notifications_gateway.rb
+++ b/app/gateways/lakeraven/ehr/notifications_gateway.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-begin
-  require "rpms_rpc/api/notifications"
-rescue LoadError
-  # rpms-rpc gem does not yet expose RpmsRpc::Notifications.
-end
+require "rpms_rpc/api/notifications"
 
 module Lakeraven
   module EHR
     # Clinician alert inbox — fires at login and on patient open.
-    # Wraps RpmsRpc::Notifications (lakeraven/rpms-rpc#74).
+    # Wraps RpmsRpc::Notifications 
     class NotificationsGateway
       MARK_READ_FAILURE = { success: false, raw: nil }.freeze
 
@@ -26,8 +22,6 @@ module Lakeraven
       end
 
       def self.default_provider
-        return nil unless defined?(::RpmsRpc::Notifications) &&
-                          ::RpmsRpc::Notifications.respond_to?(:inbox)
         ::RpmsRpc::Notifications
       end
     end

--- a/app/gateways/lakeraven/ehr/notifications_gateway.rb
+++ b/app/gateways/lakeraven/ehr/notifications_gateway.rb
@@ -5,7 +5,7 @@ require "rpms_rpc/api/notifications"
 module Lakeraven
   module EHR
     # Clinician alert inbox — fires at login and on patient open.
-    # Wraps RpmsRpc::Notifications 
+    # Wraps RpmsRpc::Notifications
     class NotificationsGateway
       MARK_READ_FAILURE = { success: false, raw: nil }.freeze
 

--- a/app/gateways/lakeraven/ehr/order_gateway.rb
+++ b/app/gateways/lakeraven/ehr/order_gateway.rb
@@ -6,7 +6,7 @@ module Lakeraven
   module EHR
     # Clinical-order list APIs — a user's unsigned queue, or a patient's
     # chart filtered by status and view.
-    # Wraps RpmsRpc::Order 
+    # Wraps RpmsRpc::Order
     class OrderGateway
       def self.unsigned_for_user(user_duz, via: default_provider)
         return [] if via.nil?

--- a/app/gateways/lakeraven/ehr/order_gateway.rb
+++ b/app/gateways/lakeraven/ehr/order_gateway.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
-begin
-  require "rpms_rpc/api/order"
-rescue LoadError
-  # rpms-rpc gem does not yet expose RpmsRpc::Order.
-end
+require "rpms_rpc/api/order"
 
 module Lakeraven
   module EHR
     # Clinical-order list APIs — a user's unsigned queue, or a patient's
     # chart filtered by status and view.
-    # Wraps RpmsRpc::Order (lakeraven/rpms-rpc#68).
+    # Wraps RpmsRpc::Order 
     class OrderGateway
       def self.unsigned_for_user(user_duz, via: default_provider)
         return [] if via.nil?
@@ -25,8 +21,6 @@ module Lakeraven
       end
 
       def self.default_provider
-        return nil unless defined?(::RpmsRpc::Order) &&
-                          ::RpmsRpc::Order.respond_to?(:list)
         ::RpmsRpc::Order
       end
     end

--- a/app/gateways/lakeraven/ehr/pov_gateway.rb
+++ b/app/gateways/lakeraven/ehr/pov_gateway.rb
@@ -5,7 +5,7 @@ require "rpms_rpc/api/pov"
 module Lakeraven
   module EHR
     # Visit purpose-of-visit (diagnosis) entry against an open encounter.
-    # Wraps RpmsRpc::Pov 
+    # Wraps RpmsRpc::Pov
     class PovGateway
       FAILURE = { success: false, ien: nil, raw: nil }.freeze
 

--- a/app/gateways/lakeraven/ehr/pov_gateway.rb
+++ b/app/gateways/lakeraven/ehr/pov_gateway.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-begin
-  require "rpms_rpc/api/pov"
-rescue LoadError
-  # rpms-rpc gem does not yet expose RpmsRpc::Pov.
-end
+require "rpms_rpc/api/pov"
 
 module Lakeraven
   module EHR
     # Visit purpose-of-visit (diagnosis) entry against an open encounter.
-    # Wraps RpmsRpc::Pov (lakeraven/rpms-rpc#63).
+    # Wraps RpmsRpc::Pov 
     class PovGateway
       FAILURE = { success: false, ien: nil, raw: nil }.freeze
 
@@ -21,7 +17,6 @@ module Lakeraven
       end
 
       def self.default_provider
-        return nil unless defined?(::RpmsRpc::Pov) && ::RpmsRpc::Pov.respond_to?(:add)
         ::RpmsRpc::Pov
       end
     end

--- a/app/gateways/lakeraven/ehr/progress_note_gateway.rb
+++ b/app/gateways/lakeraven/ehr/progress_note_gateway.rb
@@ -6,7 +6,7 @@ module Lakeraven
   module EHR
     # TIU progress note create, list, fetch, edit, lock. Signing lives in
     # ESignatureGateway, not here.
-    # Wraps RpmsRpc::ProgressNote 
+    # Wraps RpmsRpc::ProgressNote
     class ProgressNoteGateway
       CREATE_FAILURE = { success: false, ien: nil, raw: nil }.freeze
       UPDATE_FAILURE = { success: false, raw: nil }.freeze

--- a/app/gateways/lakeraven/ehr/progress_note_gateway.rb
+++ b/app/gateways/lakeraven/ehr/progress_note_gateway.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
-begin
-  require "rpms_rpc/api/progress_note"
-rescue LoadError
-  # rpms-rpc gem does not yet expose RpmsRpc::ProgressNote.
-end
+require "rpms_rpc/api/progress_note"
 
 module Lakeraven
   module EHR
     # TIU progress note create, list, fetch, edit, lock. Signing lives in
     # ESignatureGateway, not here.
-    # Wraps RpmsRpc::ProgressNote (lakeraven/rpms-rpc#57).
+    # Wraps RpmsRpc::ProgressNote 
     class ProgressNoteGateway
       CREATE_FAILURE = { success: false, ien: nil, raw: nil }.freeze
       UPDATE_FAILURE = { success: false, raw: nil }.freeze
@@ -58,8 +54,6 @@ module Lakeraven
       end
 
       def self.default_provider
-        return nil unless defined?(::RpmsRpc::ProgressNote) &&
-                          ::RpmsRpc::ProgressNote.respond_to?(:create)
         ::RpmsRpc::ProgressNote
       end
     end

--- a/app/gateways/lakeraven/ehr/reminders_gateway.rb
+++ b/app/gateways/lakeraven/ehr/reminders_gateway.rb
@@ -5,18 +5,14 @@
 # stays undefined and `default_provider` returns nil. When the gem
 # updates, this require succeeds and the gateway begins delegating —
 # no engine-side change needed.
-begin
-  require "rpms_rpc/api/reminders"
-rescue LoadError
-  # rpms-rpc gem does not yet expose RpmsRpc::Reminders.
-end
+require "rpms_rpc/api/reminders"
 
 module Lakeraven
   module EHR
     # Clinical reminders relevant to a specific encounter.
     #
     # Backed by RpmsRpc::Reminders.for_visit once that primitive ships
-    # (lakeraven/rpms-rpc#59). Until then, returns an empty list so the
+    #  Until then, returns an empty list so the
     # encounter open path can wire the contract without a hard dependency
     # on the unreleased gateway method.
     class RemindersGateway
@@ -31,8 +27,6 @@ module Lakeraven
       # reminders API, otherwise nil. Tests can pass `via:` directly to
       # exercise both branches without monkey-patching constants.
       def self.default_provider
-        return nil unless defined?(::RpmsRpc::Reminders) &&
-                          ::RpmsRpc::Reminders.respond_to?(:for_visit)
         ::RpmsRpc::Reminders
       end
     end

--- a/app/gateways/lakeraven/ehr/reminders_gateway.rb
+++ b/app/gateways/lakeraven/ehr/reminders_gateway.rb
@@ -1,31 +1,17 @@
 # frozen_string_literal: true
 
-# Try to load the reminders RPC API. The gem may not yet ship it
-# (lakeraven/rpms-rpc#59), in which case `RpmsRpc::Reminders` simply
-# stays undefined and `default_provider` returns nil. When the gem
-# updates, this require succeeds and the gateway begins delegating —
-# no engine-side change needed.
 require "rpms_rpc/api/reminders"
 
 module Lakeraven
   module EHR
     # Clinical reminders relevant to a specific encounter.
-    #
-    # Backed by RpmsRpc::Reminders.for_visit once that primitive ships
-    #  Until then, returns an empty list so the
-    # encounter open path can wire the contract without a hard dependency
-    # on the unreleased gateway method.
+    # Wraps RpmsRpc::Reminders.for_visit.
     class RemindersGateway
-      # Normalizes identifiers to strings to match the convention used by
-      # the other gateways (EncounterGateway, ObservationGateway, etc.).
       def self.for_visit(dfn, visit_ien, via: default_provider)
         return [] if via.nil?
         via.for_visit(dfn.to_s, visit_ien.to_s)
       end
 
-      # Returns the RPC provider if the rpms-rpc gem has shipped the
-      # reminders API, otherwise nil. Tests can pass `via:` directly to
-      # exercise both branches without monkey-patching constants.
       def self.default_provider
         ::RpmsRpc::Reminders
       end

--- a/app/gateways/lakeraven/ehr/session_gateway.rb
+++ b/app/gateways/lakeraven/ehr/session_gateway.rb
@@ -6,7 +6,7 @@ module Lakeraven
   module EHR
     # Cold-launch bootstrap: resolves a user DUZ to client-config root,
     # registry hints, and the user's default division IEN.
-    # Wraps RpmsRpc::Session 
+    # Wraps RpmsRpc::Session
     class SessionGateway
       def self.bootstrap(duz, via: default_provider)
         return nil if via.nil?

--- a/app/gateways/lakeraven/ehr/session_gateway.rb
+++ b/app/gateways/lakeraven/ehr/session_gateway.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
-begin
-  require "rpms_rpc/api/session"
-rescue LoadError
-  # rpms-rpc gem does not yet expose RpmsRpc::Session.
-end
+require "rpms_rpc/api/session"
 
 module Lakeraven
   module EHR
     # Cold-launch bootstrap: resolves a user DUZ to client-config root,
     # registry hints, and the user's default division IEN.
-    # Wraps RpmsRpc::Session (lakeraven/rpms-rpc#99).
+    # Wraps RpmsRpc::Session 
     class SessionGateway
       def self.bootstrap(duz, via: default_provider)
         return nil if via.nil?
@@ -19,8 +15,6 @@ module Lakeraven
       end
 
       def self.default_provider
-        return nil unless defined?(::RpmsRpc::Session) &&
-                          ::RpmsRpc::Session.respond_to?(:bootstrap)
         ::RpmsRpc::Session
       end
     end

--- a/app/gateways/lakeraven/ehr/site_gateway.rb
+++ b/app/gateways/lakeraven/ehr/site_gateway.rb
@@ -6,7 +6,7 @@ module Lakeraven
   module EHR
     # Division (site) context: list accessible divisions, look up the
     # currently-selected one, and switch the active division.
-    # Wraps RpmsRpc::Site 
+    # Wraps RpmsRpc::Site
     class SiteGateway
       def self.list(duz, via: default_provider)
         return [] if via.nil?

--- a/app/gateways/lakeraven/ehr/site_gateway.rb
+++ b/app/gateways/lakeraven/ehr/site_gateway.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
-begin
-  require "rpms_rpc/api/site"
-rescue LoadError
-  # rpms-rpc gem does not yet expose RpmsRpc::Site.
-end
+require "rpms_rpc/api/site"
 
 module Lakeraven
   module EHR
     # Division (site) context: list accessible divisions, look up the
     # currently-selected one, and switch the active division.
-    # Wraps RpmsRpc::Site (lakeraven/rpms-rpc#100).
+    # Wraps RpmsRpc::Site 
     class SiteGateway
       def self.list(duz, via: default_provider)
         return [] if via.nil?
@@ -31,8 +27,6 @@ module Lakeraven
       end
 
       def self.default_provider
-        return nil unless defined?(::RpmsRpc::Site) &&
-                          ::RpmsRpc::Site.respond_to?(:list)
         ::RpmsRpc::Site
       end
     end

--- a/app/gateways/lakeraven/ehr/symptom_gateway.rb
+++ b/app/gateways/lakeraven/ehr/symptom_gateway.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
-begin
-  require "rpms_rpc/api/symptom"
-rescue LoadError
-  # rpms-rpc gem does not yet expose RpmsRpc::Symptom.
-end
+require "rpms_rpc/api/symptom"
 
 module Lakeraven
   module EHR
     # Allergy-symptom catalog lookup, driving the order-entry
     # allergy-precheck UI.
-    # Wraps RpmsRpc::Symptom (lakeraven/rpms-rpc#73).
+    # Wraps RpmsRpc::Symptom 
     class SymptomGateway
       def self.search(query, via: default_provider)
         return [] if via.nil?
@@ -25,8 +21,6 @@ module Lakeraven
       end
 
       def self.default_provider
-        return nil unless defined?(::RpmsRpc::Symptom) &&
-                          ::RpmsRpc::Symptom.respond_to?(:search)
         ::RpmsRpc::Symptom
       end
     end

--- a/app/gateways/lakeraven/ehr/symptom_gateway.rb
+++ b/app/gateways/lakeraven/ehr/symptom_gateway.rb
@@ -6,7 +6,7 @@ module Lakeraven
   module EHR
     # Allergy-symptom catalog lookup, driving the order-entry
     # allergy-precheck UI.
-    # Wraps RpmsRpc::Symptom 
+    # Wraps RpmsRpc::Symptom
     class SymptomGateway
       def self.search(query, via: default_provider)
         return [] if via.nil?


### PR DESCRIPTION
## Summary

Removes the defensive `begin/rescue LoadError` + `defined?(...) && respond_to?(...)` guards in 17 gateways that wrapped `rpms-rpc` API modules. Those guards were added when the corresponding `rpms-rpc` gem APIs didn't yet exist; all referenced upstream issues (`lakeraven/rpms-rpc#56, #57, #58, #59, #63, #65, #66, #67, #68, #73, #74, #75, #76, #99, #100, #101, #107`) are now CLOSED or MERGED. The guards are dead defense — they silently swallowed gem-dependency problems rather than surfacing them.

## Gateways cleaned up (17)

- `capabilities_gateway` (was guarding `Capabilities.imaging_user?`)
- `e_signature_gateway` (was guarding `ESignature.add`)
- `exam_component_gateway` (was guarding `ExamComponent.add`)
- `health_factor_gateway` (was guarding `HealthFactor.add`)
- `image_gateway` (was guarding `Image.launch_token`)
- `immunization_gateway` (was guarding `Immunization.for_patient`)
- `immunization_refusal_gateway` (was guarding `ImmunizationRefusal.record`)
- `measurement_gateway` (was guarding `Measurement.add`)
- `note_template_gateway` (was guarding `NoteTemplate.roots`)
- `notifications_gateway` (was guarding `Notifications.inbox`)
- `order_gateway` (was guarding `Order.list`)
- `pov_gateway` (was guarding `Pov.add`)
- `progress_note_gateway` (was guarding `ProgressNote.create`)
- `reminders_gateway` (was guarding `Reminders.for_visit`)
- `session_gateway` (was guarding `Session.bootstrap`)
- `site_gateway` (was guarding `Site.list`)
- `symptom_gateway` (was guarding `Symptom.search`)

## What changed in each gateway

1. **Plain `require` instead of `begin/rescue LoadError`** — the gem is a Gemfile dependency; missing modules should surface as load errors, not silent nils.
2. **Removed obsolete header comments** like *"rpms-rpc gem does not yet expose RpmsRpc::X."* — no longer true.
3. **Simplified `default_provider`** — drops the `defined?(::RpmsRpc::X) && X.respond_to?(:method)` check. Just returns `::RpmsRpc::X`.
4. **Removed stale `(lakeraven/rpms-rpc#NN)` issue refs** — those issues are closed.

`via: nil` test paths still work — the public contract (callers can pass an explicit nil provider to skip) is unchanged.

## Test plan

- [x] Full suite: `2704 runs, 5403 assertions, 0 failures, 0 errors, 1 skip`
- [x] No production behavior change — only dead-defense removal. The methods all degraded to nil already in the guarded paths; on a healthy gem install (which is the only path that exists today), the new code produces the same result without the defensive wrapping.
- [x] If `rpms-rpc` ever does ship without one of these modules, the load failure will surface at app boot — fail-fast vs silent-degrade, which is the correct behavior per the "no silent failures" rule.

## Net diff

```
17 files changed, 33 insertions(+), 134 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)